### PR TITLE
feat: 토론 결과 단계별 즉시 표시 + EXAONE 프롬프트 개선

### DIFF
--- a/components/DebateLoading.tsx
+++ b/components/DebateLoading.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useRef, useState } from "react";
 import type { AgentEvaluation, ModeratorResult } from "@/lib/agents";
+import type { AgentId } from "@/lib/interview";
 
 export interface DebateResultData {
   agentEvaluations: AgentEvaluation[];
@@ -28,8 +29,24 @@ function stageIndex(status: string): number {
   return idx === -1 ? STAGES.length : idx;
 }
 
+const AGENT_COLORS: Record<AgentId, { border: string; badge: string }> = {
+  organization: {
+    border: "border-purple-100 dark:border-purple-900/40",
+    badge: "bg-purple-100 dark:bg-purple-900/40 text-purple-700 dark:text-purple-300",
+  },
+  logic: {
+    border: "border-blue-100 dark:border-blue-900/40",
+    badge: "bg-blue-100 dark:bg-blue-900/40 text-blue-700 dark:text-blue-300",
+  },
+  technical: {
+    border: "border-green-100 dark:border-green-900/40",
+    badge: "bg-green-100 dark:bg-green-900/40 text-green-700 dark:text-green-300",
+  },
+};
+
 export default function DebateLoading({ sessionId, onDone, onError }: Props) {
   const [currentStatus, setCurrentStatus] = useState("evaluating");
+  const [agentEvaluations, setAgentEvaluations] = useState<AgentEvaluation[]>([]);
   const intervalRef = useRef<ReturnType<typeof setInterval>>();
 
   useEffect(() => {
@@ -40,6 +57,10 @@ export default function DebateLoading({ sessionId, onDone, onError }: Props) {
         const data = await res.json();
 
         setCurrentStatus(data.status);
+
+        if (data.agentEvaluations?.length > 0) {
+          setAgentEvaluations(data.agentEvaluations);
+        }
 
         if (data.status === "done") {
           clearInterval(intervalRef.current);
@@ -67,52 +88,92 @@ export default function DebateLoading({ sessionId, onDone, onError }: Props) {
   const current = stageIndex(currentStatus);
 
   return (
-    <div className="card p-10 flex flex-col items-center justify-center space-y-8 text-center min-h-64">
-      <div>
-        <h2 className="text-lg font-bold text-gray-900 dark:text-slate-50 mb-1">
-          면접관들이 평가하고 있습니다
-        </h2>
-        <p className="text-sm text-gray-500 dark:text-slate-400">
-          3명의 전문 면접관이 토론을 진행 중입니다
+    <div className="space-y-6">
+      {/* 진행 상태 */}
+      <div className="card p-8 flex flex-col items-center justify-center space-y-6 text-center">
+        <div>
+          <h2 className="text-lg font-bold text-gray-900 dark:text-slate-50 mb-1">
+            면접관들이 평가하고 있습니다
+          </h2>
+          <p className="text-sm text-gray-500 dark:text-slate-400">
+            3명의 전문 면접관이 토론을 진행 중입니다
+          </p>
+        </div>
+
+        <div className="space-y-4 w-full max-w-xs">
+          {STAGES.map((stage, i) => {
+            const done = i < current;
+            const active = i === current;
+            return (
+              <div key={stage.status} className="flex items-center gap-3">
+                {done ? (
+                  <span className="w-5 h-5 rounded-full bg-green-500 flex items-center justify-center text-white text-xs shrink-0">
+                    ✓
+                  </span>
+                ) : active ? (
+                  <span className="w-5 h-5 rounded-full border-2 border-blue-500 flex items-center justify-center shrink-0">
+                    <span className="w-2 h-2 rounded-full bg-blue-500 animate-pulse" />
+                  </span>
+                ) : (
+                  <span className="w-5 h-5 rounded-full border-2 border-gray-200 dark:border-slate-600 shrink-0" />
+                )}
+                <span
+                  className={`text-sm ${
+                    done
+                      ? "text-gray-400 dark:text-slate-500 line-through"
+                      : active
+                        ? "text-gray-700 dark:text-slate-200 font-medium"
+                        : "text-gray-400 dark:text-slate-600"
+                  }`}
+                >
+                  {stage.label}
+                </span>
+              </div>
+            );
+          })}
+        </div>
+
+        <p className="text-xs text-gray-400 dark:text-slate-500">
+          Ollama 모델에 따라 1~3분 소요될 수 있습니다
         </p>
       </div>
 
-      <div className="space-y-4 w-full max-w-xs">
-        {STAGES.map((stage, i) => {
-          const done = i < current;
-          const active = i === current;
-          return (
-            <div key={stage.status} className="flex items-center gap-3">
-              {done ? (
-                <span className="w-5 h-5 rounded-full bg-green-500 flex items-center justify-center text-white text-xs shrink-0">
-                  ✓
-                </span>
-              ) : active ? (
-                <span className="w-5 h-5 rounded-full border-2 border-blue-500 flex items-center justify-center shrink-0">
-                  <span className="w-2 h-2 rounded-full bg-blue-500 animate-pulse" />
-                </span>
-              ) : (
-                <span className="w-5 h-5 rounded-full border-2 border-gray-200 dark:border-slate-600 shrink-0" />
-              )}
-              <span
-                className={`text-sm ${
-                  done
-                    ? "text-gray-400 dark:text-slate-500 line-through"
-                    : active
-                      ? "text-gray-700 dark:text-slate-200 font-medium"
-                      : "text-gray-400 dark:text-slate-600"
-                }`}
-              >
-                {stage.label}
-              </span>
-            </div>
-          );
-        })}
-      </div>
-
-      <p className="text-xs text-gray-400 dark:text-slate-500">
-        Ollama 모델에 따라 1~3분 소요될 수 있습니다
-      </p>
+      {/* Round 0 완료 즉시 표시 */}
+      {agentEvaluations.length > 0 && (
+        <div className="space-y-3 animate-fade-in-up">
+          <h3 className="font-bold text-gray-900 dark:text-slate-50 px-1">면접관별 평가</h3>
+          {agentEvaluations.map((e) => {
+            const colors = AGENT_COLORS[e.agentId] ?? AGENT_COLORS.organization;
+            return (
+              <div key={e.agentId} className={`card p-5 space-y-3 border-l-4 ${colors.border}`}>
+                <div className="flex items-center justify-between">
+                  <div className="space-y-0.5">
+                    <span className={`text-xs font-semibold px-2 py-0.5 rounded-full ${colors.badge}`}>
+                      {e.agentLabel}
+                    </span>
+                    <p className="text-xs text-gray-400 dark:text-slate-500 pt-1">{e.criterion}</p>
+                  </div>
+                  <span className="text-2xl font-bold text-gray-700 dark:text-slate-300">
+                    {e.score}
+                    <span className="text-sm font-normal text-gray-400 dark:text-slate-500">/100</span>
+                  </span>
+                </div>
+                <p className="text-sm text-gray-700 dark:text-slate-300 leading-relaxed">{e.opinion}</p>
+                {e.highlights.length > 0 && (
+                  <ul className="space-y-1">
+                    {e.highlights.map((h, i) => (
+                      <li key={i} className="text-xs text-gray-500 dark:text-slate-400 flex gap-1.5">
+                        <span className="text-gray-300 dark:text-slate-600 shrink-0">•</span>
+                        {h}
+                      </li>
+                    ))}
+                  </ul>
+                )}
+              </div>
+            );
+          })}
+        </div>
+      )}
     </div>
   );
 }

--- a/lib/agents.ts
+++ b/lib/agents.ts
@@ -39,6 +39,7 @@ async function callOllama(systemPrompt: string, userContent: string): Promise<st
     body: JSON.stringify({
       model: OLLAMA_MODEL,
       stream: false,
+      format: "json",
       messages: [
         { role: "system", content: systemPrompt },
         { role: "user", content: userContent },
@@ -93,7 +94,8 @@ Respond with this exact JSON structure:
   "score": <integer 0-100 based solely on your criteria>,
   "opinion": "<evaluation in Korean, 3-5 sentences, cite specific answers from the transcript>",
   "highlights": ["<key observation 1 in Korean>", "<key observation 2 in Korean>", "<key observation 3 in Korean>"]
-}`;
+}
+Do not use markdown formatting (no **, *, #) inside any string values.`;
 
   const raw = await callOllama(systemPrompt, userContent);
   const parsed = extractJSON<{ score: number; opinion: string; highlights: string[] }>(raw);
@@ -159,7 +161,8 @@ Respond with this exact JSON:
   "replies": [
 ${replySchema}
   ]
-}`;
+}
+Do not use markdown formatting (no **, *, #) inside any string values.`;
 
   const raw = await callOllama(systemPrompt, userContent);
   const parsed = extractJSON<{
@@ -232,7 +235,8 @@ Synthesize the panel discussion. Respond with this exact JSON:
   },
   "improvementTips": ["<specific tip 1 in Korean>", "<specific tip 2 in Korean>", "<specific tip 3 in Korean>"],
   "debateSummary": "<2-3 sentences in Korean summarizing key disagreements between evaluators and score changes>"
-}`;
+}
+Do not use markdown formatting (no **, *, #) inside any string values.`;
 
   const raw = await callOllama(systemPrompt, userContent);
   const parsed = extractJSON<{

--- a/lib/interview.ts
+++ b/lib/interview.ts
@@ -155,7 +155,7 @@ function buildAgentSystemPrompt(
   const agentRole: Record<AgentId, string> = {
     organization: `You are an organizational culture and HR specialist interviewer. Your evaluation focuses on: growth potential, self-awareness, authenticity, and organizational culture fit. Ask questions that reveal the candidate's values, motivations, and alignment with the company culture.`,
     logic: `You are a logical thinking and communication specialist interviewer. Your evaluation focuses on: answer structure, logical flow, and STAR method (Situation, Task, Action, Result). Ask questions based on past experiences and assess how clearly and logically the candidate communicates.`,
-    technical: `You are a technical skills specialist interviewer. Your evaluation focuses on: job relevance and technical specificity (concrete numbers, project names, measurable results). Ask questions about technical skills and competencies required for the job.`,
+    technical: `You are a job competency specialist interviewer. Your evaluation focuses on: whether the candidate has the specific skills, knowledge, and hands-on experience explicitly listed in the job posting requirements. You must only ask about competencies directly stated in the job posting — do NOT assume the role requires IT, software, or data skills unless the job posting explicitly says so. Ask questions that probe depth of relevant experience with concrete examples and measurable results.`,
   };
 
   return `${agentRole[agentId]} Always respond in Korean only.
@@ -216,8 +216,8 @@ export async function generateAgentBaseQuestion(
 
   const baseQuestionGuide: Record<AgentId, string> = {
     organization: `Based on the job posting and candidate profile, ask a warm, welcoming question about the candidate's motivation for applying and their background. This is the opening question of the interview.`,
-    logic: `Based on the interview conversation so far, ask a question that requires the candidate to describe a specific past experience using the STAR method (Situation, Task, Action, Result). Focus on experiences relevant to the job.`,
-    technical: `Based on the job posting requirements and the interview so far, ask a question about specific technical skills or competencies relevant to this role. Request concrete examples with measurable outcomes.`,
+    logic: `Based on the interview conversation so far, ask a question that requires the candidate to describe a specific past experience using the STAR method. The question must be in Korean only — do not include English terms like "Situation", "Task", "Action", "Result", or "STAR" in the output. Focus on experiences relevant to the job.`,
+    technical: `Based strictly on the job posting requirements above, ask a question that probes whether the candidate has the hands-on skills and experience this specific role demands. Ground your question in the actual responsibilities and requirements listed — not generic technical skills. Request a concrete example with measurable outcomes.`,
   };
 
   const conversationText = messages

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -25,6 +25,15 @@ const config: Config = {
         card: "0 1px 3px 0 rgb(0 0 0 / 0.07), 0 1px 2px -1px rgb(0 0 0 / 0.07)",
         "card-md": "0 4px 6px -1px rgb(0 0 0 / 0.07), 0 2px 4px -2px rgb(0 0 0 / 0.07)",
       },
+      keyframes: {
+        "fade-in-up": {
+          "0%": { opacity: "0", transform: "translateY(10px)" },
+          "100%": { opacity: "1", transform: "translateY(0)" },
+        },
+      },
+      animation: {
+        "fade-in-up": "fade-in-up 0.4s ease-out",
+      },
     },
   },
   plugins: [],


### PR DESCRIPTION
## Summary

- Round 0 완료 즉시 에이전트 평가 카드 표시 (기존: 전체 완료 전까지 스피너만 보임)
- 기술 전문가가 직무와 무관한 IT 기술을 묻는 문제 수정 (바리스타에게 수요 예측 모델 질문 등)
- 논리 전문가 질문에 영어 STAR 약어가 섞이는 문제 수정
- 평가 결과 highlights에 마크다운 볼드(`**`)가 노출되는 문제 수정
- EXAONE JSON 안정성을 위해 `agents.ts` callOllama에 `format: "json"` 추가

## Test plan

- [ ] 이지 난이도로 면접 진행 후 토론 대기 화면에서 Round 0 완료 시 평가 카드가 즉시 노출되는지 확인
- [ ] 기술 전문가 질문이 채용공고 직무 요건에 맞는 내용인지 확인
- [ ] 논리 전문가 질문에 영어가 섞이지 않는지 확인
- [ ] highlights에 `**` 같은 마크다운 문자가 없는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)