### PR TITLE
feat: 면접 힌트 기능 추가

### DIFF
--- a/app/api/interview/question/route.ts
+++ b/app/api/interview/question/route.ts
@@ -89,10 +89,10 @@ export async function POST(request: NextRequest) {
       if (followUp === null) {
         return NextResponse.json({ followUp: false });
       }
-      return NextResponse.json({ question: followUp, followUp: true });
+      return NextResponse.json({ question: followUp.question, hint: followUp.hint, followUp: true });
     }
 
-    const question = await generateAgentBaseQuestion(
+    const result = await generateAgentBaseQuestion(
       agentId,
       profileContext,
       jobPostingContext,
@@ -100,7 +100,7 @@ export async function POST(request: NextRequest) {
       difficulty ?? "normal",
     );
 
-    return NextResponse.json({ question });
+    return NextResponse.json({ question: result.question, hint: result.hint });
   } catch (error) {
     console.error("Interview question error:", error);
     return NextResponse.json(

--- a/components/InterviewSession.tsx
+++ b/components/InterviewSession.tsx
@@ -24,7 +24,7 @@ async function fetchQuestion(
   agentId: AgentId,
   isFollowUpRequest: boolean,
   difficulty: Difficulty,
-): Promise<{ question?: string; followUp?: boolean }> {
+): Promise<{ question?: string; hint?: string; followUp?: boolean }> {
   const res = await fetch("/api/interview/question", {
     method: "POST",
     headers: { "Content-Type": "application/json" },
@@ -240,6 +240,8 @@ export default function InterviewSession({ name }: { name: string }) {
   });
 
   const [messages, setMessages] = useState<Message[]>([]);
+  const [currentHint, setCurrentHint] = useState("");
+  const [hintVisible, setHintVisible] = useState(false);
   const [answer, setAnswer] = useState("");
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState("");
@@ -255,6 +257,8 @@ export default function InterviewSession({ name }: { name: string }) {
     setDifficulty(d);
     setAvatarSeeds({ organization: randomSeed(), logic: randomSeed(), technical: randomSeed() });
     setMessages([{ role: "interviewer", content: getFirstQuestion(name), agentId: "organization" }]);
+    setCurrentHint("지원자의 기본 배경과 이 회사·직무에 지원한 이유를 파악하는 질문입니다. 단순한 경력 나열보다는 지원 동기의 진정성과 이 포지션과의 연관성을 구체적으로 전달하세요.");
+    setHintVisible(false);
     setAgentIndex(0);
     setFollowUpCount(0);
     setPhase("interviewing");
@@ -273,6 +277,13 @@ export default function InterviewSession({ name }: { name: string }) {
     const timer = setTimeout(() => setTimeLeft((t) => t - 1), 1000);
     return () => clearTimeout(timer);
   }, [timeLeft, isLoading, phase]);
+
+  // 30초 이하 남으면 힌트 자동 표시
+  useEffect(() => {
+    if (timeLeft === 30 && currentHint && !hintVisible) {
+      setHintVisible(true);
+    }
+  }, [timeLeft, currentHint, hintVisible]);
 
   async function handleSubmit() {
     const trimmed = answer.trim();
@@ -301,6 +312,8 @@ export default function InterviewSession({ name }: { name: string }) {
             ...updatedMessages,
             { role: "interviewer", content: result.question, agentId: currentAgentId },
           ]);
+          setCurrentHint(result.hint ?? "");
+          setHintVisible(false);
           setFollowUpCount((c) => c + 1);
         }
       } else {
@@ -335,6 +348,8 @@ export default function InterviewSession({ name }: { name: string }) {
         ...currentMessages,
         { role: "interviewer", content: result.question, agentId: nextAgentId },
       ]);
+      setCurrentHint(result.hint ?? "");
+      setHintVisible(false);
       setAgentIndex(nextAgentIndex);
       setFollowUpCount(0);
     }
@@ -348,6 +363,8 @@ export default function InterviewSession({ name }: { name: string }) {
     setAnswer("");
     setTimeLeft(ANSWER_TIME_LIMIT);
     setError("");
+    setCurrentHint("");
+    setHintVisible(false);
     setSessionId(null);
     setDebateResult(null);
     setDebateError("");
@@ -448,7 +465,29 @@ export default function InterviewSession({ name }: { name: string }) {
 
       {/* 현재 질문 말풍선 */}
       {currentQuestion && currentQuestionAgentId && (
-        <QuestionBubble agentId={currentQuestionAgentId} question={currentQuestion} />
+        <div className="space-y-2">
+          <QuestionBubble agentId={currentQuestionAgentId} question={currentQuestion} />
+          {/* 힌트 버튼 + 카드 */}
+          {currentHint && (
+            <div>
+              {!hintVisible && (
+                <button
+                  onClick={() => setHintVisible(true)}
+                  className="flex items-center gap-1.5 text-xs text-amber-500 dark:text-amber-400 hover:text-amber-600 dark:hover:text-amber-300 transition-colors px-1"
+                >
+                  <span>💡</span>
+                  <span>힌트 보기</span>
+                </button>
+              )}
+              {hintVisible && (
+                <div className="bg-amber-50 dark:bg-amber-900/20 border border-amber-200 dark:border-amber-800/50 rounded-xl px-4 py-3 flex items-start gap-2">
+                  <span className="text-amber-500 text-sm shrink-0 mt-0.5">💡</span>
+                  <p className="text-amber-800 dark:text-amber-300 text-xs leading-relaxed">{currentHint}</p>
+                </div>
+              )}
+            </div>
+          )}
+        </div>
       )}
 
       {/* 이전 대화 기록 */}

--- a/lib/interview.ts
+++ b/lib/interview.ts
@@ -179,11 +179,7 @@ Preferred Qualifications: ${jobPosting.preferredQuals || "N/A"}
 ${profileSummary}
 
 [Interview Guide]
-${contextualHints}
-
-[Output Rules]
-1. Output exactly one interview question in Korean. No extra text.
-2. Do not prefix with "면접관:", "질문:", "Q:", or anything similar.`;
+${contextualHints}`;
 }
 
 async function callOllama(systemPrompt: string, userContent: string, json = false): Promise<string> {
@@ -213,6 +209,13 @@ async function callOllama(systemPrompt: string, userContent: string, json = fals
   return raw.replace(/^(면접관|질문|interviewer|question)\s*:\s*/i, "").trim();
 }
 
+export interface QuestionResult {
+  question: string;
+  hint: string;
+}
+
+const FIRST_QUESTION_HINT = "지원자의 기본 배경과 이 회사·직무에 지원한 이유를 파악하는 질문입니다. 단순한 경력 나열보다는 지원 동기의 진정성과 이 포지션과의 연관성을 구체적으로 전달하세요.";
+
 // 에이전트의 기본 질문 생성
 export async function generateAgentBaseQuestion(
   agentId: AgentId,
@@ -220,10 +223,10 @@ export async function generateAgentBaseQuestion(
   jobPosting: JobPostingContext,
   messages: Message[],
   difficulty: Difficulty,
-): Promise<string> {
+): Promise<QuestionResult> {
   // 조직 전문가 첫 질문은 고정
   if (agentId === "organization" && messages.length === 0) {
-    return getFirstQuestion(profile.name);
+    return { question: getFirstQuestion(profile.name), hint: FIRST_QUESTION_HINT };
   }
 
   const systemPrompt = buildAgentSystemPrompt(agentId, profile, jobPosting, difficulty);
@@ -238,11 +241,28 @@ export async function generateAgentBaseQuestion(
     .map((m) => `${m.role === "interviewer" ? "면접관" : "지원자"}: ${m.content}`)
     .join("\n\n");
 
-  const userContent = conversationText
+  const guide = conversationText
     ? `[Interview Conversation So Far]\n${conversationText}\n\n${baseQuestionGuide[agentId]}`
     : baseQuestionGuide[agentId];
 
-  return callOllama(systemPrompt, userContent);
+  const userContent = `${guide}
+
+Respond with this exact JSON (no other text):
+{
+  "question": "<exactly one interview question in Korean — no prefix like 면접관: or Q:>",
+  "hint": "<1-2 sentences in Korean explaining what you want to assess with this question — will be shown to the candidate as a hint>"
+}`;
+
+  const raw = await callOllama(systemPrompt, userContent, true);
+  try {
+    const match = raw.match(/\{[\s\S]*\}/);
+    if (!match) throw new Error("no JSON");
+    const parsed = JSON.parse(match[0]) as { question: string; hint: string };
+    const question = parsed.question?.replace(/^(면접관|질문|interviewer|question)\s*:\s*/i, "").trim();
+    return { question: question ?? raw.trim(), hint: parsed.hint ?? "" };
+  } catch {
+    return { question: raw.replace(/^(면접관|질문|interviewer|question)\s*:\s*/i, "").trim(), hint: "" };
+  }
 }
 
 const DIFFICULTY_FOLLOWUP_HINT: Record<Difficulty, string> = {
@@ -258,7 +278,7 @@ export async function generateAgentFollowUpQuestion(
   jobPosting: JobPostingContext,
   messages: Message[],
   difficulty: Difficulty,
-): Promise<string | null> {
+): Promise<QuestionResult | null> {
   const systemPrompt = buildAgentSystemPrompt(agentId, profile, jobPosting, difficulty);
 
   const conversationText = messages
@@ -282,7 +302,8 @@ If you want to follow up, the question MUST reference a specific part of the can
 Respond with this exact JSON:
 {
   "shouldFollowUp": <true if a follow-up is needed, false if the answer is sufficient>,
-  "question": "<follow-up question in Korean, or empty string if shouldFollowUp is false>"
+  "question": "<follow-up question in Korean, or empty string if shouldFollowUp is false>",
+  "hint": "<1-2 sentences in Korean explaining what you want to assess — shown to the candidate as a hint. Empty string if shouldFollowUp is false>"
 }`;
 
   const raw = await callOllama(systemPrompt, userContent, true);
@@ -290,9 +311,9 @@ Respond with this exact JSON:
   try {
     const match = raw.match(/\{[\s\S]*\}/);
     if (!match) return null;
-    const parsed = JSON.parse(match[0]) as { shouldFollowUp: boolean; question: string };
+    const parsed = JSON.parse(match[0]) as { shouldFollowUp: boolean; question: string; hint: string };
     if (!parsed.shouldFollowUp || !parsed.question?.trim()) return null;
-    return parsed.question.trim();
+    return { question: parsed.question.trim(), hint: parsed.hint ?? "" };
   } catch {
     return null;
   }


### PR DESCRIPTION
## Summary

- 질문 생성 시 Ollama가 질문과 함께 면접관 의도(hint)를 JSON으로 생성
- 💡 힌트 보기 버튼 클릭 시 말풍선 아래 amber 카드로 표시
- 타이머 30초 이하 도달 시 힌트 자동 노출
- 질문이 바뀔 때마다 힌트 초기화 (버튼 다시 숨김)
- 첫 질문(자기소개/지원동기)은 고정 힌트 사용

## Test plan

- [ ] 면접 시작 후 💡 힌트 보기 버튼 표시 확인
- [ ] 클릭 시 amber 카드로 힌트 표시
- [ ] 타이머 30초 이하 시 힌트 자동 노출
- [ ] 다음 질문으로 넘어가면 힌트 초기화 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)