### PR TITLE
docs: README에 면접 질문 생성 기능 반영

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,8 @@
 | 게스트 세션 (쿠키 기반, 30일 유지) | ✅ |
 | 프로필 입력 — 학력 / 경력 / 자격증 / 대외활동 | ✅ |
 | 채용공고 URL 입력 + AI 분석 (담당업무 / 자격요건 / 우대사항) | ✅ |
-| 면접 질문 생성 | 예정 |
+| AI 면접 질문 생성 — 5문항 (직무역량 / 경험기반 / 심화 / 문화적합성) | ✅ |
+| 꼬리 질문 — 이전 답변을 반영한 맥락 연계 질문 | ✅ |
 
 ## 기술 스택
 
@@ -25,10 +26,12 @@
 
 ```
 브라우저 → Next.js (포트 3000)
-              └─ /api/job-posting/analyze
-                    └─ Python 서버 (포트 8000)
-                          ├─ Playwright로 채용공고 크롤링
-                          └─ Ollama API로 정보 추출
+              ├─ /api/job-posting/analyze
+              │     └─ Python 서버 (포트 8000)
+              │           ├─ Playwright로 채용공고 크롤링
+              │           └─ Ollama API로 정보 추출
+              └─ /api/interview/question
+                    └─ Ollama API — 프로필 + 채용공고 기반 맞춤 질문 생성
 ```
 
 ## 사전 요구사항
@@ -107,22 +110,27 @@ ai-interview/
 │   ├── api/
 │   │   ├── session/route.ts          # 세션 생성/조회
 │   │   ├── profile/route.ts          # 프로필 CRUD
-│   │   └── job-posting/
-│   │       ├── route.ts              # 채용공고 저장
-│   │       └── analyze/route.ts     # Python 서버 호출 → DB 저장
+│   │   ├── job-posting/
+│   │   │   ├── route.ts              # 채용공고 저장
+│   │   │   └── analyze/route.ts      # Python 서버 호출 → DB 저장
+│   │   └── interview/
+│   │       └── question/route.ts     # 면접 질문 생성 (Ollama 호출)
 │   ├── profile/page.tsx
 │   ├── job-posting/page.tsx
+│   ├── interview/page.tsx            # 면접 페이지 (준비 상태 검증 후 세션 시작)
 │   ├── layout.tsx
 │   └── page.tsx
 ├── components/
 │   ├── ProfileForm.tsx
 │   ├── JobPostingForm.tsx            # URL 입력 + 분석 결과 표시
+│   ├── InterviewSession.tsx          # 면접 진행 UI (채팅 버블 + 진행 표시)
 │   └── SessionInitializer.tsx
 ├── lib/
 │   ├── supabase.ts                   # Supabase 클라이언트
 │   ├── claude.ts                     # Ollama API 클라이언트
 │   ├── session.ts                    # 세션 유틸리티
-│   └── schemas.ts                    # Zod 스키마
+│   ├── schemas.ts                    # Zod 스키마
+│   └── interview.ts                  # 면접 질문 생성 (프롬프트 빌더 + Ollama 호출)
 ├── server/
 │   ├── server.py                     # FastAPI 서버 (POST /extract)
 │   ├── extract_job.py                # Playwright 크롤링 + Ollama 분석


### PR DESCRIPTION
## Summary

- 구현 기능 테이블에 AI 면접 5문항 + 꼬리 질문 항목 추가 (기존 "예정" → ✅)
- 아키텍처 다이어그램에 `/api/interview/question` 경로 추가
- 프로젝트 구조에 신규 파일 반영: `interview.ts`, `InterviewSession.tsx`, `interview/page.tsx`, `question/route.ts`

## 구현된 면접 기능 요약

- 5개 카테고리 질문: 자기소개/지원동기 → 직무역량 → 경험기반 → 심화 → 회사/문화 적합성
- 채용공고(담당업무·자격요건·우대사항) 기반 맞춤 질문 생성
- 꼬리 질문: 이전 답변을 포함한 전체 대화 히스토리를 Ollama에 전달하여 맥락 연계

## Test plan

- [ ] `/job-posting` 에서 채용공고 분석 완료 후 "면접 시작하기" 버튼 노출 확인
- [ ] `/interview` 접속 시 프로필·채용공고 미입력 상태면 리다이렉트 확인
- [ ] 5문항 순서대로 진행, 마지막 답변 제출 후 완료 화면 표시 확인
- [ ] "다시 연습하기" 버튼으로 처음부터 재시작 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)