### PR TITLE
feat: 페이지 전환 UX 개선 — 스켈레톤 로딩 + 상단 프로그레스 바

### DIFF
--- a/app/interview/loading.tsx
+++ b/app/interview/loading.tsx
@@ -1,0 +1,23 @@
+export default function InterviewLoading() {
+  return (
+    <main className="min-h-screen py-8 px-4">
+      <div className="max-w-2xl mx-auto space-y-6">
+        <div className="space-y-2">
+          <div className="h-5 w-16 bg-gray-200 dark:bg-slate-700 rounded-md animate-pulse" />
+          <div className="h-8 w-56 bg-gray-200 dark:bg-slate-700 rounded-md animate-pulse" />
+          <div className="h-4 w-80 bg-gray-200 dark:bg-slate-700 rounded animate-pulse" />
+        </div>
+        <div className="card p-5 space-y-4">
+          <div className="h-4 w-20 bg-gray-200 dark:bg-slate-700 rounded animate-pulse" />
+          <div className="space-y-2">
+            <div className="h-4 bg-gray-200 dark:bg-slate-700 rounded animate-pulse" />
+            <div className="h-4 bg-gray-200 dark:bg-slate-700 rounded animate-pulse" />
+            <div className="h-4 w-3/4 bg-gray-200 dark:bg-slate-700 rounded animate-pulse" />
+          </div>
+          <div className="h-32 bg-gray-200 dark:bg-slate-700 rounded-xl animate-pulse" />
+          <div className="h-11 bg-gray-200 dark:bg-slate-700 rounded-xl animate-pulse" />
+        </div>
+      </div>
+    </main>
+  );
+}

--- a/app/job-posting/loading.tsx
+++ b/app/job-posting/loading.tsx
@@ -1,0 +1,22 @@
+export default function JobPostingLoading() {
+  return (
+    <main className="min-h-screen py-8 px-4">
+      <div className="max-w-3xl mx-auto space-y-6">
+        <div className="space-y-2">
+          <div className="h-5 w-16 bg-gray-200 dark:bg-slate-700 rounded-md animate-pulse" />
+          <div className="h-8 w-56 bg-gray-200 dark:bg-slate-700 rounded-md animate-pulse" />
+          <div className="h-4 w-72 bg-gray-200 dark:bg-slate-700 rounded animate-pulse" />
+        </div>
+        <div className="card p-5 space-y-4">
+          <div className="h-4 w-24 bg-gray-200 dark:bg-slate-700 rounded animate-pulse" />
+          <div className="h-11 bg-gray-200 dark:bg-slate-700 rounded-xl animate-pulse" />
+          <div className="h-4 w-64 bg-gray-200 dark:bg-slate-700 rounded animate-pulse" />
+        </div>
+        <div className="flex justify-between">
+          <div className="h-11 w-28 bg-gray-200 dark:bg-slate-700 rounded-xl animate-pulse" />
+          <div className="h-11 w-24 bg-gray-200 dark:bg-slate-700 rounded-xl animate-pulse" />
+        </div>
+      </div>
+    </main>
+  );
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import "./globals.css";
 import Header from "@/components/Header";
+import ProgressBarProvider from "@/components/ProgressBarProvider";
 
 export const metadata: Metadata = {
   title: "AI 면접 코치",
@@ -15,6 +16,7 @@ export default function RootLayout({
   return (
     <html lang="ko">
       <body className="bg-gray-50 text-gray-900 antialiased">
+        <ProgressBarProvider />
         <Header />
         {children}
       </body>

--- a/app/profile/detail/loading.tsx
+++ b/app/profile/detail/loading.tsx
@@ -1,0 +1,21 @@
+export default function ProfileDetailLoading() {
+  return (
+    <main className="min-h-screen py-8 px-4">
+      <div className="max-w-3xl mx-auto space-y-6">
+        <div className="space-y-2">
+          <div className="h-5 w-16 bg-gray-200 dark:bg-slate-700 rounded-md animate-pulse" />
+          <div className="h-8 w-64 bg-gray-200 dark:bg-slate-700 rounded-md animate-pulse" />
+          <div className="h-4 w-80 bg-gray-200 dark:bg-slate-700 rounded animate-pulse" />
+        </div>
+        {[...Array(3)].map((_, i) => (
+          <div key={i} className="card p-5 space-y-4">
+            <div className="h-5 w-24 bg-gray-200 dark:bg-slate-700 rounded animate-pulse" />
+            <div className="h-11 bg-gray-200 dark:bg-slate-700 rounded-xl animate-pulse" />
+            <div className="h-11 bg-gray-200 dark:bg-slate-700 rounded-xl animate-pulse" />
+            <div className="h-11 w-32 bg-gray-200 dark:bg-slate-700 rounded-xl animate-pulse" />
+          </div>
+        ))}
+      </div>
+    </main>
+  );
+}

--- a/app/profile/loading.tsx
+++ b/app/profile/loading.tsx
@@ -1,0 +1,17 @@
+export default function ProfileLoading() {
+  return (
+    <main className="min-h-screen py-8 px-4">
+      <div className="max-w-md mx-auto space-y-6">
+        <div className="space-y-2">
+          <div className="h-5 w-16 bg-gray-200 dark:bg-slate-700 rounded-md animate-pulse" />
+          <div className="h-8 w-52 bg-gray-200 dark:bg-slate-700 rounded-md animate-pulse" />
+        </div>
+        <div className="card p-5 space-y-4">
+          <div className="h-4 w-20 bg-gray-200 dark:bg-slate-700 rounded animate-pulse" />
+          <div className="h-11 bg-gray-200 dark:bg-slate-700 rounded-xl animate-pulse" />
+          <div className="h-11 bg-gray-200 dark:bg-slate-700 rounded-xl animate-pulse" />
+        </div>
+      </div>
+    </main>
+  );
+}

--- a/components/ProgressBarProvider.tsx
+++ b/components/ProgressBarProvider.tsx
@@ -1,0 +1,14 @@
+"use client";
+
+import { AppProgressBar } from "next-nprogress-bar";
+
+export default function ProgressBarProvider() {
+  return (
+    <AppProgressBar
+      height="3px"
+      color="#2563eb"
+      options={{ showSpinner: false }}
+      shallowRouting
+    />
+  );
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "@supabase/ssr": "^0.10.0",
         "@supabase/supabase-js": "^2.101.1",
         "next": "^14.2.0",
+        "next-nprogress-bar": "^2.4.7",
         "react": "^18.3.0",
         "react-dom": "^18.3.0",
         "zod": "^3.23.8"
@@ -1081,6 +1082,15 @@
         }
       }
     },
+    "node_modules/next-nprogress-bar": {
+      "version": "2.4.7",
+      "resolved": "https://registry.npmjs.org/next-nprogress-bar/-/next-nprogress-bar-2.4.7.tgz",
+      "integrity": "sha512-OeveNQYFBhQhZ+RgrDnvHNUEQfHCmipymmD4AfAVE9pFV4jeWi7/nNK5f0lIk7ODRrtjyyr/n2YpkRbs5kUoMg==",
+      "license": "MIT",
+      "dependencies": {
+        "nprogress-v2": "^1.0.4"
+      }
+    },
     "node_modules/next/node_modules/postcss": {
       "version": "8.4.31",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.31.tgz",
@@ -1125,6 +1135,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/nprogress-v2": {
+      "version": "1.1.10",
+      "resolved": "https://registry.npmjs.org/nprogress-v2/-/nprogress-v2-1.1.10.tgz",
+      "integrity": "sha512-MypWLNIPIM07SS0bAc/oac0vhVFz9vAHm7d1sj//Pnf3J03LQ3CuWrlDteIu6exq0fIvkDJ6tUDRWLaifsIt5w==",
+      "license": "MIT"
     },
     "node_modules/object-assign": {
       "version": "4.1.1",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "@supabase/ssr": "^0.10.0",
     "@supabase/supabase-js": "^2.101.1",
     "next": "^14.2.0",
+    "next-nprogress-bar": "^2.4.7",
     "react": "^18.3.0",
     "react-dom": "^18.3.0",
     "zod": "^3.23.8"


### PR DESCRIPTION
## Summary

- `router.push()` 후 서버 데이터 로딩 중 화면이 굳어 보이는 문제 해결
- 각 페이지 폴더에 `loading.tsx` 스켈레톤 추가 → 이동 즉시 화면 전환 피드백 제공
- `next-nprogress-bar` 패키지로 상단 파란 프로그레스 바 추가

## 변경 파일

- `components/ProgressBarProvider.tsx` — 신규, 상단 프로그레스 바 클라이언트 컴포넌트
- `app/layout.tsx` — `ProgressBarProvider` 추가
- `app/profile/loading.tsx` — 이름 입력 페이지 스켈레톤
- `app/profile/detail/loading.tsx` — 상세 정보 페이지 스켈레톤
- `app/job-posting/loading.tsx` — 채용공고 페이지 스켈레톤
- `app/interview/loading.tsx` — 면접 페이지 스켈레톤

## Test plan

- [ ] 로그인 → `/profile` 이동 시 스켈레톤 즉시 표시 확인
- [ ] 이름 입력 → `/profile/detail` 스켈레톤 확인
- [ ] 프로필 저장 → `/job-posting` 스켈레톤 확인
- [ ] 면접 시작 → `/interview` 스켈레톤 확인
- [ ] 모든 페이지 이동 시 상단 파란 프로그레스 바 표시 확인
- [ ] 다크모드에서 스켈레톤 색상 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)