### PR TITLE
feat: 꼬리질문 품질 개선 + 면접관 UI 개선

### DIFF
--- a/app/api/interview/question/route.ts
+++ b/app/api/interview/question/route.ts
@@ -5,6 +5,7 @@ import {
   generateAgentBaseQuestion,
   generateAgentFollowUpQuestion,
   AgentId,
+  Difficulty,
   Message,
 } from "@/lib/interview";
 
@@ -16,10 +17,11 @@ export async function POST(request: NextRequest) {
     }
 
     const body = await request.json();
-    const { messages, agentId, isFollowUpRequest } = body as {
+    const { messages, agentId, isFollowUpRequest, difficulty } = body as {
       messages: Message[];
       agentId: AgentId;
       isFollowUpRequest: boolean;
+      difficulty: Difficulty;
     };
 
     const { data: profile } = await supabase
@@ -82,6 +84,7 @@ export async function POST(request: NextRequest) {
         profileContext,
         jobPostingContext,
         messages,
+        difficulty ?? "normal",
       );
       if (followUp === null) {
         return NextResponse.json({ followUp: false });
@@ -94,6 +97,7 @@ export async function POST(request: NextRequest) {
       profileContext,
       jobPostingContext,
       messages,
+      difficulty ?? "normal",
     );
 
     return NextResponse.json({ question });

--- a/components/InterviewSession.tsx
+++ b/components/InterviewSession.tsx
@@ -23,11 +23,12 @@ async function fetchQuestion(
   messages: Message[],
   agentId: AgentId,
   isFollowUpRequest: boolean,
+  difficulty: Difficulty,
 ): Promise<{ question?: string; followUp?: boolean }> {
   const res = await fetch("/api/interview/question", {
     method: "POST",
     headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({ messages, agentId, isFollowUpRequest }),
+    body: JSON.stringify({ messages, agentId, isFollowUpRequest, difficulty }),
   });
   const data = await res.json();
   if (!res.ok) throw new Error(data.error ?? "질문 생성에 실패했습니다");
@@ -54,26 +55,34 @@ function formatTime(seconds: number) {
   return `${m}:${s.toString().padStart(2, "0")}`;
 }
 
-const AGENT_META: Record<AgentId, { color: string; bg: string; avatarUrl: string; role: string }> = {
+const AGENT_META: Record<AgentId, { color: string; bg: string; bgColor: string; name: string }> = {
   organization: {
     color: "text-purple-600 dark:text-purple-400",
     bg: "bg-purple-100 dark:bg-purple-900/40",
-    avatarUrl: "https://api.dicebear.com/9.x/notionists/svg?seed=organization&backgroundColor=e9d5ff",
-    role: "조직 · 문화 전문가",
+    bgColor: "e9d5ff",
+    name: "면접관 1",
   },
   logic: {
     color: "text-blue-600 dark:text-blue-400",
     bg: "bg-blue-100 dark:bg-blue-900/40",
-    avatarUrl: "https://api.dicebear.com/9.x/notionists/svg?seed=logic&backgroundColor=bfdbfe",
-    role: "논리 · 경험 전문가",
+    bgColor: "bfdbfe",
+    name: "면접관 2",
   },
   technical: {
     color: "text-green-600 dark:text-green-400",
     bg: "bg-green-100 dark:bg-green-900/40",
-    avatarUrl: "https://api.dicebear.com/9.x/notionists/svg?seed=technical&backgroundColor=bbf7d0",
-    role: "직무 역량 전문가",
+    bgColor: "bbf7d0",
+    name: "면접관 3",
   },
 };
+
+function randomSeed() {
+  return Math.random().toString(36).slice(2, 10);
+}
+
+function makeAvatarUrl(seed: string, bgColor: string) {
+  return `https://api.dicebear.com/9.x/notionists/svg?seed=${seed}&backgroundColor=${bgColor}`;
+}
 
 function useTypewriter(text: string, speed = 18) {
   const [displayed, setDisplayed] = useState("");
@@ -116,10 +125,12 @@ function InterviewerPanel({
   agentIndex,
   isLoading,
   isSpeaking,
+  avatarSeeds,
 }: {
   agentIndex: number;
   isLoading: boolean;
   isSpeaking: boolean;
+  avatarSeeds: Record<AgentId, string>;
 }) {
   return (
     <div className="grid grid-cols-3 gap-3">
@@ -128,6 +139,7 @@ function InterviewerPanel({
         const isActive = i === agentIndex;
         const isDone = i < agentIndex;
         const isPending = i > agentIndex;
+        const avatarUrl = makeAvatarUrl(avatarSeeds[aid], meta.bgColor);
 
         return (
           <div
@@ -150,8 +162,8 @@ function InterviewerPanel({
                 }`}
               >
                 <img
-                  src={meta.avatarUrl}
-                  alt={AGENTS[aid].label}
+                  src={avatarUrl}
+                  alt={meta.name}
                   className={`w-full h-full object-cover transition-all duration-300 ${isPending ? "grayscale" : ""}`}
                 />
               </div>
@@ -185,11 +197,8 @@ function InterviewerPanel({
             {/* 이름 */}
             <div className="text-center">
               <p className={`text-xs font-semibold ${isActive ? meta.color : "text-gray-400 dark:text-slate-500"}`}>
-                {AGENTS[aid].label}
+                {meta.name}
               </p>
-              {isActive && (
-                <p className="text-[10px] text-gray-400 dark:text-slate-500 mt-0.5">{meta.role}</p>
-              )}
             </div>
           </div>
         );
@@ -224,6 +233,11 @@ export default function InterviewSession({ name }: { name: string }) {
   const [difficulty, setDifficulty] = useState<Difficulty>("normal");
   const [agentIndex, setAgentIndex] = useState(0);
   const [followUpCount, setFollowUpCount] = useState(0);
+  const [avatarSeeds, setAvatarSeeds] = useState<Record<AgentId, string>>({
+    organization: "organization",
+    logic: "logic",
+    technical: "technical",
+  });
 
   const [messages, setMessages] = useState<Message[]>([]);
   const [answer, setAnswer] = useState("");
@@ -239,6 +253,7 @@ export default function InterviewSession({ name }: { name: string }) {
 
   function handleDifficultySelect(d: Difficulty) {
     setDifficulty(d);
+    setAvatarSeeds({ organization: randomSeed(), logic: randomSeed(), technical: randomSeed() });
     setMessages([{ role: "interviewer", content: getFirstQuestion(name), agentId: "organization" }]);
     setAgentIndex(0);
     setFollowUpCount(0);
@@ -278,7 +293,7 @@ export default function InterviewSession({ name }: { name: string }) {
       const canFollowUp = followUpCount < maxFollowUps;
 
       if (canFollowUp) {
-        const result = await fetchQuestion(updatedMessages, currentAgentId, true);
+        const result = await fetchQuestion(updatedMessages, currentAgentId, true, difficulty);
         if (result.followUp === false) {
           await advanceToNextAgent(updatedMessages);
         } else if (result.question) {
@@ -314,7 +329,7 @@ export default function InterviewSession({ name }: { name: string }) {
     }
 
     const nextAgentId = AGENT_ORDER[nextAgentIndex];
-    const result = await fetchQuestion(currentMessages, nextAgentId, false);
+    const result = await fetchQuestion(currentMessages, nextAgentId, false, difficulty);
     if (result.question) {
       setMessages([
         ...currentMessages,
@@ -429,7 +444,7 @@ export default function InterviewSession({ name }: { name: string }) {
   return (
     <div className="space-y-4">
       {/* 면접관 패널 */}
-      <InterviewerPanel agentIndex={agentIndex} isLoading={isLoading} isSpeaking={isSpeaking} />
+      <InterviewerPanel agentIndex={agentIndex} isLoading={isLoading} isSpeaking={isSpeaking} avatarSeeds={avatarSeeds} />
 
       {/* 현재 질문 말풍선 */}
       {currentQuestion && currentQuestionAgentId && (
@@ -450,7 +465,7 @@ export default function InterviewSession({ name }: { name: string }) {
                 <div key={idx} className="space-y-2">
                   <div className="flex items-start gap-2">
                     <div className="w-6 h-6 rounded-full overflow-hidden shrink-0 mt-0.5">
-                      <img src={pairMeta.avatarUrl} alt="" className="w-full h-full object-cover" />
+                      <img src={makeAvatarUrl(avatarSeeds[pair.agentId], pairMeta.bgColor)} alt="" className="w-full h-full object-cover" />
                     </div>
                     <div className="bg-white dark:bg-slate-800 border border-gray-100 dark:border-slate-700 rounded-2xl rounded-tl-sm px-3 py-2 text-sm text-gray-700 dark:text-slate-300 leading-relaxed shadow-card flex-1">
                       {pair.question}

--- a/lib/interview.ts
+++ b/lib/interview.ts
@@ -144,10 +144,17 @@ export function getFirstQuestion(name: string) {
   return `안녕하세요, ${name}님. 간단한 자기소개와 지원동기를 말씀해주세요.`;
 }
 
+const DIFFICULTY_QUESTION_HINT: Record<Difficulty, string> = {
+  easy: "Ask friendly, open-ended questions. Accept general answers; do not demand specific metrics or data.",
+  normal: "Ask standard interview questions. Expect reasonably specific answers with at least one concrete example.",
+  hard: "Ask rigorous, probing questions. Demand specific metrics, project names, timelines, and measurable results. Push for depth.",
+};
+
 function buildAgentSystemPrompt(
   agentId: AgentId,
   profile: ProfileContext,
   jobPosting: JobPostingContext,
+  difficulty: Difficulty,
 ): string {
   const profileSummary = buildProfileSummary(profile);
   const contextualHints = buildContextualHints(profile, jobPosting);
@@ -159,6 +166,9 @@ function buildAgentSystemPrompt(
   };
 
   return `${agentRole[agentId]} Always respond in Korean only.
+
+[Interview Difficulty: ${difficulty.toUpperCase()}]
+${DIFFICULTY_QUESTION_HINT[difficulty]}
 
 [Job Posting]
 Responsibilities: ${jobPosting.responsibilities || "N/A"}
@@ -176,18 +186,21 @@ ${contextualHints}
 2. Do not prefix with "면접관:", "질문:", "Q:", or anything similar.`;
 }
 
-async function callOllama(systemPrompt: string, userContent: string): Promise<string> {
+async function callOllama(systemPrompt: string, userContent: string, json = false): Promise<string> {
+  const body: Record<string, unknown> = {
+    model: OLLAMA_MODEL,
+    stream: false,
+    messages: [
+      { role: "system", content: systemPrompt },
+      { role: "user", content: userContent },
+    ],
+  };
+  if (json) body.format = "json";
+
   const response = await fetch(`${OLLAMA_BASE_URL}/api/chat`, {
     method: "POST",
     headers: { "Content-Type": "application/json", "ngrok-skip-browser-warning": "true" },
-    body: JSON.stringify({
-      model: OLLAMA_MODEL,
-      stream: false,
-      messages: [
-        { role: "system", content: systemPrompt },
-        { role: "user", content: userContent },
-      ],
-    }),
+    body: JSON.stringify(body),
     signal: AbortSignal.timeout(180_000),
   });
 
@@ -206,13 +219,14 @@ export async function generateAgentBaseQuestion(
   profile: ProfileContext,
   jobPosting: JobPostingContext,
   messages: Message[],
+  difficulty: Difficulty,
 ): Promise<string> {
   // 조직 전문가 첫 질문은 고정
   if (agentId === "organization" && messages.length === 0) {
     return getFirstQuestion(profile.name);
   }
 
-  const systemPrompt = buildAgentSystemPrompt(agentId, profile, jobPosting);
+  const systemPrompt = buildAgentSystemPrompt(agentId, profile, jobPosting, difficulty);
 
   const baseQuestionGuide: Record<AgentId, string> = {
     organization: `Based on the job posting and candidate profile, ask a warm, welcoming question about the candidate's motivation for applying and their background. This is the opening question of the interview.`,
@@ -231,14 +245,21 @@ export async function generateAgentBaseQuestion(
   return callOllama(systemPrompt, userContent);
 }
 
+const DIFFICULTY_FOLLOWUP_HINT: Record<Difficulty, string> = {
+  easy: "Only set shouldFollowUp to true if the answer is critically incomplete — missing the core point entirely.",
+  normal: "Set shouldFollowUp to true if the answer lacks a concrete example or key specifics needed to assess the candidate fairly.",
+  hard: "Set shouldFollowUp to true unless the answer includes specific metrics, project names, and demonstrates clear depth. Be demanding — a vague or generic answer always warrants a follow-up.",
+};
+
 // 에이전트의 꼬리질문 생성. null 반환 시 다음 에이전트로 넘어감
 export async function generateAgentFollowUpQuestion(
   agentId: AgentId,
   profile: ProfileContext,
   jobPosting: JobPostingContext,
   messages: Message[],
+  difficulty: Difficulty,
 ): Promise<string | null> {
-  const systemPrompt = buildAgentSystemPrompt(agentId, profile, jobPosting);
+  const systemPrompt = buildAgentSystemPrompt(agentId, profile, jobPosting, difficulty);
 
   const conversationText = messages
     .map((m) => `${m.role === "interviewer" ? "면접관" : "지원자"}: ${m.content}`)
@@ -254,15 +275,25 @@ export async function generateAgentFollowUpQuestion(
 
 The candidate just answered your last question. Evaluate whether their answer sufficiently addresses your evaluation criteria: ${agentCriteria[agentId]}.
 
-Rules:
-- If the answer lacks important specifics or needs clarification, output EXACTLY ONE follow-up question in Korean. The question must reference a specific part of the candidate's last answer.
-- If the answer is sufficiently detailed and complete from your perspective, output EXACTLY: DONE
-- Do not add any explanation. Output only the follow-up question OR the word DONE.`;
+Difficulty guidance: ${DIFFICULTY_FOLLOWUP_HINT[difficulty]}
 
-  const raw = await callOllama(systemPrompt, userContent);
+If you want to follow up, the question MUST reference a specific part of the candidate's last answer.
 
-  if (raw.trim().toUpperCase() === "DONE" || raw.trim() === "") {
+Respond with this exact JSON:
+{
+  "shouldFollowUp": <true if a follow-up is needed, false if the answer is sufficient>,
+  "question": "<follow-up question in Korean, or empty string if shouldFollowUp is false>"
+}`;
+
+  const raw = await callOllama(systemPrompt, userContent, true);
+
+  try {
+    const match = raw.match(/\{[\s\S]*\}/);
+    if (!match) return null;
+    const parsed = JSON.parse(match[0]) as { shouldFollowUp: boolean; question: string };
+    if (!parsed.shouldFollowUp || !parsed.question?.trim()) return null;
+    return parsed.question.trim();
+  } catch {
     return null;
   }
-  return raw;
 }


### PR DESCRIPTION
## Summary

- 꼬리질문 DONE 감지를 JSON 포맷(`{ shouldFollowUp, question }`)으로 변경해 EXAONE 모델 안정성 향상
- `difficulty`를 API 및 프롬프트에 전달 — easy/normal/hard별 질문 강도 및 꼬리질문 기준 차별화
- 면접 진행 중 면접관 이름을 "면접관 1/2/3"으로 표시 (역할명 노출 제거)
- 면접 시작마다 DiceBear notionists 아바타 랜덤 seed 생성

## Test plan

- [ ] 노말 모드: 모호한 답변 → 꼬리질문 1회 발생, 상세 답변 → 다음 에이전트로 이동
- [ ] 하드 모드: 꼬리질문 최대 3회까지 발생 확인
- [ ] 이지 모드: 꼬리질문 없이 바로 다음 에이전트로 이동
- [ ] 면접 재시작 시 아바타가 달라지는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)