### PR TITLE
feat: 멀티 에이전트 토론 시스템 구현 (2단계)

### DIFF
--- a/app/api/interview/debate/[sessionId]/status/route.ts
+++ b/app/api/interview/debate/[sessionId]/status/route.ts
@@ -1,0 +1,33 @@
+import { NextRequest, NextResponse } from "next/server";
+import { supabase } from "@/lib/supabase";
+import { getAuthUser } from "@/lib/auth";
+
+export async function GET(
+  _request: NextRequest,
+  { params }: { params: Promise<{ sessionId: string }> },
+) {
+  try {
+    const userId = await getAuthUser();
+    if (!userId) return NextResponse.json({ error: "로그인이 필요합니다" }, { status: 401 });
+
+    const { sessionId } = await params;
+
+    const { data: session } = await supabase
+      .from("interview_sessions")
+      .select(
+        "status, agentEvaluations, finalScore, finalFeedback, debateSummary, improvementTips, errorMessage",
+      )
+      .eq("id", sessionId)
+      .eq("userId", userId)
+      .maybeSingle();
+
+    if (!session) {
+      return NextResponse.json({ error: "세션을 찾을 수 없습니다" }, { status: 404 });
+    }
+
+    return NextResponse.json(session);
+  } catch (error) {
+    console.error("Status check error:", error);
+    return NextResponse.json({ error: "상태 확인 중 오류가 발생했습니다" }, { status: 500 });
+  }
+}

--- a/app/api/interview/debate/route.ts
+++ b/app/api/interview/debate/route.ts
@@ -1,0 +1,136 @@
+import { NextRequest, NextResponse } from "next/server";
+import { supabase } from "@/lib/supabase";
+import { getAuthUser } from "@/lib/auth";
+import type { Json } from "@/types/supabase";
+import { Message, Difficulty, AGENT_ORDER } from "@/lib/interview";
+import {
+  generateAgentEvaluation,
+  generateAgentReply,
+  generateModeratorResult,
+  AgentEvaluation,
+  AgentReply,
+} from "@/lib/agents";
+
+async function runDebate(
+  sessionId: string,
+  messages: Message[],
+) {
+  try {
+    // Round 0: 3 에이전트 병렬 독립 평가
+    const round0Results = await Promise.allSettled(
+      AGENT_ORDER.map((agentId) => generateAgentEvaluation(agentId, messages)),
+    );
+
+    const evaluations: AgentEvaluation[] = round0Results
+      .filter((r): r is PromiseFulfilledResult<AgentEvaluation> => r.status === "fulfilled")
+      .map((r) => r.value);
+
+    if (evaluations.length < 2) {
+      throw new Error("에이전트 평가 실패 (2개 미만 성공)");
+    }
+
+    await supabase
+      .from("interview_sessions")
+      .update({ agentEvaluations: evaluations as unknown as Json, status: "debating", updatedAt: new Date().toISOString() })
+      .eq("id", sessionId);
+
+    // Round 1: 병렬 상호 반론
+    const round1Results = await Promise.allSettled(
+      evaluations.map((myEval) => {
+        const others = evaluations.filter((e) => e.agentId !== myEval.agentId);
+        return generateAgentReply(myEval.agentId, myEval, others, messages);
+      }),
+    );
+
+    const replies: AgentReply[] = round1Results
+      .filter((r): r is PromiseFulfilledResult<AgentReply> => r.status === "fulfilled")
+      .map((r) => r.value);
+
+    await supabase
+      .from("interview_sessions")
+      .update({ debateReplies: replies as unknown as Json, status: "finalizing", updatedAt: new Date().toISOString() })
+      .eq("id", sessionId);
+
+    // 중재자: 최종 결론
+    const repliesForScore: AgentReply[] =
+      replies.length > 0
+        ? replies
+        : evaluations.map((e) => ({
+            agentId: e.agentId,
+            agentLabel: e.agentLabel,
+            revisedScore: e.score,
+            scoreChanged: false,
+            scoreReason: "",
+            replies: [],
+          }));
+
+    const moderatorResult = await generateModeratorResult(evaluations, repliesForScore, messages);
+
+    await supabase
+      .from("interview_sessions")
+      .update({
+        finalScore: moderatorResult.score,
+        finalFeedback: moderatorResult.overall as unknown as Json,
+        debateSummary: moderatorResult.debateSummary,
+        improvementTips: moderatorResult.improvementTips as unknown as Json,
+        status: "done",
+        updatedAt: new Date().toISOString(),
+      })
+      .eq("id", sessionId);
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : "알 수 없는 오류";
+    await supabase
+      .from("interview_sessions")
+      .update({ status: "error", errorMessage: msg, updatedAt: new Date().toISOString() })
+      .eq("id", sessionId);
+  }
+}
+
+export async function POST(request: NextRequest) {
+  try {
+    const userId = await getAuthUser();
+    if (!userId) return NextResponse.json({ error: "로그인이 필요합니다" }, { status: 401 });
+
+    const { messages, difficulty } = (await request.json()) as {
+      messages: Message[];
+      difficulty: Difficulty;
+    };
+
+    const { data: profile } = await supabase
+      .from("profiles")
+      .select("*")
+      .eq("userId", userId)
+      .maybeSingle();
+    if (!profile) return NextResponse.json({ error: "프로필이 없습니다" }, { status: 404 });
+
+    const { data: jobPosting } = await supabase
+      .from("job_postings")
+      .select("id, responsibilities, requirements, preferredQuals")
+      .eq("userId", userId)
+      .order("updatedAt", { ascending: false })
+      .limit(1)
+      .maybeSingle();
+    if (!jobPosting) return NextResponse.json({ error: "채용공고가 없습니다" }, { status: 404 });
+
+    const sessionId = crypto.randomUUID();
+
+    await supabase.from("interview_sessions").insert({
+      id: sessionId,
+      userId,
+      jobPostingId: jobPosting.id,
+      difficulty,
+      messages: messages as unknown as Json,
+      status: "evaluating",
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+    });
+
+    // fire-and-forget
+    runDebate(sessionId, messages).catch(() => {});
+
+    return NextResponse.json({ sessionId });
+  } catch (error) {
+    console.error("Debate start error:", error);
+    return NextResponse.json({ error: "토론을 시작할 수 없습니다" }, { status: 500 });
+  }
+}

--- a/components/DebateLoading.tsx
+++ b/components/DebateLoading.tsx
@@ -1,0 +1,118 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import type { AgentEvaluation, ModeratorResult } from "@/lib/agents";
+
+export interface DebateResultData {
+  agentEvaluations: AgentEvaluation[];
+  finalScore: number;
+  finalFeedback: ModeratorResult["overall"];
+  debateSummary: string;
+  improvementTips: string[];
+}
+
+interface Props {
+  sessionId: string;
+  onDone: (result: DebateResultData) => void;
+  onError: (message: string) => void;
+}
+
+const STAGES: { status: string; label: string }[] = [
+  { status: "evaluating", label: "에이전트별 평가 중" },
+  { status: "debating", label: "면접관들이 토론 중" },
+  { status: "finalizing", label: "최종 결과 정리 중" },
+];
+
+function stageIndex(status: string): number {
+  const idx = STAGES.findIndex((s) => s.status === status);
+  return idx === -1 ? STAGES.length : idx;
+}
+
+export default function DebateLoading({ sessionId, onDone, onError }: Props) {
+  const [currentStatus, setCurrentStatus] = useState("evaluating");
+  const intervalRef = useRef<ReturnType<typeof setInterval>>();
+
+  useEffect(() => {
+    const poll = async () => {
+      try {
+        const res = await fetch(`/api/interview/debate/${sessionId}/status`);
+        if (!res.ok) return;
+        const data = await res.json();
+
+        setCurrentStatus(data.status);
+
+        if (data.status === "done") {
+          clearInterval(intervalRef.current);
+          onDone({
+            agentEvaluations: data.agentEvaluations ?? [],
+            finalScore: data.finalScore ?? 0,
+            finalFeedback: data.finalFeedback ?? { strengths: "", weaknesses: "", advice: "" },
+            debateSummary: data.debateSummary ?? "",
+            improvementTips: data.improvementTips ?? [],
+          });
+        } else if (data.status === "error") {
+          clearInterval(intervalRef.current);
+          onError(data.errorMessage ?? "토론 중 오류가 발생했습니다");
+        }
+      } catch {
+        // 일시적 네트워크 오류 무시
+      }
+    };
+
+    poll();
+    intervalRef.current = setInterval(poll, 1500);
+    return () => clearInterval(intervalRef.current);
+  }, [sessionId, onDone, onError]);
+
+  const current = stageIndex(currentStatus);
+
+  return (
+    <div className="card p-10 flex flex-col items-center justify-center space-y-8 text-center min-h-64">
+      <div>
+        <h2 className="text-lg font-bold text-gray-900 dark:text-slate-50 mb-1">
+          면접관들이 평가하고 있습니다
+        </h2>
+        <p className="text-sm text-gray-500 dark:text-slate-400">
+          3명의 전문 면접관이 토론을 진행 중입니다
+        </p>
+      </div>
+
+      <div className="space-y-4 w-full max-w-xs">
+        {STAGES.map((stage, i) => {
+          const done = i < current;
+          const active = i === current;
+          return (
+            <div key={stage.status} className="flex items-center gap-3">
+              {done ? (
+                <span className="w-5 h-5 rounded-full bg-green-500 flex items-center justify-center text-white text-xs shrink-0">
+                  ✓
+                </span>
+              ) : active ? (
+                <span className="w-5 h-5 rounded-full border-2 border-blue-500 flex items-center justify-center shrink-0">
+                  <span className="w-2 h-2 rounded-full bg-blue-500 animate-pulse" />
+                </span>
+              ) : (
+                <span className="w-5 h-5 rounded-full border-2 border-gray-200 dark:border-slate-600 shrink-0" />
+              )}
+              <span
+                className={`text-sm ${
+                  done
+                    ? "text-gray-400 dark:text-slate-500 line-through"
+                    : active
+                      ? "text-gray-700 dark:text-slate-200 font-medium"
+                      : "text-gray-400 dark:text-slate-600"
+                }`}
+              >
+                {stage.label}
+              </span>
+            </div>
+          );
+        })}
+      </div>
+
+      <p className="text-xs text-gray-400 dark:text-slate-500">
+        Ollama 모델에 따라 1~3분 소요될 수 있습니다
+      </p>
+    </div>
+  );
+}

--- a/components/DebateResult.tsx
+++ b/components/DebateResult.tsx
@@ -1,0 +1,158 @@
+"use client";
+
+import type { AgentEvaluation } from "@/lib/agents";
+import type { AgentId } from "@/lib/interview";
+
+interface Props {
+  finalScore: number;
+  agentEvaluations: AgentEvaluation[];
+  finalFeedback: { strengths: string; weaknesses: string; advice: string };
+  debateSummary: string;
+  improvementTips: string[];
+  onRestart: () => void;
+}
+
+function ScoreRing({ score }: { score: number }) {
+  const color =
+    score >= 80 ? "text-green-500" : score >= 60 ? "text-blue-500" : "text-orange-500";
+  return (
+    <div className={`text-5xl font-bold ${color}`}>
+      {score}
+      <span className="text-2xl text-gray-400 dark:text-slate-500 font-normal">/100</span>
+    </div>
+  );
+}
+
+const AGENT_COLORS: Record<AgentId, { border: string; badge: string }> = {
+  organization: {
+    border: "border-purple-100 dark:border-purple-900/40",
+    badge: "bg-purple-100 dark:bg-purple-900/40 text-purple-700 dark:text-purple-300",
+  },
+  logic: {
+    border: "border-blue-100 dark:border-blue-900/40",
+    badge: "bg-blue-100 dark:bg-blue-900/40 text-blue-700 dark:text-blue-300",
+  },
+  technical: {
+    border: "border-green-100 dark:border-green-900/40",
+    badge: "bg-green-100 dark:bg-green-900/40 text-green-700 dark:text-green-300",
+  },
+};
+
+export default function DebateResult({
+  finalScore,
+  agentEvaluations,
+  finalFeedback,
+  debateSummary,
+  improvementTips,
+  onRestart,
+}: Props) {
+  return (
+    <div className="space-y-6">
+      {/* 최종 점수 */}
+      <div className="card p-6 text-center space-y-3">
+        <h2 className="text-xl font-bold text-gray-900 dark:text-slate-50">면접 완료!</h2>
+        <p className="text-sm text-gray-500 dark:text-slate-400">3명의 면접관 토론 결과입니다</p>
+        <ScoreRing score={finalScore} />
+      </div>
+
+      {/* 에이전트별 평가 카드 (Round 0 의견) */}
+      {agentEvaluations.length > 0 && (
+        <div className="space-y-3">
+          <h3 className="font-bold text-gray-900 dark:text-slate-50 px-1">면접관별 평가</h3>
+          {agentEvaluations.map((e) => {
+            const colors = AGENT_COLORS[e.agentId] ?? AGENT_COLORS.organization;
+            return (
+              <div key={e.agentId} className={`card p-5 space-y-3 border-l-4 ${colors.border}`}>
+                <div className="flex items-center justify-between">
+                  <div className="space-y-0.5">
+                    <span
+                      className={`text-xs font-semibold px-2 py-0.5 rounded-full ${colors.badge}`}
+                    >
+                      {e.agentLabel}
+                    </span>
+                    <p className="text-xs text-gray-400 dark:text-slate-500 pt-1">{e.criterion}</p>
+                  </div>
+                  <span className="text-2xl font-bold text-gray-700 dark:text-slate-300">
+                    {e.score}
+                    <span className="text-sm font-normal text-gray-400 dark:text-slate-500">/100</span>
+                  </span>
+                </div>
+                <p className="text-sm text-gray-700 dark:text-slate-300 leading-relaxed">
+                  {e.opinion}
+                </p>
+                {e.highlights.length > 0 && (
+                  <ul className="space-y-1">
+                    {e.highlights.map((h, i) => (
+                      <li key={i} className="text-xs text-gray-500 dark:text-slate-400 flex gap-1.5">
+                        <span className="text-gray-300 dark:text-slate-600 shrink-0">•</span>
+                        {h}
+                      </li>
+                    ))}
+                  </ul>
+                )}
+              </div>
+            );
+          })}
+        </div>
+      )}
+
+      {/* 종합 피드백 */}
+      <div className="card p-6 space-y-4">
+        <h3 className="font-bold text-gray-900 dark:text-slate-50">종합 평가</h3>
+        <div className="space-y-3">
+          <div className="bg-green-50 dark:bg-green-900/20 rounded-xl p-4">
+            <p className="text-xs font-semibold text-green-600 dark:text-green-400 mb-1">강점</p>
+            <p className="text-sm text-gray-700 dark:text-slate-300 leading-relaxed">
+              {finalFeedback.strengths}
+            </p>
+          </div>
+          <div className="bg-orange-50 dark:bg-orange-900/20 rounded-xl p-4">
+            <p className="text-xs font-semibold text-orange-600 dark:text-orange-400 mb-1">약점</p>
+            <p className="text-sm text-gray-700 dark:text-slate-300 leading-relaxed">
+              {finalFeedback.weaknesses}
+            </p>
+          </div>
+          <div className="bg-blue-50 dark:bg-blue-900/20 rounded-xl p-4">
+            <p className="text-xs font-semibold text-blue-600 dark:text-blue-400 mb-1">핵심 조언</p>
+            <p className="text-sm text-gray-700 dark:text-slate-300 leading-relaxed">
+              {finalFeedback.advice}
+            </p>
+          </div>
+        </div>
+      </div>
+
+      {/* 개선 코멘트 */}
+      {improvementTips.length > 0 && (
+        <div className="card p-6 space-y-3">
+          <h3 className="font-bold text-gray-900 dark:text-slate-50">개선 포인트</h3>
+          <ul className="space-y-2">
+            {improvementTips.map((tip, i) => (
+              <li key={i} className="flex gap-2 text-sm text-gray-700 dark:text-slate-300">
+                <span className="text-blue-500 font-bold shrink-0">{i + 1}.</span>
+                {tip}
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+
+      {/* 토론 요약 */}
+      {debateSummary && (
+        <div className="card p-5 space-y-2 bg-gray-50 dark:bg-slate-800/50">
+          <h3 className="text-sm font-semibold text-gray-600 dark:text-slate-400">면접관 토론 요약</h3>
+          <p className="text-sm text-gray-600 dark:text-slate-400 leading-relaxed">{debateSummary}</p>
+        </div>
+      )}
+
+      {/* 액션 버튼 */}
+      <div className="flex flex-col sm:flex-row gap-3">
+        <a href="/job-posting" className="btn-secondary text-center">
+          채용공고 변경
+        </a>
+        <button onClick={onRestart} className="btn-primary">
+          다시 연습하기
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/components/InterviewSession.tsx
+++ b/components/InterviewSession.tsx
@@ -11,12 +11,13 @@ import {
   MAX_FOLLOWUPS,
   getFirstQuestion,
 } from "@/lib/interview";
-import type { FeedbackResult } from "@/app/api/interview/feedback/route";
 import DifficultySelect from "@/components/DifficultySelect";
+import DebateLoading, { type DebateResultData } from "@/components/DebateLoading";
+import DebateResult from "@/components/DebateResult";
 
 const ANSWER_TIME_LIMIT = 80;
 
-type Phase = "selecting" | "interviewing";
+type Phase = "selecting" | "interviewing" | "debating" | "done";
 
 async function fetchQuestion(
   messages: Message[],
@@ -33,31 +34,24 @@ async function fetchQuestion(
   return data;
 }
 
-async function fetchFeedback(msgs: Message[]): Promise<FeedbackResult> {
-  const res = await fetch("/api/interview/feedback", {
+async function startDebate(
+  messages: Message[],
+  difficulty: Difficulty,
+): Promise<string> {
+  const res = await fetch("/api/interview/debate", {
     method: "POST",
     headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({ messages: msgs }),
+    body: JSON.stringify({ messages, difficulty }),
   });
   const data = await res.json();
-  if (!res.ok) throw new Error(data.error ?? "피드백 생성에 실패했습니다");
-  return data.feedback;
+  if (!res.ok) throw new Error(data.error ?? "토론을 시작할 수 없습니다");
+  return data.sessionId as string;
 }
 
 function formatTime(seconds: number) {
   const m = Math.floor(seconds / 60);
   const s = seconds % 60;
   return `${m}:${s.toString().padStart(2, "0")}`;
-}
-
-function ScoreRing({ score }: { score: number }) {
-  const color = score >= 80 ? "text-green-500" : score >= 60 ? "text-blue-500" : "text-orange-500";
-  return (
-    <div className={`text-5xl font-bold ${color}`}>
-      {score}
-      <span className="text-2xl text-gray-400 dark:text-slate-500 font-normal">/100</span>
-    </div>
-  );
 }
 
 function AgentBadge({ agentId }: { agentId: AgentId }) {
@@ -82,15 +76,15 @@ export default function InterviewSession({ name }: { name: string }) {
   const [messages, setMessages] = useState<Message[]>([]);
   const [answer, setAnswer] = useState("");
   const [isLoading, setIsLoading] = useState(false);
-  const [isDone, setIsDone] = useState(false);
-  const [isFetchingFeedback, setIsFetchingFeedback] = useState(false);
-  const [feedback, setFeedback] = useState<FeedbackResult | null>(null);
-  const [feedbackError, setFeedbackError] = useState("");
   const [error, setError] = useState("");
   const [timeLeft, setTimeLeft] = useState(ANSWER_TIME_LIMIT);
+
+  const [sessionId, setSessionId] = useState<string | null>(null);
+  const [debateResult, setDebateResult] = useState<DebateResultData | null>(null);
+  const [debateError, setDebateError] = useState("");
+
   const bottomRef = useRef<HTMLDivElement>(null);
 
-  // 면접 시작: 조직 전문가 첫 질문 고정 설정
   function handleDifficultySelect(d: Difficulty) {
     setDifficulty(d);
     setMessages([{ role: "interviewer", content: getFirstQuestion(name), agentId: "organization" }]);
@@ -101,18 +95,17 @@ export default function InterviewSession({ name }: { name: string }) {
 
   useEffect(() => {
     bottomRef.current?.scrollIntoView({ behavior: "smooth" });
-  }, [messages, isLoading, isDone]);
+  }, [messages, isLoading, phase]);
 
   useEffect(() => {
     setTimeLeft(ANSWER_TIME_LIMIT);
   }, [messages.length]);
 
   useEffect(() => {
-    if (isDone || isLoading || phase !== "interviewing") return;
-    if (timeLeft <= 0) return;
+    if (phase !== "interviewing" || isLoading || timeLeft <= 0) return;
     const timer = setTimeout(() => setTimeLeft((t) => t - 1), 1000);
     return () => clearTimeout(timer);
-  }, [timeLeft, isDone, isLoading, phase]);
+  }, [timeLeft, isLoading, phase]);
 
   async function handleSubmit() {
     const trimmed = answer.trim();
@@ -133,11 +126,8 @@ export default function InterviewSession({ name }: { name: string }) {
       const canFollowUp = followUpCount < maxFollowUps;
 
       if (canFollowUp) {
-        // 꼬리질문 시도
         const result = await fetchQuestion(updatedMessages, currentAgentId, true);
-
         if (result.followUp === false) {
-          // 에이전트 만족 → 다음 에이전트로
           await advanceToNextAgent(updatedMessages);
         } else if (result.question) {
           setMessages([
@@ -147,7 +137,6 @@ export default function InterviewSession({ name }: { name: string }) {
           setFollowUpCount((c) => c + 1);
         }
       } else {
-        // 꼬리질문 한도 초과 → 다음 에이전트로
         await advanceToNextAgent(updatedMessages);
       }
     } catch (e: unknown) {
@@ -161,22 +150,17 @@ export default function InterviewSession({ name }: { name: string }) {
     const nextAgentIndex = agentIndex + 1;
 
     if (nextAgentIndex >= TOTAL_AGENTS) {
-      // 모든 에이전트 완료 → 피드백
-      setIsDone(true);
-      setIsFetchingFeedback(true);
-      setFeedbackError("");
+      // 면접 종료 → 토론 시작
+      setPhase("debating");
       try {
-        const result = await fetchFeedback(currentMessages);
-        setFeedback(result);
+        const sid = await startDebate(currentMessages, difficulty);
+        setSessionId(sid);
       } catch (e: unknown) {
-        setFeedbackError(e instanceof Error ? e.message : "피드백 생성에 실패했습니다");
-      } finally {
-        setIsFetchingFeedback(false);
+        setDebateError(e instanceof Error ? e.message : "토론을 시작할 수 없습니다");
       }
       return;
     }
 
-    // 다음 에이전트 기본 질문 요청
     const nextAgentId = AGENT_ORDER[nextAgentIndex];
     const result = await fetchQuestion(currentMessages, nextAgentId, false);
     if (result.question) {
@@ -194,110 +178,78 @@ export default function InterviewSession({ name }: { name: string }) {
     setMessages([]);
     setAgentIndex(0);
     setFollowUpCount(0);
-    setIsDone(false);
     setAnswer("");
     setTimeLeft(ANSWER_TIME_LIMIT);
-    setFeedback(null);
-    setFeedbackError("");
     setError("");
+    setSessionId(null);
+    setDebateResult(null);
+    setDebateError("");
   }
 
-  // 난이도 선택 화면
+  // 난이도 선택
   if (phase === "selecting") {
     return <DifficultySelect onSelect={handleDifficultySelect} />;
   }
 
-  // 피드백 로딩 화면
-  if (isDone && isFetchingFeedback) {
-    return (
-      <div className="card flex flex-col items-center justify-center py-20 px-6 space-y-4 text-center">
-        <div className="flex gap-1.5">
-          <span className="w-2 h-2 bg-blue-500 rounded-full animate-bounce [animation-delay:0ms]" />
-          <span className="w-2 h-2 bg-blue-500 rounded-full animate-bounce [animation-delay:150ms]" />
-          <span className="w-2 h-2 bg-blue-500 rounded-full animate-bounce [animation-delay:300ms]" />
+  // 토론 중
+  if (phase === "debating") {
+    if (debateError) {
+      return (
+        <div className="card flex flex-col items-center justify-center py-16 px-6 space-y-4 text-center">
+          <p className="text-red-500 text-sm">{debateError}</p>
+          <button onClick={handleRestart} className="btn-primary">
+            다시 연습하기
+          </button>
         </div>
-        <p className="text-gray-600 dark:text-slate-400 font-medium">면접 피드백을 생성하고 있습니다</p>
-        <p className="text-gray-400 dark:text-slate-500 text-sm">잠시만 기다려주세요...</p>
-      </div>
-    );
-  }
+      );
+    }
 
-  // 피드백 결과 화면
-  if (isDone && feedback) {
-    return (
-      <div className="space-y-6">
-        <div className="card p-6 text-center space-y-3">
-          <h2 className="text-xl font-bold text-gray-900 dark:text-slate-50">면접 완료!</h2>
-          <p className="text-gray-500 dark:text-slate-400 text-sm">
-            {name}님의 면접 피드백입니다
-          </p>
-          <ScoreRing score={feedback.score} />
-        </div>
-
-        <div className="card p-6 space-y-4">
-          <h3 className="font-bold text-gray-900 dark:text-slate-50">종합 평가</h3>
-          <div className="space-y-3">
-            <div className="bg-green-50 dark:bg-green-900/20 rounded-xl p-4">
-              <p className="text-xs font-semibold text-green-600 dark:text-green-400 mb-1">강점</p>
-              <p className="text-sm text-gray-700 dark:text-slate-300 leading-relaxed">{feedback.overall.strengths}</p>
-            </div>
-            <div className="bg-orange-50 dark:bg-orange-900/20 rounded-xl p-4">
-              <p className="text-xs font-semibold text-orange-600 dark:text-orange-400 mb-1">약점</p>
-              <p className="text-sm text-gray-700 dark:text-slate-300 leading-relaxed">{feedback.overall.weaknesses}</p>
-            </div>
-            <div className="bg-blue-50 dark:bg-blue-900/20 rounded-xl p-4">
-              <p className="text-xs font-semibold text-blue-600 dark:text-blue-400 mb-1">핵심 조언</p>
-              <p className="text-sm text-gray-700 dark:text-slate-300 leading-relaxed">{feedback.overall.advice}</p>
-            </div>
+    if (!sessionId) {
+      return (
+        <div className="card flex flex-col items-center justify-center py-20 px-6 space-y-4 text-center">
+          <div className="flex gap-1.5">
+            <span className="w-2 h-2 bg-blue-500 rounded-full animate-bounce [animation-delay:0ms]" />
+            <span className="w-2 h-2 bg-blue-500 rounded-full animate-bounce [animation-delay:150ms]" />
+            <span className="w-2 h-2 bg-blue-500 rounded-full animate-bounce [animation-delay:300ms]" />
           </div>
+          <p className="text-gray-600 dark:text-slate-400 font-medium">토론을 시작하는 중...</p>
         </div>
+      );
+    }
 
-        <div className="space-y-3">
-          <h3 className="font-bold text-gray-900 dark:text-slate-50 px-1">질문별 피드백</h3>
-          {feedback.perQuestion.map((q, i) => (
-            <div key={i} className="card p-5 space-y-3">
-              <p className="text-xs font-semibold text-blue-600 dark:text-blue-400">Q{i + 1}</p>
-              <p className="text-sm text-gray-700 dark:text-slate-300 leading-relaxed">{q.question}</p>
-              <div className="space-y-2 pt-1">
-                <div className="flex gap-2">
-                  <span className="text-green-500 text-xs font-semibold mt-0.5 shrink-0">잘한 점</span>
-                  <p className="text-xs text-gray-600 dark:text-slate-400 leading-relaxed">{q.good}</p>
-                </div>
-                <div className="flex gap-2">
-                  <span className="text-orange-500 text-xs font-semibold mt-0.5 shrink-0">개선점</span>
-                  <p className="text-xs text-gray-600 dark:text-slate-400 leading-relaxed">{q.improve}</p>
-                </div>
-              </div>
-            </div>
-          ))}
-        </div>
-
-        <div className="flex flex-col sm:flex-row gap-3">
-          <a href="/job-posting" className="btn-secondary text-center">채용공고 변경</a>
-          <button onClick={handleRestart} className="btn-primary">다시 연습하기</button>
-        </div>
-      </div>
-    );
-  }
-
-  // 피드백 에러 화면
-  if (isDone && feedbackError) {
     return (
-      <div className="card flex flex-col items-center justify-center py-16 px-6 space-y-4 text-center">
-        <h2 className="text-xl font-bold text-gray-900 dark:text-slate-50">면접 완료!</h2>
-        <p className="text-red-500 text-sm">{feedbackError}</p>
-        <div className="flex gap-3">
-          <a href="/job-posting" className="btn-secondary">채용공고 변경</a>
-          <button onClick={handleRestart} className="btn-primary">다시 연습하기</button>
-        </div>
-      </div>
+      <DebateLoading
+        sessionId={sessionId}
+        onDone={(result) => {
+          setDebateResult(result);
+          setPhase("done");
+        }}
+        onError={(msg) => {
+          setDebateError(msg);
+        }}
+      />
     );
   }
 
+  // 결과 화면
+  if (phase === "done" && debateResult) {
+    return (
+      <DebateResult
+        finalScore={debateResult.finalScore}
+        agentEvaluations={debateResult.agentEvaluations}
+        finalFeedback={debateResult.finalFeedback}
+        debateSummary={debateResult.debateSummary}
+        improvementTips={debateResult.improvementTips}
+        onRestart={handleRestart}
+      />
+    );
+  }
+
+  // 면접 진행
   const isAnswered = messages[messages.length - 1]?.role === "candidate";
-  const lastInterviewerIdx = messages.reduce((acc, m, i) => m.role === "interviewer" ? i : acc, -1);
+  const lastInterviewerIdx = messages.reduce((acc, m, i) => (m.role === "interviewer" ? i : acc), -1);
   const currentQuestion = isAnswered ? "" : (messages[lastInterviewerIdx]?.content ?? "");
-  const currentQuestionAgentId = isAnswered ? undefined : (messages[lastInterviewerIdx]?.agentId);
+  const currentQuestionAgentId = isAnswered ? undefined : messages[lastInterviewerIdx]?.agentId;
   const pastMessages = isAnswered ? messages : messages.slice(0, lastInterviewerIdx);
 
   const isTimeWarning = timeLeft <= 30 && timeLeft > 0;
@@ -305,7 +257,7 @@ export default function InterviewSession({ name }: { name: string }) {
 
   return (
     <div className="space-y-4">
-      {/* 진행 상황 — 에이전트 3단계 */}
+      {/* 진행 상황 */}
       <div className="flex items-center gap-2">
         {AGENT_ORDER.map((aid, i) => {
           const isDoneAgent = i < agentIndex;
@@ -324,14 +276,20 @@ export default function InterviewSession({ name }: { name: string }) {
             <div key={aid} className="flex-1 space-y-1">
               <div
                 className={`h-1.5 rounded-full transition-all duration-300 ${
-                  isDoneAgent ? colorMap[aid] : isCurrentAgent ? dimMap[aid] : "bg-gray-200 dark:bg-slate-700"
+                  isDoneAgent
+                    ? colorMap[aid]
+                    : isCurrentAgent
+                      ? dimMap[aid]
+                      : "bg-gray-200 dark:bg-slate-700"
                 }`}
               />
-              <p className={`text-xs text-center truncate ${
-                isCurrentAgent
-                  ? "font-semibold text-gray-700 dark:text-slate-300"
-                  : "text-gray-400 dark:text-slate-600"
-              }`}>
+              <p
+                className={`text-xs text-center truncate ${
+                  isCurrentAgent
+                    ? "font-semibold text-gray-700 dark:text-slate-300"
+                    : "text-gray-400 dark:text-slate-600"
+                }`}
+              >
                 {AGENTS[aid].label}
               </p>
             </div>
@@ -366,7 +324,9 @@ export default function InterviewSession({ name }: { name: string }) {
       {currentQuestion && (
         <div className="card border-blue-100 dark:border-blue-900/50 p-5 space-y-1">
           {currentQuestionAgentId && <AgentBadge agentId={currentQuestionAgentId} />}
-          <p className="text-gray-900 dark:text-slate-100 text-base leading-relaxed pt-1">{currentQuestion}</p>
+          <p className="text-gray-900 dark:text-slate-100 text-base leading-relaxed pt-1">
+            {currentQuestion}
+          </p>
         </div>
       )}
 
@@ -396,10 +356,12 @@ export default function InterviewSession({ name }: { name: string }) {
         </div>
       )}
 
-      {/* 시간 초과 경고 */}
+      {/* 시간 초과 */}
       {isTimeUp && (
         <div className="bg-red-50 dark:bg-red-900/30 border border-red-200 dark:border-red-800 rounded-xl px-4 py-3 text-center">
-          <p className="text-red-600 dark:text-red-400 text-sm font-semibold">⏰ 시간이 초과됐습니다. 빠르게 답변을 마무리해주세요!</p>
+          <p className="text-red-600 dark:text-red-400 text-sm font-semibold">
+            ⏰ 시간이 초과됐습니다. 빠르게 답변을 마무리해주세요!
+          </p>
         </div>
       )}
 
@@ -417,9 +379,15 @@ export default function InterviewSession({ name }: { name: string }) {
           className="w-full resize-none border-0 outline-none text-sm text-gray-800 dark:text-slate-200 placeholder-gray-400 dark:placeholder-slate-500 bg-transparent disabled:opacity-50"
         />
         <div className="flex justify-between items-center pt-1 border-t border-gray-100 dark:border-slate-700">
-          <span className={`text-xs font-medium tabular-nums ${
-            isTimeUp ? "text-red-500" : isTimeWarning ? "text-orange-500" : "text-gray-400 dark:text-slate-500"
-          }`}>
+          <span
+            className={`text-xs font-medium tabular-nums ${
+              isTimeUp
+                ? "text-red-500"
+                : isTimeWarning
+                  ? "text-orange-500"
+                  : "text-gray-400 dark:text-slate-500"
+            }`}
+          >
             {isTimeUp ? "시간 초과" : formatTime(timeLeft)}
           </span>
           <button

--- a/lib/agents.ts
+++ b/lib/agents.ts
@@ -1,0 +1,250 @@
+import { AgentId, AGENTS, Message } from "@/lib/interview";
+
+const OLLAMA_BASE_URL = process.env.OLLAMA_BASE_URL ?? "http://localhost:11434";
+const OLLAMA_MODEL = process.env.OLLAMA_MODEL ?? "qwen2.5:7b";
+
+export interface AgentEvaluation {
+  agentId: AgentId;
+  agentLabel: string;
+  criterion: string;
+  score: number;        // 0~100
+  opinion: string;      // 3~5 문장
+  highlights: string[]; // 2~3개 핵심 포인트
+}
+
+export interface AgentReply {
+  agentId: AgentId;
+  agentLabel: string;
+  revisedScore: number;
+  scoreChanged: boolean;
+  scoreReason: string;
+  replies: {
+    targetAgentId: string;
+    stance: "agree" | "disagree" | "partial";
+    comment: string;
+  }[];
+}
+
+export interface ModeratorResult {
+  score: number;
+  overall: { strengths: string; weaknesses: string; advice: string };
+  improvementTips: string[];
+  debateSummary: string;
+}
+
+async function callOllama(systemPrompt: string, userContent: string): Promise<string> {
+  const response = await fetch(`${OLLAMA_BASE_URL}/api/chat`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json", "ngrok-skip-browser-warning": "true" },
+    body: JSON.stringify({
+      model: OLLAMA_MODEL,
+      stream: false,
+      messages: [
+        { role: "system", content: systemPrompt },
+        { role: "user", content: userContent },
+      ],
+    }),
+    signal: AbortSignal.timeout(180_000),
+  });
+
+  if (!response.ok) {
+    throw new Error(`Ollama 요청 실패: ${response.status} ${response.statusText}`);
+  }
+
+  const data = await response.json();
+  return (data.message?.content ?? "").trim();
+}
+
+function extractJSON<T>(raw: string): T {
+  const match = raw.match(/\{[\s\S]*\}/);
+  if (!match) throw new Error(`JSON not found in response: ${raw.slice(0, 200)}`);
+  return JSON.parse(match[0]) as T;
+}
+
+function buildConversationText(messages: Message[]): string {
+  return messages
+    .map((m) => {
+      const label =
+        m.role === "interviewer"
+          ? `면접관(${m.agentId ? AGENTS[m.agentId].label : "면접관"})`
+          : "지원자";
+      return `${label}: ${m.content}`;
+    })
+    .join("\n\n");
+}
+
+// Round 0: 에이전트별 독립 평가
+export async function generateAgentEvaluation(
+  agentId: AgentId,
+  messages: Message[],
+): Promise<AgentEvaluation> {
+  const agent = AGENTS[agentId];
+  const conversationText = buildConversationText(messages);
+
+  const systemPrompt = `You are ${agent.label}, an expert interviewer evaluating a job interview. Your evaluation criteria: ${agent.criterion}. Always respond with valid JSON only — no extra text.`;
+
+  const userContent = `[Interview Transcript]
+${conversationText}
+
+Evaluate this interview strictly from your perspective as ${agent.label}. Focus only on your criteria: ${agent.criterion}.
+
+Respond with this exact JSON structure:
+{
+  "score": <integer 0-100 based solely on your criteria>,
+  "opinion": "<evaluation in Korean, 3-5 sentences, cite specific answers from the transcript>",
+  "highlights": ["<key observation 1 in Korean>", "<key observation 2 in Korean>", "<key observation 3 in Korean>"]
+}`;
+
+  const raw = await callOllama(systemPrompt, userContent);
+  const parsed = extractJSON<{ score: number; opinion: string; highlights: string[] }>(raw);
+
+  return {
+    agentId,
+    agentLabel: agent.label,
+    criterion: agent.criterion,
+    score: Math.max(0, Math.min(100, Math.round(parsed.score))),
+    opinion: parsed.opinion,
+    highlights: (parsed.highlights ?? []).slice(0, 3),
+  };
+}
+
+// Round 1: 상호 반론 + 점수 재검토
+export async function generateAgentReply(
+  agentId: AgentId,
+  myEvaluation: AgentEvaluation,
+  otherEvaluations: AgentEvaluation[],
+  messages: Message[],
+): Promise<AgentReply> {
+  const agent = AGENTS[agentId];
+  const conversationText = buildConversationText(messages);
+
+  const othersText = otherEvaluations
+    .map(
+      (e) =>
+        `[${e.agentLabel}] Score: ${e.score}/100\n${e.opinion}\nHighlights: ${e.highlights.join(" | ")}`,
+    )
+    .join("\n\n");
+
+  const replySchema = otherEvaluations
+    .map((e, i) =>
+      i === 0
+        ? `    {\n      "targetAgentId": "${e.agentId}",\n      "stance": "<agree|disagree|partial>",\n      "comment": "<2-3 sentences in Korean referencing a specific part of the transcript>"\n    }`
+        : `    {\n      "targetAgentId": "${e.agentId}",\n      "stance": "<agree|disagree|partial>",\n      "comment": "<2-3 sentences in Korean referencing a specific part of the transcript>"\n    }`,
+    )
+    .join(",\n");
+
+  const systemPrompt = `You are ${agent.label}, an expert interviewer. Your evaluation criteria: ${agent.criterion}. Always respond with valid JSON only — no extra text.`;
+
+  const userContent = `[Interview Transcript]
+${conversationText}
+
+[Your Round 0 Evaluation]
+Score: ${myEvaluation.score}/100
+${myEvaluation.opinion}
+
+[Other Evaluators' Opinions]
+${othersText}
+
+Now respond to the other evaluators. Rules:
+- You MUST engage with at least one specific moment from the interview transcript
+- Disagree or partially agree with at least one evaluator — don't just agree with everything
+- Revise your score ONLY if an evaluator pointed out something you genuinely missed from the transcript
+- Score changes must be meaningful (at least ±5 points) if they occur
+
+Respond with this exact JSON:
+{
+  "revisedScore": <integer 0-100>,
+  "scoreChanged": <true|false>,
+  "scoreReason": "<why you kept or changed your score, in Korean, 1-2 sentences>",
+  "replies": [
+${replySchema}
+  ]
+}`;
+
+  const raw = await callOllama(systemPrompt, userContent);
+  const parsed = extractJSON<{
+    revisedScore: number;
+    scoreChanged: boolean;
+    scoreReason: string;
+    replies: { targetAgentId: string; stance: string; comment: string }[];
+  }>(raw);
+
+  return {
+    agentId,
+    agentLabel: agent.label,
+    revisedScore: Math.max(0, Math.min(100, Math.round(parsed.revisedScore))),
+    scoreChanged: Boolean(parsed.scoreChanged),
+    scoreReason: parsed.scoreReason ?? "",
+    replies: (parsed.replies ?? []).map((r) => ({
+      targetAgentId: r.targetAgentId,
+      stance: (["agree", "disagree", "partial"].includes(r.stance)
+        ? r.stance
+        : "partial") as "agree" | "disagree" | "partial",
+      comment: r.comment,
+    })),
+  };
+}
+
+// 중재자: 최종 종합
+export async function generateModeratorResult(
+  evaluations: AgentEvaluation[],
+  replies: AgentReply[],
+  messages: Message[],
+): Promise<ModeratorResult> {
+  const conversationText = buildConversationText(messages);
+
+  const avgScore = Math.round(
+    replies.reduce((sum, r) => sum + r.revisedScore, 0) / replies.length,
+  );
+
+  const evaluationsText = evaluations
+    .map((e) => `[${e.agentLabel}] Initial Score: ${e.score}/100\n${e.opinion}`)
+    .join("\n\n");
+
+  const repliesText = replies
+    .map((r) => {
+      const replyLines = r.replies
+        .map((reply) => `  → To ${reply.targetAgentId} [${reply.stance}]: ${reply.comment}`)
+        .join("\n");
+      return `[${r.agentLabel}] Revised Score: ${r.revisedScore}/100 (${r.scoreChanged ? "changed" : "unchanged"})\nReason: ${r.scoreReason}\n${replyLines}`;
+    })
+    .join("\n\n");
+
+  const systemPrompt = `You are a neutral moderator synthesizing an interview panel debate into a final assessment. Always respond with valid JSON only — no extra text.`;
+
+  const userContent = `[Interview Transcript]
+${conversationText}
+
+[Round 0 — Independent Evaluations]
+${evaluationsText}
+
+[Round 1 — Debate & Score Revisions]
+${repliesText}
+
+[Final Score: ${avgScore}/100 (average of revised scores)]
+
+Synthesize the panel discussion. Respond with this exact JSON:
+{
+  "overall": {
+    "strengths": "<2-3 sentences in Korean about what the candidate did well, citing specific answers>",
+    "weaknesses": "<2-3 sentences in Korean about clear gaps>",
+    "advice": "<2-3 sentences in Korean of actionable improvement advice>"
+  },
+  "improvementTips": ["<specific tip 1 in Korean>", "<specific tip 2 in Korean>", "<specific tip 3 in Korean>"],
+  "debateSummary": "<2-3 sentences in Korean summarizing key disagreements between evaluators and score changes>"
+}`;
+
+  const raw = await callOllama(systemPrompt, userContent);
+  const parsed = extractJSON<{
+    overall: { strengths: string; weaknesses: string; advice: string };
+    improvementTips: string[];
+    debateSummary: string;
+  }>(raw);
+
+  return {
+    score: avgScore,
+    overall: parsed.overall,
+    improvementTips: (parsed.improvementTips ?? []).slice(0, 3),
+    debateSummary: parsed.debateSummary ?? "",
+  };
+}

--- a/types/supabase.ts
+++ b/types/supabase.ts
@@ -157,6 +157,60 @@ export type Database = {
           },
         ]
       }
+      interview_sessions: {
+        Row: {
+          agentEvaluations: Json | null
+          createdAt: string | null
+          debateReplies: Json | null
+          debateSummary: string | null
+          difficulty: string
+          errorMessage: string | null
+          finalFeedback: Json | null
+          finalScore: number | null
+          id: string
+          improvementTips: Json | null
+          jobPostingId: string | null
+          messages: Json
+          status: string
+          updatedAt: string | null
+          userId: string
+        }
+        Insert: {
+          agentEvaluations?: Json | null
+          createdAt?: string | null
+          debateReplies?: Json | null
+          debateSummary?: string | null
+          difficulty: string
+          errorMessage?: string | null
+          finalFeedback?: Json | null
+          finalScore?: number | null
+          id: string
+          improvementTips?: Json | null
+          jobPostingId?: string | null
+          messages: Json
+          status?: string
+          updatedAt?: string | null
+          userId: string
+        }
+        Update: {
+          agentEvaluations?: Json | null
+          createdAt?: string | null
+          debateReplies?: Json | null
+          debateSummary?: string | null
+          difficulty?: string
+          errorMessage?: string | null
+          finalFeedback?: Json | null
+          finalScore?: number | null
+          id?: string
+          improvementTips?: Json | null
+          jobPostingId?: string | null
+          messages?: Json
+          status?: string
+          updatedAt?: string | null
+          userId?: string
+        }
+        Relationships: []
+      }
       job_postings: {
         Row: {
           createdAt: string


### PR DESCRIPTION
## Summary

- Round 0: 3 에이전트(조직/논리/기술 전문가)가 병렬로 독립 평가 + 점수 산출
- Round 1: 각 에이전트가 다른 2명의 의견을 읽고 반론 + 점수 재검토
- 중재자: Round 1 점수 평균 → 최종 점수 + 종합 피드백 + 개선 코멘트
- Supabase `interview_sessions` 테이블로 세션 저장 + 1.5초 폴링으로 진행 상황 실시간 표시
- 결과 화면: 최종 점수 / 에이전트별 평가 카드(Round 0 의견) / 토론 요약 / 개선 포인트

## Test plan

- [ ] 난이도 선택 → 면접 진행 → 모든 에이전트 완료
- [ ] DebateLoading 3단계(평가→토론→정리) 순서대로 표시 확인
- [ ] DebateResult 화면: 점수, 에이전트 카드 3개, 종합 피드백, 개선 코멘트 표시 확인
- [ ] Supabase `interview_sessions` 테이블에 레코드 저장 확인
- [ ] "다시 연습하기" 버튼으로 난이도 선택 화면 복귀 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)