### PR TITLE
feat: 토론 실시간 채팅 UI + 최종 평가 버튼 + 뒤로가기

### DIFF
--- a/app/api/interview/debate/route.ts
+++ b/app/api/interview/debate/route.ts
@@ -52,19 +52,16 @@ async function runDebate(
       .eq("id", sessionId);
 
     // 중재자: 최종 결론
-    const repliesForScore: AgentReply[] =
+    const repliesForModerator: AgentReply[] =
       replies.length > 0
         ? replies
         : evaluations.map((e) => ({
             agentId: e.agentId,
             agentLabel: e.agentLabel,
-            revisedScore: e.score,
-            scoreChanged: false,
-            scoreReason: "",
             replies: [],
           }));
 
-    const moderatorResult = await generateModeratorResult(evaluations, repliesForScore, messages);
+    const moderatorResult = await generateModeratorResult(evaluations, repliesForModerator, messages);
 
     await supabase
       .from("interview_sessions")

--- a/app/api/interview/debate/route.ts
+++ b/app/api/interview/debate/route.ts
@@ -16,39 +16,49 @@ async function runDebate(
   messages: Message[],
 ) {
   try {
-    // Round 0: 3 에이전트 병렬 독립 평가
-    const round0Results = await Promise.allSettled(
-      AGENT_ORDER.map((agentId) => generateAgentEvaluation(agentId, messages)),
-    );
-
-    const evaluations: AgentEvaluation[] = round0Results
-      .filter((r): r is PromiseFulfilledResult<AgentEvaluation> => r.status === "fulfilled")
-      .map((r) => r.value);
+    // Round 0: 에이전트 순차 평가 — 각자 완료 즉시 저장 (클라이언트에 실시간 표시)
+    const evaluations: AgentEvaluation[] = [];
+    for (const agentId of AGENT_ORDER) {
+      let evaluation: AgentEvaluation;
+      try {
+        evaluation = await generateAgentEvaluation(agentId, messages);
+      } catch {
+        continue; // 한 에이전트 실패 시 다음으로
+      }
+      evaluations.push(evaluation);
+      await supabase
+        .from("interview_sessions")
+        .update({
+          agentEvaluations: evaluations as unknown as Json,
+          status: evaluations.length === 1 ? "evaluating" : "debating",
+          updatedAt: new Date().toISOString(),
+        })
+        .eq("id", sessionId);
+    }
 
     if (evaluations.length < 2) {
       throw new Error("에이전트 평가 실패 (2개 미만 성공)");
     }
 
+    // Round 1: 순차 상호 반론 — 완료 즉시 저장 (클라이언트에 1명씩 표시)
+    const replies: AgentReply[] = [];
+    for (const myEval of evaluations) {
+      const others = evaluations.filter((e) => e.agentId !== myEval.agentId);
+      try {
+        const reply = await generateAgentReply(myEval.agentId, myEval, others, messages);
+        replies.push(reply);
+        await supabase
+          .from("interview_sessions")
+          .update({ debateReplies: replies as unknown as Json, updatedAt: new Date().toISOString() })
+          .eq("id", sessionId);
+      } catch {
+        continue;
+      }
+    }
+
     await supabase
       .from("interview_sessions")
-      .update({ agentEvaluations: evaluations as unknown as Json, status: "debating", updatedAt: new Date().toISOString() })
-      .eq("id", sessionId);
-
-    // Round 1: 병렬 상호 반론
-    const round1Results = await Promise.allSettled(
-      evaluations.map((myEval) => {
-        const others = evaluations.filter((e) => e.agentId !== myEval.agentId);
-        return generateAgentReply(myEval.agentId, myEval, others, messages);
-      }),
-    );
-
-    const replies: AgentReply[] = round1Results
-      .filter((r): r is PromiseFulfilledResult<AgentReply> => r.status === "fulfilled")
-      .map((r) => r.value);
-
-    await supabase
-      .from("interview_sessions")
-      .update({ debateReplies: replies as unknown as Json, status: "finalizing", updatedAt: new Date().toISOString() })
+      .update({ status: "finalizing", updatedAt: new Date().toISOString() })
       .eq("id", sessionId);
 
     // 중재자: 최종 결론

--- a/components/DebateLoading.tsx
+++ b/components/DebateLoading.tsx
@@ -14,51 +14,135 @@ export interface DebateResultData {
 
 interface Props {
   sessionId: string;
+  avatarSeeds: Record<AgentId, string>;
   onDone: (result: DebateResultData) => void;
   onError: (message: string) => void;
 }
 
-const STAGES: { status: string; label: string }[] = [
-  { status: "evaluating", label: "에이전트별 평가 중" },
-  { status: "debating", label: "면접관들이 토론 중" },
-  { status: "finalizing", label: "최종 결과 정리 중" },
-];
+type ChatMsg = {
+  id: string;
+  agentId?: AgentId;
+  text: string;
+  stance?: "agree" | "disagree" | "partial";
+  targetName?: string;
+  isSystem?: boolean;
+};
 
-function stageIndex(status: string): number {
-  const idx = STAGES.findIndex((s) => s.status === status);
-  return idx === -1 ? STAGES.length : idx;
-}
-
-const AGENT_COLORS: Record<AgentId, { border: string; badge: string; text: string }> = {
+const AGENT_META: Record<AgentId, { name: string; bgColor: string; color: string; bubble: string }> = {
   organization: {
-    border: "border-purple-100 dark:border-purple-900/40",
-    badge: "bg-purple-100 dark:bg-purple-900/40 text-purple-700 dark:text-purple-300",
-    text: "text-purple-600 dark:text-purple-400",
+    name: "면접관 1",
+    bgColor: "e9d5ff",
+    color: "text-purple-500 dark:text-purple-400",
+    bubble: "bg-purple-50 dark:bg-purple-900/30 border border-purple-100 dark:border-purple-800/40",
   },
   logic: {
-    border: "border-blue-100 dark:border-blue-900/40",
-    badge: "bg-blue-100 dark:bg-blue-900/40 text-blue-700 dark:text-blue-300",
-    text: "text-blue-600 dark:text-blue-400",
+    name: "면접관 2",
+    bgColor: "bfdbfe",
+    color: "text-blue-500 dark:text-blue-400",
+    bubble: "bg-blue-50 dark:bg-blue-900/30 border border-blue-100 dark:border-blue-800/40",
   },
   technical: {
-    border: "border-green-100 dark:border-green-900/40",
-    badge: "bg-green-100 dark:bg-green-900/40 text-green-700 dark:text-green-300",
-    text: "text-green-600 dark:text-green-400",
+    name: "면접관 3",
+    bgColor: "bbf7d0",
+    color: "text-green-500 dark:text-green-400",
+    bubble: "bg-green-50 dark:bg-green-900/30 border border-green-100 dark:border-green-800/40",
   },
 };
 
+const AGENT_ORDER: AgentId[] = ["organization", "logic", "technical"];
+
 const STANCE_LABEL: Record<string, { label: string; color: string }> = {
-  agree:    { label: "동의",   color: "text-green-600 dark:text-green-400 bg-green-50 dark:bg-green-900/20" },
-  disagree: { label: "반박",   color: "text-red-600 dark:text-red-400 bg-red-50 dark:bg-red-900/20" },
-  partial:  { label: "부분동의", color: "text-orange-600 dark:text-orange-400 bg-orange-50 dark:bg-orange-900/20" },
+  agree:    { label: "동의",     color: "text-green-600 dark:text-green-400 bg-green-50 dark:bg-green-900/20" },
+  disagree: { label: "반박",     color: "text-red-500 dark:text-red-400 bg-red-50 dark:bg-red-900/20" },
+  partial:  { label: "부분동의", color: "text-orange-500 dark:text-orange-400 bg-orange-50 dark:bg-orange-900/20" },
 };
 
-export default function DebateLoading({ sessionId, onDone, onError }: Props) {
+function avatarUrl(seed: string, bgColor: string) {
+  return `https://api.dicebear.com/9.x/notionists/svg?seed=${seed}&backgroundColor=${bgColor}`;
+}
+
+function TypingIndicator({ agentId, avatarSeeds }: { agentId: AgentId; avatarSeeds: Record<AgentId, string> }) {
+  const meta = AGENT_META[agentId];
+  return (
+    <div className="flex items-end gap-2 animate-fade-in">
+      <img
+        src={avatarUrl(avatarSeeds[agentId], meta.bgColor)}
+        alt={meta.name}
+        className="w-8 h-8 rounded-full shrink-0"
+      />
+      <div className={`px-4 py-3 rounded-2xl rounded-bl-sm ${meta.bubble}`}>
+        <span className="flex gap-1">
+          <span className="w-1.5 h-1.5 rounded-full bg-gray-400 dark:bg-slate-500 animate-bounce [animation-delay:0ms]" />
+          <span className="w-1.5 h-1.5 rounded-full bg-gray-400 dark:bg-slate-500 animate-bounce [animation-delay:150ms]" />
+          <span className="w-1.5 h-1.5 rounded-full bg-gray-400 dark:bg-slate-500 animate-bounce [animation-delay:300ms]" />
+        </span>
+      </div>
+    </div>
+  );
+}
+
+function ChatBubble({ msg, avatarSeeds }: { msg: ChatMsg; avatarSeeds: Record<AgentId, string> }) {
+  if (msg.isSystem) {
+    return (
+      <div className="flex items-center gap-3 py-1 animate-fade-in">
+        <div className="flex-1 h-px bg-gray-200 dark:bg-slate-700" />
+        <span className="text-xs text-gray-400 dark:text-slate-500 shrink-0 px-2">{msg.text}</span>
+        <div className="flex-1 h-px bg-gray-200 dark:bg-slate-700" />
+      </div>
+    );
+  }
+
+  if (!msg.agentId) return null;
+  const meta = AGENT_META[msg.agentId];
+
+  return (
+    <div className="flex items-end gap-2 animate-fade-in">
+      <img
+        src={avatarUrl(avatarSeeds[msg.agentId], meta.bgColor)}
+        alt={meta.name}
+        className="w-8 h-8 rounded-full shrink-0"
+      />
+      <div className="flex flex-col gap-1 max-w-[85%]">
+        {/* 이름 + 수신자 + 스탠스 */}
+        <div className="flex items-center gap-2 px-1">
+          <span className={`text-xs font-semibold ${meta.color}`}>{meta.name}</span>
+          {msg.targetName && (
+            <span className="text-xs text-gray-400 dark:text-slate-500">
+              → {msg.targetName}에게
+            </span>
+          )}
+          {msg.stance && (
+            <span className={`text-xs font-semibold px-1.5 py-0.5 rounded ${STANCE_LABEL[msg.stance]?.color}`}>
+              {STANCE_LABEL[msg.stance]?.label}
+            </span>
+          )}
+        </div>
+        {/* 말풍선 */}
+        <div className={`px-4 py-3 rounded-2xl rounded-bl-sm ${meta.bubble}`}>
+          <p className="text-sm text-gray-700 dark:text-slate-200 leading-relaxed">{msg.text}</p>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default function DebateLoading({ sessionId, avatarSeeds, onDone, onError }: Props) {
   const [currentStatus, setCurrentStatus] = useState("evaluating");
   const [agentEvaluations, setAgentEvaluations] = useState<AgentEvaluation[]>([]);
   const [debateReplies, setDebateReplies] = useState<AgentReply[]>([]);
-  const intervalRef = useRef<ReturnType<typeof setInterval>>();
 
+  const [visibleMsgs, setVisibleMsgs] = useState<ChatMsg[]>([]);
+  const [typingAgentId, setTypingAgentId] = useState<AgentId | null>(null);
+
+  const pendingQueue = useRef<ChatMsg[]>([]);
+  const queuedEvalCount = useRef(0);
+  const queuedReplyCount = useRef(0);
+  const addedSystemMsg = useRef(false);
+  const popTimerRef = useRef<ReturnType<typeof setTimeout>>();
+  const pollRef = useRef<ReturnType<typeof setInterval>>();
+  const bottomRef = useRef<HTMLDivElement>(null);
+
+  // 폴링
   useEffect(() => {
     const poll = async () => {
       try {
@@ -67,16 +151,11 @@ export default function DebateLoading({ sessionId, onDone, onError }: Props) {
         const data = await res.json();
 
         setCurrentStatus(data.status);
-
-        if (data.agentEvaluations?.length > 0) {
-          setAgentEvaluations(data.agentEvaluations);
-        }
-        if (data.debateReplies?.length > 0) {
-          setDebateReplies(data.debateReplies);
-        }
+        if (data.agentEvaluations?.length > 0) setAgentEvaluations(data.agentEvaluations);
+        if (data.debateReplies?.length > 0) setDebateReplies(data.debateReplies);
 
         if (data.status === "done") {
-          clearInterval(intervalRef.current);
+          clearInterval(pollRef.current);
           onDone({
             agentEvaluations: data.agentEvaluations ?? [],
             finalScore: data.finalScore ?? 0,
@@ -85,173 +164,164 @@ export default function DebateLoading({ sessionId, onDone, onError }: Props) {
             improvementTips: data.improvementTips ?? [],
           });
         } else if (data.status === "error") {
-          clearInterval(intervalRef.current);
+          clearInterval(pollRef.current);
           onError(data.errorMessage ?? "토론 중 오류가 발생했습니다");
         }
-      } catch {
-        // 일시적 네트워크 오류 무시
-      }
+      } catch { /* 일시적 네트워크 오류 무시 */ }
     };
 
     poll();
-    intervalRef.current = setInterval(poll, 1500);
-    return () => clearInterval(intervalRef.current);
+    pollRef.current = setInterval(poll, 1500);
+    return () => clearInterval(pollRef.current);
   }, [sessionId, onDone, onError]);
 
-  const current = stageIndex(currentStatus);
+  // Round 0 평가 → 큐 추가
+  useEffect(() => {
+    if (agentEvaluations.length <= queuedEvalCount.current) return;
+    const newEvals = agentEvaluations.slice(queuedEvalCount.current);
+    newEvals.forEach((e) => {
+      pendingQueue.current.push({
+        id: `eval-${e.agentId}`,
+        agentId: e.agentId,
+        text: e.opinion,
+      });
+    });
+    queuedEvalCount.current = agentEvaluations.length;
+    scheduleNext();
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [agentEvaluations]);
+
+  // Round 1 반론 → 큐 추가
+  useEffect(() => {
+    if (debateReplies.length <= queuedReplyCount.current) return;
+
+    if (!addedSystemMsg.current) {
+      pendingQueue.current.push({
+        id: "system-debate",
+        isSystem: true,
+        text: "이제 면접관들이 서로 의견을 교환합니다",
+      });
+      addedSystemMsg.current = true;
+    }
+
+    const newReplies = debateReplies.slice(queuedReplyCount.current);
+    newReplies.forEach((r) => {
+      r.replies.forEach((reply, i) => {
+        const targetMeta = AGENT_META[reply.targetAgentId as AgentId];
+        pendingQueue.current.push({
+          id: `reply-${r.agentId}-${i}`,
+          agentId: r.agentId,
+          text: reply.comment,
+          stance: reply.stance as "agree" | "disagree" | "partial",
+          targetName: targetMeta?.name ?? reply.targetAgentId,
+        });
+      });
+    });
+    queuedReplyCount.current = debateReplies.length;
+    scheduleNext();
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [debateReplies]);
+
+  // 다음 메시지 팝
+  function scheduleNext() {
+    if (popTimerRef.current) return; // 이미 타이머 실행 중
+    popTimerRef.current = setTimeout(popNext, 300);
+  }
+
+  function popNext() {
+    popTimerRef.current = undefined;
+    const next = pendingQueue.current.shift();
+    if (!next) {
+      setTypingAgentId(null);
+      return;
+    }
+
+    // 시스템 메시지는 바로 표시, 타이핑 없음
+    if (next.isSystem) {
+      setTypingAgentId(null);
+      setVisibleMsgs((prev) => [...prev, next]);
+      popTimerRef.current = setTimeout(popNext, 800);
+      return;
+    }
+
+    // 다음 에이전트 타이핑 인디케이터 표시
+    const nextAgentId = next.agentId ?? null;
+    setTypingAgentId(nextAgentId);
+
+    popTimerRef.current = setTimeout(() => {
+      popTimerRef.current = undefined;
+      setTypingAgentId(null);
+      setVisibleMsgs((prev) => [...prev, next]);
+
+      // 큐에 더 있으면 이어서
+      if (pendingQueue.current.length > 0) {
+        popTimerRef.current = setTimeout(popNext, 600);
+      }
+    }, 1800);
+  }
+
+  // 자동 스크롤
+  useEffect(() => {
+    bottomRef.current?.scrollIntoView({ behavior: "smooth" });
+  }, [visibleMsgs, typingAgentId]);
+
+  // 타이핑 에이전트 결정 (큐 없을 때 현재 상태 기반)
+  const displayTypingId: AgentId | null =
+    typingAgentId ??
+    (currentStatus === "evaluating" && visibleMsgs.filter((m) => !m.isSystem).length < 3
+      ? (AGENT_ORDER[visibleMsgs.filter((m) => !m.isSystem).length] ?? null)
+      : null);
+
+  const isActive = currentStatus !== "done" && currentStatus !== "error";
 
   return (
-    <div className="space-y-6">
-      {/* 진행 상태 */}
-      <div className="card p-8 flex flex-col items-center justify-center space-y-6 text-center">
-        <div>
-          <h2 className="text-lg font-bold text-gray-900 dark:text-slate-50 mb-1">
-            면접관들이 평가하고 있습니다
-          </h2>
-          <p className="text-sm text-gray-500 dark:text-slate-400">
-            3명의 전문 면접관이 토론을 진행 중입니다
-          </p>
+    <div className="flex flex-col gap-4">
+      {/* 회의실 헤더 */}
+      <div className="bg-slate-800 dark:bg-slate-900 rounded-2xl p-4 shadow-lg">
+        <div className="flex items-center justify-between mb-3">
+          <div className="flex items-center gap-2">
+            <span className="text-base">👁️</span>
+            <span className="text-sm font-semibold text-slate-200">면접관 전용 회의실</span>
+          </div>
+          {isActive && (
+            <div className="flex items-center gap-1.5">
+              <span className="w-2 h-2 rounded-full bg-green-400 animate-pulse" />
+              <span className="text-xs text-green-400">진행 중</span>
+            </div>
+          )}
         </div>
-
-        <div className="space-y-4 w-full max-w-xs">
-          {STAGES.map((stage, i) => {
-            const done = i < current;
-            const active = i === current;
-            return (
-              <div key={stage.status} className="flex items-center gap-3">
-                {done ? (
-                  <span className="w-5 h-5 rounded-full bg-green-500 flex items-center justify-center text-white text-xs shrink-0">
-                    ✓
-                  </span>
-                ) : active ? (
-                  <span className="w-5 h-5 rounded-full border-2 border-blue-500 flex items-center justify-center shrink-0">
-                    <span className="w-2 h-2 rounded-full bg-blue-500 animate-pulse" />
-                  </span>
-                ) : (
-                  <span className="w-5 h-5 rounded-full border-2 border-gray-200 dark:border-slate-600 shrink-0" />
-                )}
-                <span
-                  className={`text-sm ${
-                    done
-                      ? "text-gray-400 dark:text-slate-500 line-through"
-                      : active
-                        ? "text-gray-700 dark:text-slate-200 font-medium"
-                        : "text-gray-400 dark:text-slate-600"
-                  }`}
-                >
-                  {stage.label}
-                </span>
-              </div>
-            );
-          })}
+        <div className="flex items-center gap-2">
+          {(["organization", "logic", "technical"] as AgentId[]).map((aid) => (
+            <img
+              key={aid}
+              src={avatarUrl(avatarSeeds[aid], AGENT_META[aid].bgColor)}
+              alt={AGENT_META[aid].name}
+              className="w-8 h-8 rounded-full border-2 border-slate-700"
+            />
+          ))}
+          <span className="text-xs text-slate-400 ml-1">몰래 엿보는 중...</span>
         </div>
-
-        <p className="text-xs text-gray-400 dark:text-slate-500">
-          Ollama 모델에 따라 1~3분 소요될 수 있습니다
-        </p>
       </div>
 
-      {/* Round 0: 에이전트별 평가 */}
-      {agentEvaluations.length > 0 && (
-        <div className="space-y-3 animate-fade-in-up">
-          <h3 className="font-bold text-gray-900 dark:text-slate-50 px-1">면접관별 평가</h3>
-          {agentEvaluations.map((e) => {
-            const colors = AGENT_COLORS[e.agentId] ?? AGENT_COLORS.organization;
-            return (
-              <div key={e.agentId} className={`card p-5 space-y-3 border-l-4 ${colors.border}`}>
-                <div className="flex items-center justify-between">
-                  <div className="space-y-0.5">
-                    <span className={`text-xs font-semibold px-2 py-0.5 rounded-full ${colors.badge}`}>
-                      {e.agentLabel}
-                    </span>
-                    <p className="text-xs text-gray-400 dark:text-slate-500 pt-1">{e.criterion}</p>
-                  </div>
-                  <span className="text-2xl font-bold text-gray-700 dark:text-slate-300">
-                    {e.score}
-                    <span className="text-sm font-normal text-gray-400 dark:text-slate-500">/100</span>
-                  </span>
-                </div>
-                <p className="text-sm text-gray-700 dark:text-slate-300 leading-relaxed">{e.opinion}</p>
-                {e.highlights.length > 0 && (
-                  <ul className="space-y-1">
-                    {e.highlights.map((h, i) => (
-                      <li key={i} className="text-xs text-gray-500 dark:text-slate-400 flex gap-1.5">
-                        <span className="text-gray-300 dark:text-slate-600 shrink-0">•</span>
-                        {h}
-                      </li>
-                    ))}
-                  </ul>
-                )}
-              </div>
-            );
-          })}
-        </div>
-      )}
+      {/* 채팅 영역 */}
+      <div className="space-y-4 min-h-[120px]">
+        {visibleMsgs.map((msg) => (
+          <ChatBubble key={msg.id} msg={msg} avatarSeeds={avatarSeeds} />
+        ))}
 
-      {/* Round 1: 토론 내용 */}
-      {debateReplies.length > 0 && (
-        <div className="space-y-3 animate-fade-in-up">
-          <h3 className="font-bold text-gray-900 dark:text-slate-50 px-1">면접관 토론</h3>
-          {debateReplies.map((r) => {
-            const colors = AGENT_COLORS[r.agentId] ?? AGENT_COLORS.organization;
-            const initialScore = agentEvaluations.find((e) => e.agentId === r.agentId)?.score;
-            return (
-              <div key={r.agentId} className={`card p-5 space-y-3 border-l-4 ${colors.border}`}>
-                {/* 헤더: 에이전트명 + 점수 변화 */}
-                <div className="flex items-center justify-between">
-                  <span className={`text-xs font-semibold px-2 py-0.5 rounded-full ${colors.badge}`}>
-                    {r.agentLabel}
-                  </span>
-                  <div className="flex items-center gap-1.5 text-sm font-semibold">
-                    {r.scoreChanged && initialScore !== undefined ? (
-                      <>
-                        <span className="text-gray-400 dark:text-slate-500 line-through text-xs font-normal">
-                          {initialScore}
-                        </span>
-                        <span className={r.revisedScore > initialScore ? "text-green-600 dark:text-green-400" : "text-red-500 dark:text-red-400"}>
-                          {r.revisedScore > initialScore ? "▲" : "▼"} {r.revisedScore}
-                        </span>
-                      </>
-                    ) : (
-                      <span className="text-gray-500 dark:text-slate-400">{r.revisedScore} 유지</span>
-                    )}
-                    <span className="text-gray-400 dark:text-slate-500 font-normal text-xs">/100</span>
-                  </div>
-                </div>
+        {/* 타이핑 인디케이터 */}
+        {isActive && displayTypingId && (
+          <TypingIndicator agentId={displayTypingId} avatarSeeds={avatarSeeds} />
+        )}
 
-                {/* 점수 변경 이유 */}
-                {r.scoreReason && (
-                  <p className="text-xs text-gray-500 dark:text-slate-400 italic">{r.scoreReason}</p>
-                )}
+        <div ref={bottomRef} />
+      </div>
 
-                {/* 다른 에이전트에 대한 반론 */}
-                {r.replies.length > 0 && (
-                  <div className="space-y-2 pt-1">
-                    {r.replies.map((reply, i) => {
-                      const targetColors = AGENT_COLORS[reply.targetAgentId as AgentId] ?? AGENT_COLORS.organization;
-                      const stance = STANCE_LABEL[reply.stance] ?? STANCE_LABEL.partial;
-                      return (
-                        <div key={i} className="bg-gray-50 dark:bg-slate-800/60 rounded-lg p-3 space-y-1.5">
-                          <div className="flex items-center gap-2">
-                            <span className={`text-xs font-medium ${targetColors.text}`}>
-                              → {reply.targetAgentId === "organization" ? "조직 전문가" : reply.targetAgentId === "logic" ? "논리 전문가" : "기술 전문가"}에게
-                            </span>
-                            <span className={`text-xs font-semibold px-1.5 py-0.5 rounded ${stance.color}`}>
-                              {stance.label}
-                            </span>
-                          </div>
-                          <p className="text-xs text-gray-600 dark:text-slate-300 leading-relaxed">
-                            {reply.comment}
-                          </p>
-                        </div>
-                      );
-                    })}
-                  </div>
-                )}
-              </div>
-            );
-          })}
-        </div>
+      {/* 소요 시간 안내 */}
+      {isActive && (
+        <p className="text-xs text-gray-400 dark:text-slate-500 text-center">
+          Ollama 모델에 따라 1~3분 소요될 수 있습니다
+        </p>
       )}
     </div>
   );

--- a/components/DebateLoading.tsx
+++ b/components/DebateLoading.tsx
@@ -133,6 +133,7 @@ export default function DebateLoading({ sessionId, avatarSeeds, onDone, onError 
 
   const [visibleMsgs, setVisibleMsgs] = useState<ChatMsg[]>([]);
   const [typingAgentId, setTypingAgentId] = useState<AgentId | null>(null);
+  const [showProceedButton, setShowProceedButton] = useState(false);
 
   const pendingQueue = useRef<ChatMsg[]>([]);
   const queuedEvalCount = useRef(0);
@@ -141,6 +142,8 @@ export default function DebateLoading({ sessionId, avatarSeeds, onDone, onError 
   const popTimerRef = useRef<ReturnType<typeof setTimeout>>();
   const pollRef = useRef<ReturnType<typeof setInterval>>();
   const bottomRef = useRef<HTMLDivElement>(null);
+  const debateFinishedRef = useRef(false);
+  const pendingResult = useRef<DebateResultData | null>(null);
 
   // 폴링
   useEffect(() => {
@@ -156,13 +159,19 @@ export default function DebateLoading({ sessionId, avatarSeeds, onDone, onError 
 
         if (data.status === "done") {
           clearInterval(pollRef.current);
-          onDone({
+          // 결과 저장 후 큐가 비면 버튼 표시 (onDone은 버튼 클릭 시 호출)
+          pendingResult.current = {
             agentEvaluations: data.agentEvaluations ?? [],
             finalScore: data.finalScore ?? 0,
             finalFeedback: data.finalFeedback ?? { strengths: "", weaknesses: "", advice: "" },
             debateSummary: data.debateSummary ?? "",
             improvementTips: data.improvementTips ?? [],
-          });
+          };
+          debateFinishedRef.current = true;
+          // 큐가 이미 비어있으면 즉시 버튼 표시 (모든 메시지가 이미 출력된 경우)
+          if (pendingQueue.current.length === 0 && !popTimerRef.current) {
+            setShowProceedButton(true);
+          }
         } else if (data.status === "error") {
           clearInterval(pollRef.current);
           onError(data.errorMessage ?? "토론 중 오류가 발생했습니다");
@@ -173,7 +182,7 @@ export default function DebateLoading({ sessionId, avatarSeeds, onDone, onError 
     poll();
     pollRef.current = setInterval(poll, 1500);
     return () => clearInterval(pollRef.current);
-  }, [sessionId, onDone, onError]);
+  }, [sessionId, onError]);
 
   // Round 0 평가 → 큐 추가
   useEffect(() => {
@@ -233,6 +242,8 @@ export default function DebateLoading({ sessionId, avatarSeeds, onDone, onError 
     const next = pendingQueue.current.shift();
     if (!next) {
       setTypingAgentId(null);
+      // 큐 비었고 토론 완료면 버튼 표시
+      if (debateFinishedRef.current) setShowProceedButton(true);
       return;
     }
 
@@ -266,10 +277,11 @@ export default function DebateLoading({ sessionId, avatarSeeds, onDone, onError 
   }, [visibleMsgs, typingAgentId]);
 
   // 타이핑 에이전트 결정 (큐 없을 때 현재 상태 기반)
+  const nonSystemMsgCount = visibleMsgs.filter((m) => !m.isSystem).length;
   const displayTypingId: AgentId | null =
     typingAgentId ??
-    (currentStatus === "evaluating" && visibleMsgs.filter((m) => !m.isSystem).length < 3
-      ? (AGENT_ORDER[visibleMsgs.filter((m) => !m.isSystem).length] ?? null)
+    ((currentStatus === "evaluating" || currentStatus === "debating") && nonSystemMsgCount < 3
+      ? (AGENT_ORDER[nonSystemMsgCount] ?? null)
       : null);
 
   const isActive = currentStatus !== "done" && currentStatus !== "error";
@@ -322,6 +334,16 @@ export default function DebateLoading({ sessionId, avatarSeeds, onDone, onError 
         <p className="text-xs text-gray-400 dark:text-slate-500 text-center">
           Ollama 모델에 따라 1~3분 소요될 수 있습니다
         </p>
+      )}
+
+      {/* 최종 평가 보기 버튼 */}
+      {showProceedButton && pendingResult.current && (
+        <button
+          onClick={() => onDone(pendingResult.current!)}
+          className="btn-primary w-full"
+        >
+          최종 평가 보기 →
+        </button>
       )}
     </div>
   );

--- a/components/DebateResult.tsx
+++ b/components/DebateResult.tsx
@@ -63,7 +63,7 @@ export default function DebateResult({
             const colors = AGENT_COLORS[e.agentId] ?? AGENT_COLORS.organization;
             return (
               <div key={e.agentId} className={`card p-5 space-y-3 border-l-4 ${colors.border}`}>
-                <div className="flex items-center justify-between">
+                <div className="flex items-start gap-2">
                   <div className="space-y-0.5">
                     <span
                       className={`text-xs font-semibold px-2 py-0.5 rounded-full ${colors.badge}`}
@@ -72,10 +72,6 @@ export default function DebateResult({
                     </span>
                     <p className="text-xs text-gray-400 dark:text-slate-500 pt-1">{e.criterion}</p>
                   </div>
-                  <span className="text-2xl font-bold text-gray-700 dark:text-slate-300">
-                    {e.score}
-                    <span className="text-sm font-normal text-gray-400 dark:text-slate-500">/100</span>
-                  </span>
                 </div>
                 <p className="text-sm text-gray-700 dark:text-slate-300 leading-relaxed">
                   {e.opinion}
@@ -85,7 +81,7 @@ export default function DebateResult({
                     {e.highlights.map((h, i) => (
                       <li key={i} className="text-xs text-gray-500 dark:text-slate-400 flex gap-1.5">
                         <span className="text-gray-300 dark:text-slate-600 shrink-0">•</span>
-                        {h}
+                        {h.replace(/\*\*/g, "")}
                       </li>
                     ))}
                   </ul>

--- a/components/DebateResult.tsx
+++ b/components/DebateResult.tsx
@@ -10,6 +10,7 @@ interface Props {
   debateSummary: string;
   improvementTips: string[];
   onRestart: () => void;
+  onBack: () => void;
 }
 
 function ScoreRing({ score }: { score: number }) {
@@ -45,9 +46,18 @@ export default function DebateResult({
   debateSummary,
   improvementTips,
   onRestart,
+  onBack,
 }: Props) {
   return (
     <div className="space-y-6">
+      {/* 뒤로가기 */}
+      <button
+        onClick={onBack}
+        className="flex items-center gap-1.5 text-sm text-gray-400 dark:text-slate-500 hover:text-gray-600 dark:hover:text-slate-300 transition-colors"
+      >
+        ← 면접관 토론 돌아보기
+      </button>
+
       {/* 최종 점수 */}
       <div className="card p-6 text-center space-y-3">
         <h2 className="text-xl font-bold text-gray-900 dark:text-slate-50">면접 완료!</h2>

--- a/components/InterviewSession.tsx
+++ b/components/InterviewSession.tsx
@@ -404,6 +404,7 @@ export default function InterviewSession({ name }: { name: string }) {
     return (
       <DebateLoading
         sessionId={sessionId}
+        avatarSeeds={avatarSeeds}
         onDone={(result) => {
           setDebateResult(result);
           setPhase("done");

--- a/components/InterviewSession.tsx
+++ b/components/InterviewSession.tsx
@@ -375,8 +375,8 @@ export default function InterviewSession({ name }: { name: string }) {
     return <DifficultySelect onSelect={handleDifficultySelect} />;
   }
 
-  // 토론 중
-  if (phase === "debating") {
+  // 토론 중 or 결과 화면 (DebateLoading은 항상 마운트 유지 — 뒤로가기 시 상태 보존)
+  if (phase === "debating" || phase === "done") {
     if (debateError) {
       return (
         <div className="card flex flex-col items-center justify-center py-16 px-6 space-y-4 text-center">
@@ -402,31 +402,33 @@ export default function InterviewSession({ name }: { name: string }) {
     }
 
     return (
-      <DebateLoading
-        sessionId={sessionId}
-        avatarSeeds={avatarSeeds}
-        onDone={(result) => {
-          setDebateResult(result);
-          setPhase("done");
-        }}
-        onError={(msg) => {
-          setDebateError(msg);
-        }}
-      />
-    );
-  }
+      <>
+        {/* 결과 화면일 때 DebateLoading을 숨김 (마운트는 유지 — 뒤로가기 상태 보존) */}
+        <div className={phase === "done" ? "hidden" : ""}>
+          <DebateLoading
+            sessionId={sessionId}
+            avatarSeeds={avatarSeeds}
+            onDone={(result) => {
+              setDebateResult(result);
+              setPhase("done");
+            }}
+            onError={(msg) => setDebateError(msg)}
+          />
+        </div>
 
-  // 결과 화면
-  if (phase === "done" && debateResult) {
-    return (
-      <DebateResult
-        finalScore={debateResult.finalScore}
-        agentEvaluations={debateResult.agentEvaluations}
-        finalFeedback={debateResult.finalFeedback}
-        debateSummary={debateResult.debateSummary}
-        improvementTips={debateResult.improvementTips}
-        onRestart={handleRestart}
-      />
+        {/* 결과 화면 */}
+        {phase === "done" && debateResult && (
+          <DebateResult
+            finalScore={debateResult.finalScore}
+            agentEvaluations={debateResult.agentEvaluations}
+            finalFeedback={debateResult.finalFeedback}
+            debateSummary={debateResult.debateSummary}
+            improvementTips={debateResult.improvementTips}
+            onRestart={handleRestart}
+            onBack={() => setPhase("debating")}
+          />
+        )}
+      </>
     );
   }
 

--- a/lib/agents.ts
+++ b/lib/agents.ts
@@ -7,7 +7,6 @@ export interface AgentEvaluation {
   agentId: AgentId;
   agentLabel: string;
   criterion: string;
-  score: number;        // 0~100
   opinion: string;      // 3~5 문장
   highlights: string[]; // 2~3개 핵심 포인트
 }
@@ -15,9 +14,6 @@ export interface AgentEvaluation {
 export interface AgentReply {
   agentId: AgentId;
   agentLabel: string;
-  revisedScore: number;
-  scoreChanged: boolean;
-  scoreReason: string;
   replies: {
     targetAgentId: string;
     stance: "agree" | "disagree" | "partial";
@@ -91,20 +87,18 @@ Evaluate this interview strictly from your perspective as ${agent.label}. Focus 
 
 Respond with this exact JSON structure:
 {
-  "score": <integer 0-100 based solely on your criteria>,
   "opinion": "<evaluation in Korean, 3-5 sentences, cite specific answers from the transcript>",
   "highlights": ["<key observation 1 in Korean>", "<key observation 2 in Korean>", "<key observation 3 in Korean>"]
 }
 Do not use markdown formatting (no **, *, #) inside any string values.`;
 
   const raw = await callOllama(systemPrompt, userContent);
-  const parsed = extractJSON<{ score: number; opinion: string; highlights: string[] }>(raw);
+  const parsed = extractJSON<{ opinion: string; highlights: string[] }>(raw);
 
   return {
     agentId,
     agentLabel: agent.label,
     criterion: agent.criterion,
-    score: Math.max(0, Math.min(100, Math.round(parsed.score))),
     opinion: parsed.opinion,
     highlights: (parsed.highlights ?? []).slice(0, 3),
   };
@@ -123,15 +117,13 @@ export async function generateAgentReply(
   const othersText = otherEvaluations
     .map(
       (e) =>
-        `[${e.agentLabel}] Score: ${e.score}/100\n${e.opinion}\nHighlights: ${e.highlights.join(" | ")}`,
+        `[${e.agentLabel}] ${e.opinion}\nHighlights: ${e.highlights.join(" | ")}`,
     )
     .join("\n\n");
 
   const replySchema = otherEvaluations
-    .map((e, i) =>
-      i === 0
-        ? `    {\n      "targetAgentId": "${e.agentId}",\n      "stance": "<agree|disagree|partial>",\n      "comment": "<2-3 sentences in Korean referencing a specific part of the transcript>"\n    }`
-        : `    {\n      "targetAgentId": "${e.agentId}",\n      "stance": "<agree|disagree|partial>",\n      "comment": "<2-3 sentences in Korean referencing a specific part of the transcript>"\n    }`,
+    .map((e) =>
+      `    {\n      "targetAgentId": "${e.agentId}",\n      "stance": "<agree|disagree|partial>",\n      "comment": "<2-3 sentences in Korean referencing a specific part of the transcript>"\n    }`
     )
     .join(",\n");
 
@@ -141,7 +133,6 @@ export async function generateAgentReply(
 ${conversationText}
 
 [Your Round 0 Evaluation]
-Score: ${myEvaluation.score}/100
 ${myEvaluation.opinion}
 
 [Other Evaluators' Opinions]
@@ -150,14 +141,9 @@ ${othersText}
 Now respond to the other evaluators. Rules:
 - You MUST engage with at least one specific moment from the interview transcript
 - Disagree or partially agree with at least one evaluator — don't just agree with everything
-- Revise your score ONLY if an evaluator pointed out something you genuinely missed from the transcript
-- Score changes must be meaningful (at least ±5 points) if they occur
 
 Respond with this exact JSON:
 {
-  "revisedScore": <integer 0-100>,
-  "scoreChanged": <true|false>,
-  "scoreReason": "<why you kept or changed your score, in Korean, 1-2 sentences>",
   "replies": [
 ${replySchema}
   ]
@@ -166,18 +152,12 @@ Do not use markdown formatting (no **, *, #) inside any string values.`;
 
   const raw = await callOllama(systemPrompt, userContent);
   const parsed = extractJSON<{
-    revisedScore: number;
-    scoreChanged: boolean;
-    scoreReason: string;
     replies: { targetAgentId: string; stance: string; comment: string }[];
   }>(raw);
 
   return {
     agentId,
     agentLabel: agent.label,
-    revisedScore: Math.max(0, Math.min(100, Math.round(parsed.revisedScore))),
-    scoreChanged: Boolean(parsed.scoreChanged),
-    scoreReason: parsed.scoreReason ?? "",
     replies: (parsed.replies ?? []).map((r) => ({
       targetAgentId: r.targetAgentId,
       stance: (["agree", "disagree", "partial"].includes(r.stance)
@@ -196,12 +176,8 @@ export async function generateModeratorResult(
 ): Promise<ModeratorResult> {
   const conversationText = buildConversationText(messages);
 
-  const avgScore = Math.round(
-    replies.reduce((sum, r) => sum + r.revisedScore, 0) / replies.length,
-  );
-
   const evaluationsText = evaluations
-    .map((e) => `[${e.agentLabel}] Initial Score: ${e.score}/100\n${e.opinion}`)
+    .map((e) => `[${e.agentLabel}] Criteria: ${e.criterion}\n${e.opinion}\nKey points: ${e.highlights.join(" / ")}`)
     .join("\n\n");
 
   const repliesText = replies
@@ -209,7 +185,7 @@ export async function generateModeratorResult(
       const replyLines = r.replies
         .map((reply) => `  → To ${reply.targetAgentId} [${reply.stance}]: ${reply.comment}`)
         .join("\n");
-      return `[${r.agentLabel}] Revised Score: ${r.revisedScore}/100 (${r.scoreChanged ? "changed" : "unchanged"})\nReason: ${r.scoreReason}\n${replyLines}`;
+      return `[${r.agentLabel}]\n${replyLines}`;
     })
     .join("\n\n");
 
@@ -221,32 +197,34 @@ ${conversationText}
 [Round 0 — Independent Evaluations]
 ${evaluationsText}
 
-[Round 1 — Debate & Score Revisions]
+[Round 1 — Panel Debate]
 ${repliesText}
 
-[Final Score: ${avgScore}/100 (average of revised scores)]
+Based on all evaluator opinions and the full debate above, assign a comprehensive final score and synthesize the findings.
 
-Synthesize the panel discussion. Respond with this exact JSON:
+Respond with this exact JSON:
 {
+  "score": <integer 0-100 reflecting the candidate's overall performance across all criteria>,
   "overall": {
     "strengths": "<2-3 sentences in Korean about what the candidate did well, citing specific answers>",
     "weaknesses": "<2-3 sentences in Korean about clear gaps>",
     "advice": "<2-3 sentences in Korean of actionable improvement advice>"
   },
   "improvementTips": ["<specific tip 1 in Korean>", "<specific tip 2 in Korean>", "<specific tip 3 in Korean>"],
-  "debateSummary": "<2-3 sentences in Korean summarizing key disagreements between evaluators and score changes>"
+  "debateSummary": "<2-3 sentences in Korean summarizing the key discussion points and what influenced the final score>"
 }
 Do not use markdown formatting (no **, *, #) inside any string values.`;
 
   const raw = await callOllama(systemPrompt, userContent);
   const parsed = extractJSON<{
+    score: number;
     overall: { strengths: string; weaknesses: string; advice: string };
     improvementTips: string[];
     debateSummary: string;
   }>(raw);
 
   return {
-    score: avgScore,
+    score: Math.max(0, Math.min(100, Math.round(parsed.score ?? 0))),
     overall: parsed.overall,
     improvementTips: (parsed.improvementTips ?? []).slice(0, 3),
     debateSummary: parsed.debateSummary ?? "",

--- a/lib/interview.ts
+++ b/lib/interview.ts
@@ -258,9 +258,21 @@ Respond with this exact JSON (no other text):
     const match = raw.match(/\{[\s\S]*\}/);
     if (!match) throw new Error("no JSON");
     const parsed = JSON.parse(match[0]) as { question: string; hint: string };
-    const question = parsed.question?.replace(/^(면접관|질문|interviewer|question)\s*:\s*/i, "").trim();
-    return { question: question ?? raw.trim(), hint: parsed.hint ?? "" };
+    const qRaw = typeof parsed.question === "string" ? parsed.question : "";
+    const question = qRaw.replace(/^(면접관|질문|interviewer|question)\s*:\s*/i, "").trim();
+    const hint = typeof parsed.hint === "string" ? parsed.hint : "";
+    if (question) return { question, hint };
+    throw new Error("empty question");
   } catch {
+    // Regex fallback: extract "question" value directly from raw string
+    const qMatch = raw.match(/"question"\s*:\s*"((?:[^"\\]|\\.)*)"/);
+    const hMatch = raw.match(/"hint"\s*:\s*"((?:[^"\\]|\\.)*)"/);
+    if (qMatch?.[1]) {
+      return {
+        question: qMatch[1].replace(/^(면접관|질문|interviewer|question)\s*:\s*/i, "").trim(),
+        hint: hMatch?.[1] ?? "",
+      };
+    }
     return { question: raw.replace(/^(면접관|질문|interviewer|question)\s*:\s*/i, "").trim(), hint: "" };
   }
 }
@@ -312,9 +324,17 @@ Respond with this exact JSON:
     const match = raw.match(/\{[\s\S]*\}/);
     if (!match) return null;
     const parsed = JSON.parse(match[0]) as { shouldFollowUp: boolean; question: string; hint: string };
-    if (!parsed.shouldFollowUp || !parsed.question?.trim()) return null;
-    return { question: parsed.question.trim(), hint: parsed.hint ?? "" };
+    if (!parsed.shouldFollowUp) return null;
+    const q = typeof parsed.question === "string" ? parsed.question.trim() : "";
+    if (!q) return null;
+    return { question: q, hint: typeof parsed.hint === "string" ? parsed.hint : "" };
   } catch {
-    return null;
+    // Regex fallback
+    const followUpMatch = raw.match(/"shouldFollowUp"\s*:\s*(true|false)/);
+    if (followUpMatch?.[1] !== "true") return null;
+    const qMatch = raw.match(/"question"\s*:\s*"((?:[^"\\]|\\.)*)"/);
+    const hMatch = raw.match(/"hint"\s*:\s*"((?:[^"\\]|\\.)*)"/);
+    if (!qMatch?.[1]) return null;
+    return { question: qMatch[1].trim(), hint: hMatch?.[1] ?? "" };
   }
 }


### PR DESCRIPTION
## Summary

- 토론 진행 중 에이전트 의견을 채팅 형태로 순차 실시간 표시 (Round 0 평가 → 시스템 메시지 → Round 1 상호 반론)
- 토론 완료 후 자동 전환 대신 **"최종 평가 보기"** 버튼으로 직접 이동
- 결과 화면에서 **"← 면접관 토론 돌아보기"** 버튼으로 채팅 화면 복원 (CSS hidden으로 상태 보존)
- Round 0/1 API를 병렬 → 순차 처리로 변경해 에이전트별 즉시 표시 가능하도록 개선
- `lib/interview.ts` JSON 파싱 실패 시 정규식 폴백 추가 (raw JSON이 질문으로 출력되는 버그 수정)
- DebateResult 하이라이트 `**` 마크다운 제거

## Changes

| 파일 | 변경 내용 |
|------|---------|
| `app/api/interview/debate/route.ts` | Round 0/1 순차 처리 + 에이전트별 즉시 Supabase 저장 |
| `components/DebateLoading.tsx` | 채팅 UI, 타이핑 인디케이터, 큐 시스템, 최종 평가 버튼 |
| `components/DebateResult.tsx` | 뒤로가기 버튼, `**` 제거 |
| `components/InterviewSession.tsx` | debating/done 페이즈 통합, CSS hidden으로 상태 보존 |
| `lib/interview.ts` | JSON 파싱 정규식 폴백 |

## Test plan

- [ ] 이지 모드로 면접 완주 후 토론 채팅 UI 확인
- [ ] Round 0 (3개), 시스템 메시지, Round 1 (6개) 순차 표시 확인
- [ ] 타이핑 인디케이터 + 아바타 + 스탠스 배지(동의/반박/부분동의) 확인
- [ ] 토론 완료 후 "최종 평가 보기" 버튼 표시 확인
- [ ] 결과 화면에서 "← 면접관 토론 돌아보기" 클릭 시 채팅 화면 복원 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)