### PR TITLE
fix: 채용공고 '모집 분야' 항목을 업무 내용으로 인식

### DIFF
--- a/server/extract_job.py
+++ b/server/extract_job.py
@@ -33,7 +33,7 @@ def extract_job_info(text: str) -> dict:
 항목명이 정확히 일치하지 않아도 의미가 같으면 해당 항목으로 분류하세요.
 
 분류 기준:
-- "업무 내용": 담당업무, 하는 일, 주요 역할, 업무 소개, What you'll do, Responsibilities 등
+- "업무 내용": 담당업무, 하는 일, 주요 역할, 업무 소개, 모집 분야, 직무 내용, What you'll do, Responsibilities 등
 - "지원 자격": 자격 요건, 필수 조건, 이런 분을 찾아요, Requirements, Qualifications 등
 - "우대 사항": 우대 조건, 이런 분이면 더 좋아요, Preferred, Nice to have 등
 
@@ -73,6 +73,8 @@ def extract_job_info(text: str) -> dict:
         "업무": "업무 내용",
         "담당": "업무 내용",
         "역할": "업무 내용",
+        "모집": "업무 내용",
+        "직무": "업무 내용",
         "자격": "지원 자격",
         "필수": "지원 자격",
         "요건": "지원 자격",


### PR DESCRIPTION
## Summary

- 일부 채용공고 사이트에서 "업무 내용" 대신 "모집 분야", "직무 내용" 등으로 표기하는 경우 누락되던 문제 수정
- Ollama 프롬프트 분류 기준에 "모집 분야", "직무 내용" 추가
- KEY_MAP에 `"모집"`, `"직무"` 키워드 추가하여 모델 출력 정규화

## Test plan

- [ ] "모집 분야"만 있고 "업무 내용"이 없는 채용공고 URL로 분석 시 `responsibilities` 필드에 값이 채워지는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)