### PR TITLE
feat: 멀티 에이전트 패널 면접 시스템 (1단계)

### DIFF
--- a/app/api/interview/question/route.ts
+++ b/app/api/interview/question/route.ts
@@ -2,9 +2,10 @@ import { NextRequest, NextResponse } from "next/server";
 import { supabase } from "@/lib/supabase";
 import { getAuthUser } from "@/lib/auth";
 import {
-  generateInterviewQuestion,
+  generateAgentBaseQuestion,
+  generateAgentFollowUpQuestion,
+  AgentId,
   Message,
-  TOTAL_QUESTIONS,
 } from "@/lib/interview";
 
 export async function POST(request: NextRequest) {
@@ -15,14 +16,11 @@ export async function POST(request: NextRequest) {
     }
 
     const body = await request.json();
-    const { messages, questionIndex } = body as {
+    const { messages, agentId, isFollowUpRequest } = body as {
       messages: Message[];
-      questionIndex: number;
+      agentId: AgentId;
+      isFollowUpRequest: boolean;
     };
-
-    if (questionIndex >= TOTAL_QUESTIONS) {
-      return NextResponse.json({ done: true });
-    }
 
     const { data: profile } = await supabase
       .from("profiles")
@@ -64,21 +62,38 @@ export async function POST(request: NextRequest) {
       );
     }
 
-    const question = await generateInterviewQuestion(
-      {
-        name: profile.name,
-        educations: educations ?? [],
-        careers: careers ?? [],
-        certifications: certifications ?? [],
-        activities: activities ?? [],
-      },
-      {
-        responsibilities: jobPosting.responsibilities ?? "",
-        requirements: jobPosting.requirements ?? "",
-        preferredQuals: jobPosting.preferredQuals ?? "",
-      },
+    const profileContext = {
+      name: profile.name,
+      educations: educations ?? [],
+      careers: careers ?? [],
+      certifications: certifications ?? [],
+      activities: activities ?? [],
+    };
+
+    const jobPostingContext = {
+      responsibilities: jobPosting.responsibilities ?? "",
+      requirements: jobPosting.requirements ?? "",
+      preferredQuals: jobPosting.preferredQuals ?? "",
+    };
+
+    if (isFollowUpRequest) {
+      const followUp = await generateAgentFollowUpQuestion(
+        agentId,
+        profileContext,
+        jobPostingContext,
+        messages,
+      );
+      if (followUp === null) {
+        return NextResponse.json({ followUp: false });
+      }
+      return NextResponse.json({ question: followUp, followUp: true });
+    }
+
+    const question = await generateAgentBaseQuestion(
+      agentId,
+      profileContext,
+      jobPostingContext,
       messages,
-      questionIndex,
     );
 
     return NextResponse.json({ question });

--- a/components/DifficultySelect.tsx
+++ b/components/DifficultySelect.tsx
@@ -1,0 +1,76 @@
+"use client";
+
+import { Difficulty, MAX_FOLLOWUPS } from "@/lib/interview";
+
+const DIFFICULTY_CONFIG: {
+  value: Difficulty;
+  label: string;
+  description: string;
+  detail: string;
+  color: string;
+}[] = [
+  {
+    value: "easy",
+    label: "이지",
+    description: "기본 질문만",
+    detail: `에이전트당 1개 질문 · 총 ${3}문항`,
+    color: "border-green-200 dark:border-green-800 hover:border-green-400 dark:hover:border-green-600",
+  },
+  {
+    value: "normal",
+    label: "노말",
+    description: "꼬리질문 최대 1회",
+    detail: `에이전트당 최대 ${1 + MAX_FOLLOWUPS.normal}개 질문 · 총 최대 ${3 * (1 + MAX_FOLLOWUPS.normal)}문항`,
+    color: "border-blue-200 dark:border-blue-800 hover:border-blue-400 dark:hover:border-blue-600",
+  },
+  {
+    value: "hard",
+    label: "하드",
+    description: "꼬리질문 최대 3회",
+    detail: `에이전트당 최대 ${1 + MAX_FOLLOWUPS.hard}개 질문 · 총 최대 ${3 * (1 + MAX_FOLLOWUPS.hard)}문항`,
+    color: "border-red-200 dark:border-red-800 hover:border-red-400 dark:hover:border-red-600",
+  },
+];
+
+interface Props {
+  onSelect: (difficulty: Difficulty) => void;
+}
+
+export default function DifficultySelect({ onSelect }: Props) {
+  return (
+    <div className="card p-6 space-y-6">
+      <div className="text-center space-y-1">
+        <h2 className="text-lg font-bold text-gray-900 dark:text-slate-50">난이도를 선택하세요</h2>
+        <p className="text-sm text-gray-500 dark:text-slate-400">
+          3명의 전문 면접관이 각자의 관점에서 질문합니다
+        </p>
+      </div>
+
+      <div className="space-y-3">
+        {DIFFICULTY_CONFIG.map((d) => (
+          <button
+            key={d.value}
+            onClick={() => onSelect(d.value)}
+            className={`w-full text-left p-4 rounded-xl border-2 bg-white dark:bg-slate-800 transition-all duration-150 ${d.color}`}
+          >
+            <div className="flex items-center justify-between">
+              <div className="space-y-0.5">
+                <div className="flex items-center gap-2">
+                  <span className="font-bold text-gray-900 dark:text-slate-50">{d.label}</span>
+                  <span className="text-sm text-gray-600 dark:text-slate-300">{d.description}</span>
+                </div>
+                <p className="text-xs text-gray-400 dark:text-slate-500">{d.detail}</p>
+              </div>
+              <span className="text-gray-300 dark:text-slate-600 text-lg">→</span>
+            </div>
+          </button>
+        ))}
+      </div>
+
+      <div className="text-xs text-gray-400 dark:text-slate-500 space-y-1 pt-1 border-t border-gray-100 dark:border-slate-700">
+        <p>조직 전문가 → 논리 전문가 → 기술 전문가 순서로 진행됩니다</p>
+        <p>꼬리질문은 답변이 부족할 경우에만 발생합니다</p>
+      </div>
+    </div>
+  );
+}

--- a/components/InterviewSession.tsx
+++ b/components/InterviewSession.tsx
@@ -1,20 +1,36 @@
 "use client";
 
 import { useState, useRef, useEffect } from "react";
-import { Message, TOTAL_QUESTIONS, getFirstQuestion } from "@/lib/interview";
+import {
+  Message,
+  Difficulty,
+  AgentId,
+  AGENTS,
+  AGENT_ORDER,
+  TOTAL_AGENTS,
+  MAX_FOLLOWUPS,
+  getFirstQuestion,
+} from "@/lib/interview";
 import type { FeedbackResult } from "@/app/api/interview/feedback/route";
+import DifficultySelect from "@/components/DifficultySelect";
 
 const ANSWER_TIME_LIMIT = 80;
 
-async function fetchQuestion(index: number, msgs: Message[]): Promise<string> {
+type Phase = "selecting" | "interviewing";
+
+async function fetchQuestion(
+  messages: Message[],
+  agentId: AgentId,
+  isFollowUpRequest: boolean,
+): Promise<{ question?: string; followUp?: boolean }> {
   const res = await fetch("/api/interview/question", {
     method: "POST",
     headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({ messages: msgs, questionIndex: index }),
+    body: JSON.stringify({ messages, agentId, isFollowUpRequest }),
   });
   const data = await res.json();
   if (!res.ok) throw new Error(data.error ?? "질문 생성에 실패했습니다");
-  return data.question;
+  return data;
 }
 
 async function fetchFeedback(msgs: Message[]): Promise<FeedbackResult> {
@@ -44,12 +60,27 @@ function ScoreRing({ score }: { score: number }) {
   );
 }
 
+function AgentBadge({ agentId }: { agentId: AgentId }) {
+  const colorMap: Record<AgentId, string> = {
+    organization: "text-purple-600 dark:text-purple-400",
+    logic: "text-blue-600 dark:text-blue-400",
+    technical: "text-green-600 dark:text-green-400",
+  };
+  return (
+    <span className={`text-xs font-semibold ${colorMap[agentId]}`}>
+      {AGENTS[agentId].label}
+    </span>
+  );
+}
+
 export default function InterviewSession({ name }: { name: string }) {
-  const [messages, setMessages] = useState<Message[]>([
-    { role: "interviewer", content: getFirstQuestion(name) },
-  ]);
+  const [phase, setPhase] = useState<Phase>("selecting");
+  const [difficulty, setDifficulty] = useState<Difficulty>("normal");
+  const [agentIndex, setAgentIndex] = useState(0);
+  const [followUpCount, setFollowUpCount] = useState(0);
+
+  const [messages, setMessages] = useState<Message[]>([]);
   const [answer, setAnswer] = useState("");
-  const [questionIndex, setQuestionIndex] = useState(0);
   const [isLoading, setIsLoading] = useState(false);
   const [isDone, setIsDone] = useState(false);
   const [isFetchingFeedback, setIsFetchingFeedback] = useState(false);
@@ -59,39 +90,83 @@ export default function InterviewSession({ name }: { name: string }) {
   const [timeLeft, setTimeLeft] = useState(ANSWER_TIME_LIMIT);
   const bottomRef = useRef<HTMLDivElement>(null);
 
+  // 면접 시작: 조직 전문가 첫 질문 고정 설정
+  function handleDifficultySelect(d: Difficulty) {
+    setDifficulty(d);
+    setMessages([{ role: "interviewer", content: getFirstQuestion(name), agentId: "organization" }]);
+    setAgentIndex(0);
+    setFollowUpCount(0);
+    setPhase("interviewing");
+  }
+
   useEffect(() => {
     bottomRef.current?.scrollIntoView({ behavior: "smooth" });
   }, [messages, isLoading, isDone]);
 
   useEffect(() => {
     setTimeLeft(ANSWER_TIME_LIMIT);
-  }, [questionIndex]);
+  }, [messages.length]);
 
   useEffect(() => {
-    if (isDone || isLoading) return;
+    if (isDone || isLoading || phase !== "interviewing") return;
     if (timeLeft <= 0) return;
     const timer = setTimeout(() => setTimeLeft((t) => t - 1), 1000);
     return () => clearTimeout(timer);
-  }, [timeLeft, isDone, isLoading]);
+  }, [timeLeft, isDone, isLoading, phase]);
 
   async function handleSubmit() {
     const trimmed = answer.trim();
     if (!trimmed || isLoading) return;
 
+    const currentAgentId = AGENT_ORDER[agentIndex];
     const updatedMessages: Message[] = [
       ...messages,
       { role: "candidate", content: trimmed },
     ];
     setMessages(updatedMessages);
     setAnswer("");
+    setIsLoading(true);
+    setError("");
 
-    const nextIndex = questionIndex + 1;
-    if (nextIndex >= TOTAL_QUESTIONS) {
+    try {
+      const maxFollowUps = MAX_FOLLOWUPS[difficulty];
+      const canFollowUp = followUpCount < maxFollowUps;
+
+      if (canFollowUp) {
+        // 꼬리질문 시도
+        const result = await fetchQuestion(updatedMessages, currentAgentId, true);
+
+        if (result.followUp === false) {
+          // 에이전트 만족 → 다음 에이전트로
+          await advanceToNextAgent(updatedMessages);
+        } else if (result.question) {
+          setMessages([
+            ...updatedMessages,
+            { role: "interviewer", content: result.question, agentId: currentAgentId },
+          ]);
+          setFollowUpCount((c) => c + 1);
+        }
+      } else {
+        // 꼬리질문 한도 초과 → 다음 에이전트로
+        await advanceToNextAgent(updatedMessages);
+      }
+    } catch (e: unknown) {
+      setError(e instanceof Error ? e.message : "질문 생성에 실패했습니다");
+    } finally {
+      setIsLoading(false);
+    }
+  }
+
+  async function advanceToNextAgent(currentMessages: Message[]) {
+    const nextAgentIndex = agentIndex + 1;
+
+    if (nextAgentIndex >= TOTAL_AGENTS) {
+      // 모든 에이전트 완료 → 피드백
       setIsDone(true);
       setIsFetchingFeedback(true);
       setFeedbackError("");
       try {
-        const result = await fetchFeedback(updatedMessages);
+        const result = await fetchFeedback(currentMessages);
         setFeedback(result);
       } catch (e: unknown) {
         setFeedbackError(e instanceof Error ? e.message : "피드백 생성에 실패했습니다");
@@ -101,28 +176,35 @@ export default function InterviewSession({ name }: { name: string }) {
       return;
     }
 
-    setIsLoading(true);
-    setError("");
-
-    try {
-      const question = await fetchQuestion(nextIndex, updatedMessages);
-      setMessages([...updatedMessages, { role: "interviewer", content: question }]);
-      setQuestionIndex(nextIndex);
-    } catch (e: unknown) {
-      setError(e instanceof Error ? e.message : "질문 생성에 실패했습니다");
-    } finally {
-      setIsLoading(false);
+    // 다음 에이전트 기본 질문 요청
+    const nextAgentId = AGENT_ORDER[nextAgentIndex];
+    const result = await fetchQuestion(currentMessages, nextAgentId, false);
+    if (result.question) {
+      setMessages([
+        ...currentMessages,
+        { role: "interviewer", content: result.question, agentId: nextAgentId },
+      ]);
+      setAgentIndex(nextAgentIndex);
+      setFollowUpCount(0);
     }
   }
 
   function handleRestart() {
-    setMessages([{ role: "interviewer", content: getFirstQuestion(name) }]);
-    setQuestionIndex(0);
+    setPhase("selecting");
+    setMessages([]);
+    setAgentIndex(0);
+    setFollowUpCount(0);
     setIsDone(false);
     setAnswer("");
     setTimeLeft(ANSWER_TIME_LIMIT);
     setFeedback(null);
     setFeedbackError("");
+    setError("");
+  }
+
+  // 난이도 선택 화면
+  if (phase === "selecting") {
+    return <DifficultySelect onSelect={handleDifficultySelect} />;
   }
 
   // 피드백 로딩 화면
@@ -144,7 +226,6 @@ export default function InterviewSession({ name }: { name: string }) {
   if (isDone && feedback) {
     return (
       <div className="space-y-6">
-        {/* 헤더 */}
         <div className="card p-6 text-center space-y-3">
           <h2 className="text-xl font-bold text-gray-900 dark:text-slate-50">면접 완료!</h2>
           <p className="text-gray-500 dark:text-slate-400 text-sm">
@@ -153,7 +234,6 @@ export default function InterviewSession({ name }: { name: string }) {
           <ScoreRing score={feedback.score} />
         </div>
 
-        {/* 총평 */}
         <div className="card p-6 space-y-4">
           <h3 className="font-bold text-gray-900 dark:text-slate-50">종합 평가</h3>
           <div className="space-y-3">
@@ -172,7 +252,6 @@ export default function InterviewSession({ name }: { name: string }) {
           </div>
         </div>
 
-        {/* 질문별 피드백 */}
         <div className="space-y-3">
           <h3 className="font-bold text-gray-900 dark:text-slate-50 px-1">질문별 피드백</h3>
           {feedback.perQuestion.map((q, i) => (
@@ -193,14 +272,9 @@ export default function InterviewSession({ name }: { name: string }) {
           ))}
         </div>
 
-        {/* 액션 버튼 */}
         <div className="flex flex-col sm:flex-row gap-3">
-          <a href="/job-posting" className="btn-secondary text-center">
-            채용공고 변경
-          </a>
-          <button onClick={handleRestart} className="btn-primary">
-            다시 연습하기
-          </button>
+          <a href="/job-posting" className="btn-secondary text-center">채용공고 변경</a>
+          <button onClick={handleRestart} className="btn-primary">다시 연습하기</button>
         </div>
       </div>
     );
@@ -223,6 +297,7 @@ export default function InterviewSession({ name }: { name: string }) {
   const isAnswered = messages[messages.length - 1]?.role === "candidate";
   const lastInterviewerIdx = messages.reduce((acc, m, i) => m.role === "interviewer" ? i : acc, -1);
   const currentQuestion = isAnswered ? "" : (messages[lastInterviewerIdx]?.content ?? "");
+  const currentQuestionAgentId = isAnswered ? undefined : (messages[lastInterviewerIdx]?.agentId);
   const pastMessages = isAnswered ? messages : messages.slice(0, lastInterviewerIdx);
 
   const isTimeWarning = timeLeft <= 30 && timeLeft > 0;
@@ -230,38 +305,48 @@ export default function InterviewSession({ name }: { name: string }) {
 
   return (
     <div className="space-y-4">
-      {/* 진행 상황 */}
-      <div className="flex items-center gap-3">
-        <div className="flex gap-1.5 flex-1">
-          {Array.from({ length: TOTAL_QUESTIONS }).map((_, i) => (
-            <div
-              key={i}
-              className={`h-1.5 flex-1 rounded-full transition-all duration-300 ${
-                i < questionIndex
-                  ? "bg-blue-600"
-                  : i === questionIndex
-                  ? "bg-blue-300 dark:bg-blue-700"
-                  : "bg-gray-200 dark:bg-slate-700"
-              }`}
-            />
-          ))}
-        </div>
-        <span className="text-xs text-gray-400 dark:text-slate-500 whitespace-nowrap">
-          {questionIndex + 1} / {TOTAL_QUESTIONS}
-        </span>
+      {/* 진행 상황 — 에이전트 3단계 */}
+      <div className="flex items-center gap-2">
+        {AGENT_ORDER.map((aid, i) => {
+          const isDoneAgent = i < agentIndex;
+          const isCurrentAgent = i === agentIndex;
+          const colorMap: Record<AgentId, string> = {
+            organization: "bg-purple-500",
+            logic: "bg-blue-500",
+            technical: "bg-green-500",
+          };
+          const dimMap: Record<AgentId, string> = {
+            organization: "bg-purple-200 dark:bg-purple-900/40",
+            logic: "bg-blue-200 dark:bg-blue-900/40",
+            technical: "bg-green-200 dark:bg-green-900/40",
+          };
+          return (
+            <div key={aid} className="flex-1 space-y-1">
+              <div
+                className={`h-1.5 rounded-full transition-all duration-300 ${
+                  isDoneAgent ? colorMap[aid] : isCurrentAgent ? dimMap[aid] : "bg-gray-200 dark:bg-slate-700"
+                }`}
+              />
+              <p className={`text-xs text-center truncate ${
+                isCurrentAgent
+                  ? "font-semibold text-gray-700 dark:text-slate-300"
+                  : "text-gray-400 dark:text-slate-600"
+              }`}>
+                {AGENTS[aid].label}
+              </p>
+            </div>
+          );
+        })}
       </div>
 
       {/* 이전 대화 */}
       {pastMessages.length > 0 && (
         <div className="space-y-3">
           {pastMessages.map((m, i) => (
-            <div
-              key={i}
-              className={`flex ${m.role === "candidate" ? "justify-end" : "justify-start"}`}
-            >
+            <div key={i} className={`flex ${m.role === "candidate" ? "justify-end" : "justify-start"}`}>
               {m.role === "interviewer" && (
                 <div className="flex flex-col gap-1 max-w-[85%] sm:max-w-[75%]">
-                  <span className="text-xs font-semibold text-blue-600 dark:text-blue-400 pl-1">면접관</span>
+                  {m.agentId && <AgentBadge agentId={m.agentId} />}
                   <div className="bg-white dark:bg-slate-800 border border-gray-100 dark:border-slate-700 text-gray-700 dark:text-slate-300 rounded-2xl rounded-tl-sm px-4 py-3 text-sm leading-relaxed shadow-card">
                     {m.content}
                   </div>
@@ -280,8 +365,8 @@ export default function InterviewSession({ name }: { name: string }) {
       {/* 현재 질문 */}
       {currentQuestion && (
         <div className="card border-blue-100 dark:border-blue-900/50 p-5 space-y-1">
-          <p className="text-xs font-semibold text-blue-600 dark:text-blue-400 mb-2">면접관</p>
-          <p className="text-gray-900 dark:text-slate-100 text-base leading-relaxed">{currentQuestion}</p>
+          {currentQuestionAgentId && <AgentBadge agentId={currentQuestionAgentId} />}
+          <p className="text-gray-900 dark:text-slate-100 text-base leading-relaxed pt-1">{currentQuestion}</p>
         </div>
       )}
 
@@ -342,7 +427,7 @@ export default function InterviewSession({ name }: { name: string }) {
             disabled={isLoading || !answer.trim()}
             className="btn-primary py-2 px-5"
           >
-            {questionIndex + 1 >= TOTAL_QUESTIONS ? "면접 완료" : "제출 →"}
+            제출 →
           </button>
         </div>
       </div>

--- a/lib/interview.ts
+++ b/lib/interview.ts
@@ -1,29 +1,38 @@
 const OLLAMA_BASE_URL = process.env.OLLAMA_BASE_URL ?? "http://localhost:11434";
 const OLLAMA_MODEL = process.env.OLLAMA_MODEL ?? "qwen2.5:7b";
 
-export type Message = { role: "interviewer" | "candidate"; content: string };
+export type AgentId = "organization" | "logic" | "technical";
+export type Difficulty = "easy" | "normal" | "hard";
 
-const QUESTION_CATEGORIES = [
-  "자기소개/지원동기",  // 0 — 고정 질문
-  "직무 역량",          // 1
-  "경험 기반",          // 2
-  "심화",               // 3
-  "회사/문화 적합성",   // 4
-] as const;
-
-// 각 카테고리별 질문 의도 — 모델이 카테고리를 정확히 이해하도록 영어로 설명
-const CATEGORY_GUIDE: Record<string, string> = {
-  "자기소개/지원동기": "Ask about the candidate's background and specific reasons for applying to this company and role.",
-  "직무 역량": "Verify technical skills and competencies required for the job based on responsibilities and requirements in the job posting.",
-  "경험 기반": "Draw out concrete past experiences (projects, internships, activities) using the STAR method (Situation, Task, Action, Result).",
-  "심화": "Follow up on unclear or interesting points from the candidate's previous answers to dig deeper.",
-  "회사/문화 적합성": "Assess the candidate's understanding of the company's values and culture, and their organizational fit.",
+export const MAX_FOLLOWUPS: Record<Difficulty, number> = {
+  easy: 0,
+  normal: 1,
+  hard: 3,
 };
 
-export const TOTAL_QUESTIONS = QUESTION_CATEGORIES.length;
-export function getFirstQuestion(name: string) {
-  return `안녕하세요, ${name}님. 간단한 자기소개와 지원동기를 말씀해주세요.`;
-}
+export const AGENT_ORDER: AgentId[] = ["organization", "logic", "technical"];
+export const TOTAL_AGENTS = AGENT_ORDER.length;
+
+export const AGENTS: Record<AgentId, { label: string; criterion: string }> = {
+  organization: {
+    label: "조직 전문가",
+    criterion: "성장 가능성, 자기 인식, 진정성, 조직 문화 적합성",
+  },
+  logic: {
+    label: "논리 전문가",
+    criterion: "답변 구조, 논리적 흐름, STAR 메서드",
+  },
+  technical: {
+    label: "기술 전문가",
+    criterion: "직무 연관성, 기술 구체성",
+  },
+};
+
+export type Message = {
+  role: "interviewer" | "candidate";
+  content: string;
+  agentId?: AgentId;
+};
 
 interface Education {
   schoolName: string;
@@ -98,28 +107,23 @@ function buildProfileSummary(profile: ProfileContext): string {
   return lines.join("\n");
 }
 
-// 지원자 프로필을 분석해 면접관에게 전달할 상황별 힌트를 생성
-// (경력자/신입 여부, 전공-직무 불일치 여부 등)
 function buildContextualHints(
   profile: ProfileContext,
   jobPosting: JobPostingContext,
 ): string {
   const hints: string[] = [];
 
-  // 경력자면 이직 동기 질문을 유도하고, 이전 직무 기술 질문은 금지
   if (profile.careers.length > 0) {
     const careerNames = profile.careers.map((c) => `${c.companyName}(${c.role})`).join(", ");
     hints.push(
       `- The candidate is an experienced hire (${careerNames}). Focus on their motivation for switching jobs and how their past experience contributes to this role. Do NOT ask technical questions specific to their previous job.`,
     );
   } else {
-    // 신입은 프로젝트·인턴·활동 경험 위주로 질문
     hints.push(
       "- The candidate is a new graduate with no full-time work experience. Focus on internships, personal projects, and extracurricular activities related to the job.",
     );
   }
 
-  // 전공과 지원 직무가 다를 경우 지원 동기를 추가로 파악
   if (profile.educations.length > 0) {
     const major = profile.educations[0].major ?? "";
     const jobText = (jobPosting.responsibilities + jobPosting.requirements).toLowerCase();
@@ -136,24 +140,25 @@ function buildContextualHints(
   return hints.join("\n");
 }
 
-export async function generateInterviewQuestion(
+export function getFirstQuestion(name: string) {
+  return `안녕하세요, ${name}님. 간단한 자기소개와 지원동기를 말씀해주세요.`;
+}
+
+function buildAgentSystemPrompt(
+  agentId: AgentId,
   profile: ProfileContext,
   jobPosting: JobPostingContext,
-  messages: Message[],
-  questionIndex: number,
-): Promise<string> {
-  const category = QUESTION_CATEGORIES[questionIndex] ?? "심화";
+): string {
   const profileSummary = buildProfileSummary(profile);
   const contextualHints = buildContextualHints(profile, jobPosting);
 
-  const conversationText = messages
-    .map((m) => `${m.role === "interviewer" ? "면접관" : "지원자"}: ${m.content}`)
-    .join("\n\n");
+  const agentRole: Record<AgentId, string> = {
+    organization: `You are an organizational culture and HR specialist interviewer. Your evaluation focuses on: growth potential, self-awareness, authenticity, and organizational culture fit. Ask questions that reveal the candidate's values, motivations, and alignment with the company culture.`,
+    logic: `You are a logical thinking and communication specialist interviewer. Your evaluation focuses on: answer structure, logical flow, and STAR method (Situation, Task, Action, Result). Ask questions based on past experiences and assess how clearly and logically the candidate communicates.`,
+    technical: `You are a technical skills specialist interviewer. Your evaluation focuses on: job relevance and technical specificity (concrete numbers, project names, measurable results). Ask questions about technical skills and competencies required for the job.`,
+  };
 
-  const categoryGuide = CATEGORY_GUIDE[category] ?? category;
-
-  // system: 면접관 역할·채용공고·지원자 정보·출력 규칙 주입
-  const systemPrompt = `You are a professional Korean job interviewer. Always respond in Korean only.
+  return `${agentRole[agentId]} Always respond in Korean only.
 
 [Job Posting]
 Responsibilities: ${jobPosting.responsibilities || "N/A"}
@@ -167,16 +172,11 @@ ${profileSummary}
 ${contextualHints}
 
 [Output Rules]
-1. Base your question on the job posting's responsibilities and requirements.
-2. Output exactly one interview question in Korean. No extra text.
-3. Do not prefix with "면접관:", "질문:", "Q:", or anything similar.
-4. Current category: "${category}" — ${categoryGuide}`;
+1. Output exactly one interview question in Korean. No extra text.
+2. Do not prefix with "면접관:", "질문:", "Q:", or anything similar.`;
+}
 
-  // user: 대화 히스토리가 있으면 꼬리질문, 없으면 첫 질문 생성 요청
-  const userContent = conversationText
-    ? `[Interview Conversation]\n${conversationText}\n\nBased on the conversation above, generate one Korean interview question for the "${category}" category. If the candidate's last answer lacks specifics or has an interesting point, prioritize a follow-up question on that.`
-    : `Based on the job posting and candidate profile, generate one Korean interview question for the "${category}" category.`;
-
+async function callOllama(systemPrompt: string, userContent: string): Promise<string> {
   const response = await fetch(`${OLLAMA_BASE_URL}/api/chat`, {
     method: "POST",
     headers: { "Content-Type": "application/json", "ngrok-skip-browser-warning": "true" },
@@ -188,6 +188,7 @@ ${contextualHints}
         { role: "user", content: userContent },
       ],
     }),
+    signal: AbortSignal.timeout(180_000),
   });
 
   if (!response.ok) {
@@ -196,7 +197,72 @@ ${contextualHints}
 
   const data = await response.json();
   const raw: string = (data.message?.content ?? "").trim();
-
-  // "면접관:", "Q:", "질문:" 등 접두어 제거
   return raw.replace(/^(면접관|질문|interviewer|question)\s*:\s*/i, "").trim();
+}
+
+// 에이전트의 기본 질문 생성
+export async function generateAgentBaseQuestion(
+  agentId: AgentId,
+  profile: ProfileContext,
+  jobPosting: JobPostingContext,
+  messages: Message[],
+): Promise<string> {
+  // 조직 전문가 첫 질문은 고정
+  if (agentId === "organization" && messages.length === 0) {
+    return getFirstQuestion(profile.name);
+  }
+
+  const systemPrompt = buildAgentSystemPrompt(agentId, profile, jobPosting);
+
+  const baseQuestionGuide: Record<AgentId, string> = {
+    organization: `Based on the job posting and candidate profile, ask a warm, welcoming question about the candidate's motivation for applying and their background. This is the opening question of the interview.`,
+    logic: `Based on the interview conversation so far, ask a question that requires the candidate to describe a specific past experience using the STAR method (Situation, Task, Action, Result). Focus on experiences relevant to the job.`,
+    technical: `Based on the job posting requirements and the interview so far, ask a question about specific technical skills or competencies relevant to this role. Request concrete examples with measurable outcomes.`,
+  };
+
+  const conversationText = messages
+    .map((m) => `${m.role === "interviewer" ? "면접관" : "지원자"}: ${m.content}`)
+    .join("\n\n");
+
+  const userContent = conversationText
+    ? `[Interview Conversation So Far]\n${conversationText}\n\n${baseQuestionGuide[agentId]}`
+    : baseQuestionGuide[agentId];
+
+  return callOllama(systemPrompt, userContent);
+}
+
+// 에이전트의 꼬리질문 생성. null 반환 시 다음 에이전트로 넘어감
+export async function generateAgentFollowUpQuestion(
+  agentId: AgentId,
+  profile: ProfileContext,
+  jobPosting: JobPostingContext,
+  messages: Message[],
+): Promise<string | null> {
+  const systemPrompt = buildAgentSystemPrompt(agentId, profile, jobPosting);
+
+  const conversationText = messages
+    .map((m) => `${m.role === "interviewer" ? "면접관" : "지원자"}: ${m.content}`)
+    .join("\n\n");
+
+  const agentCriteria: Record<AgentId, string> = {
+    organization: "growth potential, self-awareness, and authenticity",
+    logic: "logical structure and STAR method completeness (Situation, Task, Action, Result)",
+    technical: "technical specificity with concrete numbers, project names, and measurable results",
+  };
+
+  const userContent = `[Interview Conversation]\n${conversationText}
+
+The candidate just answered your last question. Evaluate whether their answer sufficiently addresses your evaluation criteria: ${agentCriteria[agentId]}.
+
+Rules:
+- If the answer lacks important specifics or needs clarification, output EXACTLY ONE follow-up question in Korean. The question must reference a specific part of the candidate's last answer.
+- If the answer is sufficiently detailed and complete from your perspective, output EXACTLY: DONE
+- Do not add any explanation. Output only the follow-up question OR the word DONE.`;
+
+  const raw = await callOllama(systemPrompt, userContent);
+
+  if (raw.trim().toUpperCase() === "DONE" || raw.trim() === "") {
+    return null;
+  }
+  return raw;
 }


### PR DESCRIPTION
## Summary

- 기존 단일 면접관 → 조직/논리/기술 전문가 3명의 패널 면접으로 전환
- 난이도 선택(이지/노말/하드)으로 꼬리질문 횟수 조절 (0/1/3회)
- 에이전트별 꼬리질문: LLM이 답변 충분성을 판단해 자율적으로 꼬리질문 또는 다음 에이전트로 이동
- 면접 UI에 에이전트 레이블 표시 및 3단계 진행 바 적용

## 변경 파일

| 파일 | 변경 내용 |
|-----|---------|
| `lib/interview.ts` | 에이전트 정의(AgentId, AGENTS, AGENT_ORDER), 기본질문/꼬리질문 생성 함수로 재작성 |
| `app/api/interview/question/route.ts` | agentId + isFollowUpRequest 파라미터 기반으로 변경 |
| `components/DifficultySelect.tsx` | 신규 — 난이도 선택 UI |
| `components/InterviewSession.tsx` | 멀티 에이전트 흐름(agentIndex + followUpCount) + 에이전트 레이블 표시 |

## 면접 흐름

```
난이도 선택 → 조직 전문가(자기소개/지원동기) → 논리 전문가(경험기반) → 기술 전문가(직무역량) → 피드백
               └─ 꼬리질문(난이도에 따라 0~3회)
```

## Test plan

- [ ] 난이도 선택 화면 표시 확인
- [ ] 이지: 3문항 후 피드백으로 이동
- [ ] 노말: 에이전트당 최대 2문항 (꼬리질문 1회)
- [ ] 하드: 에이전트당 최대 4문항 (꼬리질문 3회)
- [ ] 각 질문마다 에이전트 레이블(조직/논리/기술 전문가) 표시 확인
- [ ] 꼬리질문 없이 에이전트가 만족한 경우 다음 에이전트로 넘어가는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)