### PR TITLE
feat: 다크모드 수동 토글 버튼 추가

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -13,8 +13,15 @@ export default function RootLayout({
   children: React.ReactNode;
 }) {
   return (
-    <html lang="ko">
-      <body className="bg-gray-50 text-gray-900 antialiased">
+    <html lang="ko" suppressHydrationWarning>
+      <head>
+        <script
+          dangerouslySetInnerHTML={{
+            __html: `(function(){try{var t=localStorage.getItem('theme');if(t==='dark'||(t===null&&window.matchMedia('(prefers-color-scheme: dark)').matches)){document.documentElement.classList.add('dark')}}catch(e){}})()`,
+          }}
+        />
+      </head>
+      <body className="bg-gray-50 text-gray-900 antialiased dark:bg-slate-950 dark:text-slate-100">
         <Header />
         {children}
       </body>

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -2,11 +2,24 @@
 
 import Link from "next/link";
 import { usePathname, useRouter } from "next/navigation";
+import { useEffect, useState } from "react";
 import { createSupabaseBrowserClient } from "@/lib/supabase-browser";
 
 export default function Header() {
   const pathname = usePathname();
   const router = useRouter();
+  const [isDark, setIsDark] = useState(false);
+
+  useEffect(() => {
+    setIsDark(document.documentElement.classList.contains("dark"));
+  }, []);
+
+  function toggleTheme() {
+    const next = !isDark;
+    setIsDark(next);
+    document.documentElement.classList.toggle("dark", next);
+    localStorage.setItem("theme", next ? "dark" : "light");
+  }
 
   if (pathname === "/" || pathname === "/login" || pathname === "/signup") return null;
 
@@ -28,12 +41,30 @@ export default function Header() {
             AI 면접 코치
           </span>
         </Link>
-        <button
-          onClick={handleLogout}
-          className="text-xs text-gray-400 hover:text-gray-600 dark:text-slate-500 dark:hover:text-slate-300 transition-colors px-3 py-1.5 rounded-lg hover:bg-gray-100 dark:hover:bg-slate-800"
-        >
-          로그아웃
-        </button>
+        <div className="flex items-center gap-2">
+          <button
+            onClick={toggleTheme}
+            className="text-gray-400 hover:text-gray-600 dark:text-slate-500 dark:hover:text-slate-300 transition-colors p-1.5 rounded-lg hover:bg-gray-100 dark:hover:bg-slate-800"
+            aria-label="테마 전환"
+          >
+            {isDark ? (
+              <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                <circle cx="12" cy="12" r="4"/>
+                <path d="M12 2v2M12 20v2M4.93 4.93l1.41 1.41M17.66 17.66l1.41 1.41M2 12h2M20 12h2M4.93 19.07l1.41-1.41M17.66 6.34l1.41-1.41"/>
+              </svg>
+            ) : (
+              <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/>
+              </svg>
+            )}
+          </button>
+          <button
+            onClick={handleLogout}
+            className="text-xs text-gray-400 hover:text-gray-600 dark:text-slate-500 dark:hover:text-slate-300 transition-colors px-3 py-1.5 rounded-lg hover:bg-gray-100 dark:hover:bg-slate-800"
+          >
+            로그아웃
+          </button>
+        </div>
       </div>
     </header>
   );

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -6,7 +6,7 @@ const config: Config = {
     "./components/**/*.{js,ts,jsx,tsx,mdx}",
     "./app/**/*.{js,ts,jsx,tsx,mdx}",
   ],
-  darkMode: "media",
+  darkMode: "class",
   theme: {
     extend: {
       fontFamily: {


### PR DESCRIPTION
## Summary
- 시스템 설정 자동 적용(`darkMode: "media"`) → 사용자 수동 전환(`darkMode: "class"`)으로 변경
- 헤더에 SVG 달/해 아이콘 버튼 추가 (라이트모드: 달, 다크모드: 해)
- 선택값 `localStorage` 저장으로 새로고침 후에도 유지
- 첫 방문 시 시스템 설정을 기본값으로 사용, flicker 방지 인라인 스크립트 적용

## Test plan
- [ ] 헤더 토글 버튼 클릭 시 라이트/다크 전환 확인
- [ ] 새로고침 후 선택한 테마 유지 확인
- [ ] 첫 방문 시 시스템 다크모드 설정 반영 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)