### PR TITLE
fix: ngrok 터널 경유 Ollama 요청 헤더 추가 (#11)

### DIFF
--- a/app/api/interview/feedback/route.ts
+++ b/app/api/interview/feedback/route.ts
@@ -65,7 +65,7 @@ Rules:
 
     const response = await fetch(`${OLLAMA_BASE_URL}/api/generate`, {
       method: "POST",
-      headers: { "Content-Type": "application/json" },
+      headers: { "Content-Type": "application/json", "ngrok-skip-browser-warning": "true" },
       body: JSON.stringify({ model: OLLAMA_MODEL, prompt, stream: false }),
       signal: AbortSignal.timeout(180_000),
     });

--- a/app/api/job-posting/analyze/route.ts
+++ b/app/api/job-posting/analyze/route.ts
@@ -44,7 +44,7 @@ ${text}`;
 
   const response = await fetch(`${OLLAMA_BASE_URL}/api/generate`, {
     method: "POST",
-    headers: { "Content-Type": "application/json" },
+    headers: { "Content-Type": "application/json", "ngrok-skip-browser-warning": "true" },
     body: JSON.stringify({ model: OLLAMA_MODEL, prompt, stream: false }),
     signal: AbortSignal.timeout(120_000),
   });

--- a/lib/interview.ts
+++ b/lib/interview.ts
@@ -162,7 +162,7 @@ ${contextualHints}
 
   const response = await fetch(`${OLLAMA_BASE_URL}/api/chat`, {
     method: "POST",
-    headers: { "Content-Type": "application/json" },
+    headers: { "Content-Type": "application/json", "ngrok-skip-browser-warning": "true" },
     body: JSON.stringify({
       model: OLLAMA_MODEL,
       stream: false,


### PR DESCRIPTION
## 변경 내용

ngrok 무료 플랜은 브라우저 경고 페이지를 먼저 보여줘서 API 요청이 차단되는 문제가 있습니다.
Ollama에 요청하는 모든 fetch에 `ngrok-skip-browser-warning: true` 헤더를 추가했습니다.

## 수정 파일
- `app/api/job-posting/analyze/route.ts`
- `lib/interview.ts`
- `app/api/interview/feedback/route.ts`