### PR TITLE
feat: 프로필 학력 입력 학사/석사/박사 구분 추가

### DIFF
--- a/components/ProfileForm.tsx
+++ b/components/ProfileForm.tsx
@@ -7,6 +7,7 @@ interface Education {
   id?: string;
   schoolName: string;
   major: string;
+  degree: "학사" | "석사" | "박사";
   startDate: string;
   endDate?: string | null;
   graduationStatus: "재학중" | "졸업" | "졸업예정" | "중퇴" | "휴학중";
@@ -38,14 +39,14 @@ interface Activity {
 
 interface InitialData {
   name?: string;
-  educations?: Array<Omit<Education, "graduationStatus"> & { graduationStatus: string }>;
+  educations?: Array<Omit<Education, "graduationStatus" | "degree"> & { graduationStatus: string; degree?: string | null }>;
   careers?: Career[];
   certifications?: Certification[];
   activities?: Activity[];
 }
 
 function newEducation(): Education {
-  return { schoolName: "", major: "", startDate: "", endDate: "", graduationStatus: "재학중" };
+  return { schoolName: "", major: "", degree: "학사", startDate: "", endDate: "", graduationStatus: "재학중" };
 }
 function newCareer(): Career {
   return { companyName: "", role: "", startDate: "", endDate: "", description: "" };
@@ -60,7 +61,11 @@ function newActivity(): Activity {
 export default function ProfileForm({ name, initialData }: { name: string; initialData?: InitialData | null }) {
   const [educations, setEducations] = useState<Education[]>(
     initialData?.educations?.length
-      ? initialData.educations.map((e) => ({ ...e, graduationStatus: e.graduationStatus as Education["graduationStatus"] }))
+      ? initialData.educations.map((e) => ({
+          ...e,
+          degree: (e.degree as Education["degree"]) ?? "학사",
+          graduationStatus: e.graduationStatus as Education["graduationStatus"],
+        }))
       : []
   );
   const [careers, setCareers] = useState<Career[]>(initialData?.careers ?? []);
@@ -126,16 +131,21 @@ export default function ProfileForm({ name, initialData }: { name: string; initi
               <Field label="전공">
                 <input type="text" value={edu.major} onChange={(e) => setEducations((p) => p.map((item, idx) => idx === i ? { ...item, major: e.target.value } : item))} placeholder="컴퓨터공학" className="input" />
               </Field>
-              <Field label="입학일">
-                <input type="month" value={edu.startDate} onChange={(e) => setEducations((p) => p.map((item, idx) => idx === i ? { ...item, startDate: e.target.value } : item))} className="input" />
-              </Field>
-              <Field label="졸업일">
-                <input type="month" value={edu.endDate ?? ""} onChange={(e) => setEducations((p) => p.map((item, idx) => idx === i ? { ...item, endDate: e.target.value } : item))} className="input" />
+              <Field label="학위">
+                <select value={edu.degree} onChange={(e) => setEducations((p) => p.map((item, idx) => idx === i ? { ...item, degree: e.target.value as Education["degree"] } : item))} className="input">
+                  {["학사", "석사", "박사"].map((d) => <option key={d} value={d}>{d}</option>)}
+                </select>
               </Field>
               <Field label="졸업상태">
                 <select value={edu.graduationStatus} onChange={(e) => setEducations((p) => p.map((item, idx) => idx === i ? { ...item, graduationStatus: e.target.value as Education["graduationStatus"] } : item))} className="input">
                   {["재학중", "졸업", "졸업예정", "중퇴", "휴학중"].map((s) => <option key={s} value={s}>{s}</option>)}
                 </select>
+              </Field>
+              <Field label="입학일">
+                <input type="month" value={edu.startDate} onChange={(e) => setEducations((p) => p.map((item, idx) => idx === i ? { ...item, startDate: e.target.value } : item))} className="input" />
+              </Field>
+              <Field label="졸업일">
+                <input type="month" value={edu.endDate ?? ""} onChange={(e) => setEducations((p) => p.map((item, idx) => idx === i ? { ...item, endDate: e.target.value } : item))} className="input" />
               </Field>
             </div>
           </ItemCard>

--- a/components/SettingsForm.tsx
+++ b/components/SettingsForm.tsx
@@ -8,6 +8,7 @@ interface Education {
   id?: string;
   schoolName: string;
   major: string;
+  degree: "학사" | "석사" | "박사";
   startDate: string;
   endDate?: string | null;
   graduationStatus: "재학중" | "졸업" | "졸업예정" | "중퇴" | "휴학중";
@@ -39,14 +40,14 @@ interface Activity {
 
 interface InitialData {
   name?: string;
-  educations?: Array<Omit<Education, "graduationStatus"> & { graduationStatus: string }>;
+  educations?: Array<Omit<Education, "graduationStatus" | "degree"> & { graduationStatus: string; degree?: string | null }>;
   careers?: Career[];
   certifications?: Certification[];
   activities?: Activity[];
 }
 
 function newEducation(): Education {
-  return { schoolName: "", major: "", startDate: "", endDate: "", graduationStatus: "재학중" };
+  return { schoolName: "", major: "", degree: "학사", startDate: "", endDate: "", graduationStatus: "재학중" };
 }
 function newCareer(): Career {
   return { companyName: "", role: "", startDate: "", endDate: "", description: "" };
@@ -62,7 +63,11 @@ export default function SettingsForm({ initialData }: { initialData: InitialData
   const [name, setName] = useState(initialData.name ?? "");
   const [educations, setEducations] = useState<Education[]>(
     initialData.educations?.length
-      ? initialData.educations.map((e) => ({ ...e, graduationStatus: e.graduationStatus as Education["graduationStatus"] }))
+      ? initialData.educations.map((e) => ({
+          ...e,
+          degree: (e.degree as Education["degree"]) ?? "학사",
+          graduationStatus: e.graduationStatus as Education["graduationStatus"],
+        }))
       : []
   );
   const [careers, setCareers] = useState<Career[]>(initialData.careers ?? []);
@@ -164,6 +169,11 @@ export default function SettingsForm({ initialData }: { initialData: InitialData
               </Field>
               <Field label="전공">
                 <input type="text" value={edu.major} onChange={(e) => setEducations((p) => p.map((item, idx) => idx === i ? { ...item, major: e.target.value } : item))} placeholder="컴퓨터공학" className="input" />
+              </Field>
+              <Field label="학위">
+                <select value={edu.degree} onChange={(e) => setEducations((p) => p.map((item, idx) => idx === i ? { ...item, degree: e.target.value as Education["degree"] } : item))} className="input">
+                  {["학사", "석사", "박사"].map((d) => <option key={d} value={d}>{d}</option>)}
+                </select>
               </Field>
               <Field label="입학일">
                 <input type="month" value={edu.startDate} onChange={(e) => setEducations((p) => p.map((item, idx) => idx === i ? { ...item, startDate: e.target.value } : item))} className="input" />

--- a/lib/schemas.ts
+++ b/lib/schemas.ts
@@ -4,6 +4,9 @@ export const educationSchema = z.object({
   id: z.string().optional(),
   schoolName: z.string().min(1, "학교명을 입력해주세요"),
   major: z.string().min(1, "전공을 입력해주세요"),
+  degree: z.enum(["학사", "석사", "박사"], {
+    errorMap: () => ({ message: "학위를 선택해주세요" }),
+  }),
   startDate: z.string().min(1, "시작일을 입력해주세요"),
   endDate: z.string().optional(),
   graduationStatus: z.enum(["재학중", "졸업", "졸업예정", "중퇴", "휴학중"], {

--- a/types/supabase.ts
+++ b/types/supabase.ts
@@ -121,6 +121,7 @@ export type Database = {
       }
       educations: {
         Row: {
+          degree: string | null
           endDate: string | null
           graduationStatus: string
           id: string
@@ -130,6 +131,7 @@ export type Database = {
           startDate: string
         }
         Insert: {
+          degree?: string | null
           endDate?: string | null
           graduationStatus: string
           id: string
@@ -139,6 +141,7 @@ export type Database = {
           startDate: string
         }
         Update: {
+          degree?: string | null
           endDate?: string | null
           graduationStatus?: string
           id?: string


### PR DESCRIPTION
## Summary
- `educations` 테이블에 `degree` 컬럼 추가 (학사/석사/박사, 기본값 학사)
- Zod 스키마 및 TypeScript 타입 업데이트
- 프로필 학력 입력 폼에 학위 선택 셀렉트 추가

Closes #34

🤖 Generated with [Claude Code](https://claude.com/claude-code)