### PR TITLE
feat: 채용공고 입력/분석 페이지 분리 + 편집 기능 추가

### DIFF
--- a/app/job-posting/edit/loading.tsx
+++ b/app/job-posting/edit/loading.tsx
@@ -1,0 +1,21 @@
+export default function JobPostingEditLoading() {
+  return (
+    <main className="min-h-screen py-8 px-4">
+      <div className="max-w-3xl mx-auto space-y-6">
+        <div className="space-y-2">
+          <div className="h-4 w-32 bg-gray-200 dark:bg-slate-700 rounded animate-pulse" />
+          <div className="h-8 w-64 bg-gray-200 dark:bg-slate-700 rounded animate-pulse" />
+          <div className="h-4 w-48 bg-gray-200 dark:bg-slate-700 rounded animate-pulse" />
+        </div>
+        <div className="card p-5 space-y-4">
+          {[1, 2, 3].map((i) => (
+            <div key={i} className="space-y-2">
+              <div className="h-4 w-20 bg-gray-200 dark:bg-slate-700 rounded animate-pulse" />
+              <div className="h-24 bg-gray-200 dark:bg-slate-700 rounded-xl animate-pulse" />
+            </div>
+          ))}
+        </div>
+      </div>
+    </main>
+  );
+}

--- a/app/job-posting/edit/page.tsx
+++ b/app/job-posting/edit/page.tsx
@@ -1,0 +1,47 @@
+import { supabase } from "@/lib/supabase";
+import { getAuthUser } from "@/lib/auth";
+import JobPostingEditForm from "@/components/JobPostingEditForm";
+import { redirect } from "next/navigation";
+
+async function getJobPosting() {
+  const userId = await getAuthUser();
+  if (!userId) return null;
+
+  const { data: rows } = await supabase
+    .from("job_postings")
+    .select("responsibilities, requirements, preferredQuals")
+    .eq("userId", userId)
+    .order("updatedAt", { ascending: false })
+    .limit(1);
+
+  return rows?.[0] ?? null;
+}
+
+export default async function JobPostingEditPage() {
+  const userId = await getAuthUser();
+  if (!userId) redirect("/login");
+
+  const jobPosting = await getJobPosting();
+
+  const initialData = {
+    responsibilities: jobPosting?.responsibilities ?? "",
+    requirements:     jobPosting?.requirements     ?? "",
+    preferredQuals:   jobPosting?.preferredQuals   ?? "",
+  };
+
+  return (
+    <main className="min-h-screen py-8 px-4">
+      <div className="max-w-3xl mx-auto space-y-6">
+        <div className="space-y-1">
+          <div className="flex items-center gap-2 text-xs text-gray-500 dark:text-slate-400">
+            <span className="bg-blue-600 text-white font-bold px-2 py-0.5 rounded-md">3 / 3</span>
+            <span>채용공고 확인</span>
+          </div>
+          <h1 className="text-2xl font-bold text-gray-900 dark:text-slate-50">분석 결과를 확인해주세요</h1>
+          <p className="text-sm text-gray-500 dark:text-slate-400">내용을 직접 수정하거나 보완할 수 있습니다</p>
+        </div>
+        <JobPostingEditForm initialData={initialData} />
+      </div>
+    </main>
+  );
+}

--- a/app/job-posting/page.tsx
+++ b/app/job-posting/page.tsx
@@ -1,24 +1,6 @@
-import { supabase } from "@/lib/supabase";
-import { getAuthUser } from "@/lib/auth";
 import JobPostingForm from "@/components/JobPostingForm";
 
-async function getJobPostingData() {
-  const userId = await getAuthUser();
-  if (!userId) return null;
-
-  const { data: rows } = await supabase
-    .from("job_postings")
-    .select("*")
-    .eq("userId", userId)
-    .order("updatedAt", { ascending: false })
-    .limit(1);
-
-  return rows?.[0] ?? null;
-}
-
-export default async function JobPostingPage() {
-  const jobPosting = await getJobPostingData();
-
+export default function JobPostingPage() {
   return (
     <main className="min-h-screen py-8 px-4">
       <div className="max-w-3xl mx-auto space-y-6">
@@ -30,7 +12,7 @@ export default async function JobPostingPage() {
           <h1 className="text-2xl font-bold text-gray-900 dark:text-slate-50">채용공고를 입력해주세요</h1>
           <p className="text-sm text-gray-500 dark:text-slate-400">채용공고 링크를 입력하면 AI가 자동으로 분석합니다</p>
         </div>
-        <JobPostingForm initialData={jobPosting} />
+        <JobPostingForm />
       </div>
     </main>
   );

--- a/components/JobPostingEditForm.tsx
+++ b/components/JobPostingEditForm.tsx
@@ -1,0 +1,95 @@
+"use client";
+
+import { useState } from "react";
+import Link from "next/link";
+import { useRouter } from "nextjs-toploader/app";
+
+interface Props {
+  initialData: {
+    responsibilities: string;
+    requirements: string;
+    preferredQuals: string;
+  };
+}
+
+const FIELDS = [
+  { key: "responsibilities" as const, label: "담당업무", required: true, placeholder: "주요 업무 내용을 입력하세요" },
+  { key: "requirements"     as const, label: "지원자격", required: true, placeholder: "필수 자격 요건을 입력하세요" },
+  { key: "preferredQuals"   as const, label: "우대사항", required: false, placeholder: "우대 사항을 입력하세요 (선택)" },
+];
+
+export default function JobPostingEditForm({ initialData }: Props) {
+  const router = useRouter();
+  const [fields, setFields] = useState(initialData);
+  const [isLoading, setIsLoading] = useState(false);
+  const [errorMessage, setErrorMessage] = useState("");
+
+  async function handleSave() {
+    if (!fields.responsibilities.trim() || !fields.requirements.trim()) return;
+
+    setIsLoading(true);
+    setErrorMessage("");
+
+    try {
+      const res = await fetch("/api/job-posting/manual", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          responsibilities: fields.responsibilities.trim(),
+          requirements: fields.requirements.trim(),
+          preferredQuals: fields.preferredQuals.trim(),
+        }),
+      });
+      const data = await res.json();
+      if (!res.ok) {
+        setErrorMessage(data.error ?? "저장에 실패했습니다");
+        return;
+      }
+      router.push("/interview");
+    } catch {
+      setErrorMessage("네트워크 오류가 발생했습니다");
+    } finally {
+      setIsLoading(false);
+    }
+  }
+
+  return (
+    <div className="space-y-4">
+      <div className="card p-5 space-y-4">
+        {FIELDS.map(({ key, label, required, placeholder }) => (
+          <div key={key} className="space-y-1">
+            <label className="text-sm font-medium text-gray-700 dark:text-slate-300">
+              {label}{required && <span className="text-red-500 ml-0.5">*</span>}
+            </label>
+            <textarea
+              value={fields[key]}
+              onChange={(e) => setFields((prev) => ({ ...prev, [key]: e.target.value }))}
+              placeholder={placeholder}
+              rows={4}
+              className="input resize-none"
+            />
+          </div>
+        ))}
+
+        {errorMessage && (
+          <div className="bg-red-50 border border-red-100 text-red-600 text-sm rounded-xl px-4 py-3 dark:bg-red-900/30 dark:border-red-800 dark:text-red-400">
+            {errorMessage}
+          </div>
+        )}
+      </div>
+
+      <div className="flex items-center justify-between gap-3">
+        <Link href="/job-posting" className="btn-secondary">
+          ← 다시 입력
+        </Link>
+        <button
+          onClick={handleSave}
+          disabled={isLoading || !fields.responsibilities.trim() || !fields.requirements.trim()}
+          className="btn-primary disabled:opacity-50"
+        >
+          {isLoading ? "저장 중..." : "면접 시작하기 →"}
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/components/JobPostingForm.tsx
+++ b/components/JobPostingForm.tsx
@@ -2,59 +2,21 @@
 
 import { useState } from "react";
 import Link from "next/link";
+import { useRouter } from "nextjs-toploader/app";
 
-interface AnalysisResult {
-  responsibilities: string;
-  requirements:     string;
-  preferredQuals:   string;
-}
-
-interface InitialData {
-  sourceUrl?:        string | null;
-  responsibilities?: string | null;
-  requirements?:     string | null;
-  preferredQuals?:   string | null;
-}
-
-export default function JobPostingForm({ initialData }: { initialData?: InitialData | null }) {
-  const [url, setUrl] = useState(initialData?.sourceUrl ?? "");
-  const [status, setStatus] = useState<"idle" | "loading" | "success" | "error">("idle");
+export default function JobPostingForm() {
+  const router = useRouter();
+  const [url, setUrl] = useState("");
+  const [status, setStatus] = useState<"idle" | "loading" | "error">("idle");
   const [errorMessage, setErrorMessage] = useState("");
-  const [analysis, setAnalysis] = useState<AnalysisResult | null>(
-    initialData?.responsibilities
-      ? {
-          responsibilities: initialData.responsibilities ?? "",
-          requirements:     initialData.requirements     ?? "",
-          preferredQuals:   initialData.preferredQuals   ?? "",
-        }
-      : null
-  );
-  const [manualMode, setManualMode] = useState(false);
-  const [manualFields, setManualFields] = useState({
-    responsibilities: "",
-    requirements: "",
-    preferredQuals: "",
-  });
-  const [manualLoading, setManualLoading] = useState(false);
 
-  function enterManualMode() {
-    setManualMode(true);
-    setErrorMessage("");
-    if (analysis) {
-      setManualFields({
-        responsibilities: analysis.responsibilities,
-        requirements:     analysis.requirements,
-        preferredQuals:   analysis.preferredQuals,
-      });
-    }
-  }
+  const isLoading = status === "loading";
 
   async function handleAnalyze() {
     if (!url.trim()) return;
 
     setStatus("loading");
     setErrorMessage("");
-    setAnalysis(null);
 
     try {
       const saveRes = await fetch("/api/job-posting", {
@@ -70,63 +32,21 @@ export default function JobPostingForm({ initialData }: { initialData?: InitialD
       }
 
       const analyzeRes = await fetch("/api/job-posting/analyze", { method: "POST" });
-      const analyzeData = await analyzeRes.json();
       if (!analyzeRes.ok) {
-        setErrorMessage(analyzeData.error ?? "분석에 실패했습니다");
-        setStatus("error");
+        // 분석 실패해도 편집 페이지로 이동 (빈 폼으로)
+        router.push("/job-posting/edit");
         return;
       }
 
-      setAnalysis({
-        responsibilities: analyzeData.jobPosting.responsibilities ?? "",
-        requirements:     analyzeData.jobPosting.requirements     ?? "",
-        preferredQuals:   analyzeData.jobPosting.preferredQuals   ?? "",
-      });
-      setStatus("success");
+      router.push("/job-posting/edit");
     } catch {
       setErrorMessage("네트워크 오류가 발생했습니다");
       setStatus("error");
     }
   }
 
-  async function handleManualSave() {
-    if (!manualFields.responsibilities.trim() || !manualFields.requirements.trim()) return;
-
-    setManualLoading(true);
-    try {
-      const res = await fetch("/api/job-posting/manual", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({
-          responsibilities: manualFields.responsibilities.trim(),
-          requirements: manualFields.requirements.trim(),
-          preferredQuals: manualFields.preferredQuals.trim(),
-        }),
-      });
-      const data = await res.json();
-      if (!res.ok) {
-        setErrorMessage(data.error ?? "저장에 실패했습니다");
-        return;
-      }
-      setAnalysis({
-        responsibilities: data.jobPosting.responsibilities ?? "",
-        requirements:     data.jobPosting.requirements     ?? "",
-        preferredQuals:   data.jobPosting.preferredQuals   ?? "",
-      });
-      setManualMode(false);
-      setStatus("success");
-    } catch {
-      setErrorMessage("네트워크 오류가 발생했습니다");
-    } finally {
-      setManualLoading(false);
-    }
-  }
-
-  const isLoading = status === "loading";
-
   return (
     <div className="space-y-4">
-      {/* URL 입력 */}
       <div className="card p-5 space-y-4">
         <div className="space-y-2">
           <label className="text-sm font-medium text-gray-700 dark:text-slate-300">채용공고 URL</label>
@@ -147,65 +67,21 @@ export default function JobPostingForm({ initialData }: { initialData?: InitialD
             {errorMessage}
           </div>
         )}
-
-        {!manualMode && (
-          <button
-            onClick={enterManualMode}
-            className="w-full text-sm text-blue-600 dark:text-blue-400 border border-blue-200 dark:border-blue-800 rounded-xl py-2 hover:bg-blue-50 dark:hover:bg-blue-900/20 transition-colors"
-          >
-            직접 입력하기
-          </button>
-        )}
       </div>
 
-      {/* 수동 입력 폼 */}
-      {manualMode && (
-        <div className="card p-5 space-y-4">
-          <div className="flex items-center justify-between">
-            <h2 className="text-base font-semibold text-gray-900 dark:text-slate-100">직접 입력</h2>
-            <button
-              onClick={() => { setManualMode(false); setStatus("idle"); setErrorMessage(""); }}
-              className="text-xs text-gray-400 dark:text-slate-500 hover:text-gray-600 dark:hover:text-slate-300"
-            >
-              URL로 다시 시도
-            </button>
+      {isLoading && (
+        <div className="card p-8 text-center space-y-2">
+          <div className="flex justify-center">
+            <svg className="animate-spin h-6 w-6 text-blue-500" viewBox="0 0 24 24" fill="none">
+              <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
+              <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8v8z" />
+            </svg>
           </div>
-          {(
-            [
-              { key: "responsibilities" as const, label: "담당업무", required: true, placeholder: "주요 업무 내용을 입력하세요" },
-              { key: "requirements"     as const, label: "지원자격", required: true, placeholder: "필수 자격 요건을 입력하세요" },
-              { key: "preferredQuals"   as const, label: "우대사항", required: false, placeholder: "우대 사항을 입력하세요 (선택)" },
-            ]
-          ).map(({ key, label, required, placeholder }) => (
-            <div key={key} className="space-y-1">
-              <label className="text-sm font-medium text-gray-700 dark:text-slate-300">
-                {label}{required && <span className="text-red-500 ml-0.5">*</span>}
-              </label>
-              <textarea
-                value={manualFields[key]}
-                onChange={(e) => setManualFields((prev) => ({ ...prev, [key]: e.target.value }))}
-                placeholder={placeholder}
-                rows={4}
-                className="input resize-none"
-              />
-            </div>
-          ))}
-          {errorMessage && (
-            <div className="bg-red-50 border border-red-100 text-red-600 text-sm rounded-xl px-4 py-3 dark:bg-red-900/30 dark:border-red-800 dark:text-red-400">
-              {errorMessage}
-            </div>
-          )}
-          <button
-            onClick={handleManualSave}
-            disabled={manualLoading || !manualFields.responsibilities.trim() || !manualFields.requirements.trim()}
-            className="btn-primary w-full disabled:opacity-50"
-          >
-            {manualLoading ? "저장 중..." : "저장하기"}
-          </button>
+          <p className="text-sm text-gray-400 dark:text-slate-500">채용공고를 분석하고 있습니다</p>
+          <p className="text-xs text-gray-300 dark:text-slate-600">최대 2분 정도 소요될 수 있습니다</p>
         </div>
       )}
 
-      {/* 버튼 */}
       <div className="flex items-center justify-between gap-3">
         <Link href="/settings" className="btn-secondary">
           ← 프로필 수정
@@ -226,55 +102,6 @@ export default function JobPostingForm({ initialData }: { initialData?: InitialD
           ) : "분석하기"}
         </button>
       </div>
-
-      {/* 로딩 */}
-      {isLoading && (
-        <div className="card p-8 text-center space-y-2">
-          <div className="flex justify-center">
-            <svg className="animate-spin h-6 w-6 text-blue-500" viewBox="0 0 24 24" fill="none">
-              <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
-              <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8v8z" />
-            </svg>
-          </div>
-          <p className="text-sm text-gray-400 dark:text-slate-500">채용공고를 분석하고 있습니다</p>
-          <p className="text-xs text-gray-300 dark:text-slate-600">최대 2분 정도 소요될 수 있습니다</p>
-        </div>
-      )}
-
-      {/* 분석 결과 */}
-      {(status === "success" || (status === "idle" && analysis)) && analysis && (
-        <div className="card p-5 space-y-4">
-          <h2 className="text-base font-semibold text-gray-900 dark:text-slate-100">분석 결과</h2>
-          {(
-            [
-              { key: "responsibilities" as const, label: "담당업무", color: "blue" },
-              { key: "requirements"     as const, label: "지원 자격", color: "indigo" },
-              { key: "preferredQuals"   as const, label: "우대사항", color: "violet" },
-            ]
-          ).map(({ key, label }) => (
-            <div key={key} className="bg-gray-50 dark:bg-slate-700/50 rounded-xl p-4">
-              <p className="text-xs font-semibold text-blue-600 dark:text-blue-400 mb-2">{label}</p>
-              <p className="text-sm text-gray-700 dark:text-slate-300 whitespace-pre-wrap leading-relaxed">
-                {analysis[key] || "해당 내용 없음"}
-              </p>
-            </div>
-          ))}
-          <div className="flex gap-3">
-            <button
-              onClick={enterManualMode}
-              className="flex-1 text-sm border border-gray-200 dark:border-slate-600 text-gray-600 dark:text-slate-300 font-semibold py-3 rounded-xl hover:bg-gray-50 dark:hover:bg-slate-700/50 active:scale-95 transition-all"
-            >
-              수정하기
-            </button>
-            <Link
-              href="/interview"
-              className="flex-1 flex items-center justify-center bg-green-600 text-white font-semibold py-3 rounded-xl hover:bg-green-700 active:scale-95 transition-all text-sm"
-            >
-              면접 시작하기 →
-            </Link>
-          </div>
-        </div>
-      )}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- `/job-posting`: URL 입력 + 분석하기만 담당, 분석 후 `/job-posting/edit`으로 리다이렉트
- `/job-posting/edit`: 분석 결과 확인 및 편집 페이지 (신규)
- 분석 성공/실패 무관하게 편집 페이지에서 항상 내용 수정 가능
- 분석 실패 시 빈 폼으로 편집 페이지 이동

Closes #37

🤖 Generated with [Claude Code](https://claude.com/claude-code)