### PR TITLE
feat: 채용공고 분석 로딩 UX 개선

### DIFF
--- a/app/job-posting/edit/page.tsx
+++ b/app/job-posting/edit/page.tsx
@@ -17,11 +17,16 @@ async function getJobPosting() {
   return rows?.[0] ?? null;
 }
 
-export default async function JobPostingEditPage() {
+export default async function JobPostingEditPage({
+  searchParams,
+}: {
+  searchParams: { analyzing?: string };
+}) {
   const userId = await getAuthUser();
   if (!userId) redirect("/login");
 
-  const jobPosting = await getJobPosting();
+  const isAnalyzing = searchParams.analyzing === "true";
+  const jobPosting = isAnalyzing ? null : await getJobPosting();
 
   const initialData = {
     responsibilities: jobPosting?.responsibilities ?? "",
@@ -37,10 +42,14 @@ export default async function JobPostingEditPage() {
             <span className="bg-blue-600 text-white font-bold px-2 py-0.5 rounded-md">3 / 3</span>
             <span>채용공고 확인</span>
           </div>
-          <h1 className="text-2xl font-bold text-gray-900 dark:text-slate-50">분석 결과를 확인해주세요</h1>
-          <p className="text-sm text-gray-500 dark:text-slate-400">내용을 직접 수정하거나 보완할 수 있습니다</p>
+          <h1 className="text-2xl font-bold text-gray-900 dark:text-slate-50">
+            {isAnalyzing ? "채용공고를 분석하고 있어요" : "분석 결과를 확인해주세요"}
+          </h1>
+          {!isAnalyzing && (
+            <p className="text-sm text-gray-500 dark:text-slate-400">내용이 맞으면 면접을 시작하세요</p>
+          )}
         </div>
-        <JobPostingEditForm initialData={initialData} />
+        <JobPostingEditForm initialData={initialData} isAnalyzing={isAnalyzing} />
       </div>
     </main>
   );

--- a/app/job-posting/page.tsx
+++ b/app/job-posting/page.tsx
@@ -10,7 +10,7 @@ export default function JobPostingPage() {
             <span>채용공고 입력</span>
           </div>
           <h1 className="text-2xl font-bold text-gray-900 dark:text-slate-50">채용공고를 입력해주세요</h1>
-          <p className="text-sm text-gray-500 dark:text-slate-400">채용공고 링크를 입력하면 AI가 자동으로 분석합니다</p>
+          <p className="text-sm text-gray-500 dark:text-slate-400">채용공고를 분석하면 면접관들이 해당 직무에 딱 맞는 질문을 출제할 수 있어요</p>
         </div>
         <JobPostingForm />
       </div>

--- a/components/JobPostingEditForm.tsx
+++ b/components/JobPostingEditForm.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useState, useEffect, useRef } from "react";
 import Link from "next/link";
 import { useRouter } from "nextjs-toploader/app";
 
@@ -10,6 +10,7 @@ interface Props {
     requirements: string;
     preferredQuals: string;
   };
+  isAnalyzing?: boolean;
 }
 
 const FIELDS = [
@@ -18,16 +19,74 @@ const FIELDS = [
   { key: "preferredQuals"   as const, label: "우대사항", required: false, placeholder: "우대 사항을 입력하세요 (선택)" },
 ];
 
-export default function JobPostingEditForm({ initialData }: Props) {
+const ANALYZE_STEPS = [
+  { message: "채용 공고 페이지를 불러오고 있어요...", delay: 0 },
+  { message: "공고 내용을 읽고 있어요...", delay: 8000 },
+  { message: "담당 업무를 파악하고 있어요...", delay: 20000 },
+  { message: "자격 요건을 분석하고 있어요...", delay: 40000 },
+  { message: "거의 다 됐어요...", delay: 70000 },
+];
+
+type Mode = "analyzing" | "view" | "editing";
+
+export default function JobPostingEditForm({ initialData, isAnalyzing = false }: Props) {
   const router = useRouter();
+  const [mode, setMode] = useState<Mode>(isAnalyzing ? "analyzing" : "view");
   const [fields, setFields] = useState(initialData);
-  const [isLoading, setIsLoading] = useState(false);
+  const [stepIndex, setStepIndex] = useState(0);
+  const [fadeIn, setFadeIn] = useState(true);
+  const [isSaving, setIsSaving] = useState(false);
   const [errorMessage, setErrorMessage] = useState("");
+  const analyzeCalledRef = useRef(false);
+
+  // 분석 단계 메시지 타이머
+  useEffect(() => {
+    if (mode !== "analyzing") return;
+    const timers: ReturnType<typeof setTimeout>[] = [];
+
+    ANALYZE_STEPS.forEach((step, i) => {
+      if (i === 0) return;
+      timers.push(
+        setTimeout(() => {
+          setFadeIn(false);
+          setTimeout(() => {
+            setStepIndex(i);
+            setFadeIn(true);
+          }, 300);
+        }, step.delay)
+      );
+    });
+
+    return () => timers.forEach(clearTimeout);
+  }, [mode]);
+
+  // 분석 API 호출 (최초 1회)
+  useEffect(() => {
+    if (mode !== "analyzing" || analyzeCalledRef.current) return;
+    analyzeCalledRef.current = true;
+
+    fetch("/api/job-posting/analyze", { method: "POST" })
+      .then((res) => res.json())
+      .then((data) => {
+        if (data.jobPosting) {
+          setFields({
+            responsibilities: data.jobPosting.responsibilities ?? "",
+            requirements:     data.jobPosting.requirements     ?? "",
+            preferredQuals:   data.jobPosting.preferredQuals   ?? "",
+          });
+        }
+      })
+      .catch(() => {})
+      .finally(() => {
+        setMode("view");
+        router.replace("/job-posting/edit");
+      });
+  }, [mode, router]);
 
   async function handleSave() {
     if (!fields.responsibilities.trim() || !fields.requirements.trim()) return;
 
-    setIsLoading(true);
+    setIsSaving(true);
     setErrorMessage("");
 
     try {
@@ -36,8 +95,8 @@ export default function JobPostingEditForm({ initialData }: Props) {
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
           responsibilities: fields.responsibilities.trim(),
-          requirements: fields.requirements.trim(),
-          preferredQuals: fields.preferredQuals.trim(),
+          requirements:     fields.requirements.trim(),
+          preferredQuals:   fields.preferredQuals.trim(),
         }),
       });
       const data = await res.json();
@@ -45,14 +104,115 @@ export default function JobPostingEditForm({ initialData }: Props) {
         setErrorMessage(data.error ?? "저장에 실패했습니다");
         return;
       }
-      router.push("/interview");
+      setFields({
+        responsibilities: data.jobPosting.responsibilities ?? "",
+        requirements:     data.jobPosting.requirements     ?? "",
+        preferredQuals:   data.jobPosting.preferredQuals   ?? "",
+      });
+      setMode("view");
     } catch {
       setErrorMessage("네트워크 오류가 발생했습니다");
     } finally {
-      setIsLoading(false);
+      setIsSaving(false);
     }
   }
 
+  // 분석 중 UI
+  if (mode === "analyzing") {
+    return (
+      <div className="space-y-3">
+        {/* 로더 + 단계 메시지 */}
+        <div className="card px-6 py-8 flex flex-col items-center gap-5">
+          {/* Toss 스타일 원형 로더 */}
+          <div
+            className="animate-spin"
+            style={{ animationDuration: "1.2s", animationTimingFunction: "linear" }}
+          >
+            <svg viewBox="0 0 44 44" className="w-11 h-11">
+              <circle cx="22" cy="22" r="18" fill="none" stroke="currentColor" strokeWidth="3.5" className="text-gray-100 dark:text-slate-700" />
+              <circle cx="22" cy="22" r="18" fill="none" stroke="#3188ff" strokeWidth="3.5"
+                strokeDasharray="72 41" strokeLinecap="round"
+                style={{ transformOrigin: "center", transform: "rotate(-90deg)" }}
+              />
+            </svg>
+          </div>
+
+          {/* 단계 메시지 */}
+          <div className="text-center" style={{ minHeight: "48px" }}>
+            <p
+              className="text-base font-semibold text-gray-900 dark:text-slate-50 transition-opacity duration-300"
+              style={{ opacity: fadeIn ? 1 : 0 }}
+            >
+              {ANALYZE_STEPS[stepIndex].message}
+            </p>
+            <p className="text-sm text-gray-400 dark:text-slate-500 mt-1">최대 2분 정도 소요될 수 있어요</p>
+          </div>
+        </div>
+
+        {/* 스켈레톤 결과 카드 */}
+        <div className="card p-5 space-y-5">
+          {[80, 65, 50].map((w, i) => (
+            <div key={i} className="space-y-2">
+              <div className="h-2.5 w-12 rounded-full bg-gray-100 dark:bg-slate-700 animate-pulse" />
+              <div className="rounded-xl p-4 bg-gray-50 dark:bg-slate-700/50 space-y-2.5">
+                <div className="h-2 rounded-full bg-gray-100 dark:bg-slate-600 animate-pulse" style={{ width: `${w}%` }} />
+                <div className="h-2 rounded-full bg-gray-100 dark:bg-slate-600 animate-pulse" style={{ width: `${w - 12}%` }} />
+                <div className="h-2 rounded-full bg-gray-100 dark:bg-slate-600 animate-pulse" style={{ width: `${w - 6}%` }} />
+              </div>
+            </div>
+          ))}
+        </div>
+      </div>
+    );
+  }
+
+  // 읽기 전용 UI
+  if (mode === "view") {
+    const isEmpty = !fields.responsibilities && !fields.requirements;
+    return (
+      <div className="space-y-4">
+        <div className="card p-5 space-y-4">
+          {isEmpty ? (
+            <div className="text-center py-6 space-y-1">
+              <p className="text-sm font-medium text-gray-700 dark:text-slate-200">공고 내용을 불러오지 못했어요</p>
+              <p className="text-xs text-gray-400 dark:text-slate-500">아래 편집하기 버튼을 눌러 직접 입력해주세요</p>
+            </div>
+          ) : (
+            FIELDS.map(({ key, label }) => (
+              <div key={key} className="space-y-1">
+                <p className="text-xs font-semibold text-blue-600 dark:text-blue-400">{label}</p>
+                <p className="text-sm text-gray-700 dark:text-slate-300 whitespace-pre-wrap leading-relaxed bg-gray-50 dark:bg-slate-700/50 rounded-xl p-4">
+                  {fields[key] || "해당 내용 없음"}
+                </p>
+              </div>
+            ))
+          )}
+        </div>
+
+        <div className="flex items-center justify-between gap-3">
+          <Link href="/job-posting" className="btn-secondary">
+            ← 다시 입력
+          </Link>
+          <div className="flex gap-2">
+            <button
+              onClick={() => setMode("editing")}
+              className="btn-secondary"
+            >
+              편집하기
+            </button>
+            <Link
+              href="/interview"
+              className="btn-primary"
+            >
+              면접 시작하기 →
+            </Link>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  // 편집 UI
   return (
     <div className="space-y-4">
       <div className="card p-5 space-y-4">
@@ -65,7 +225,7 @@ export default function JobPostingEditForm({ initialData }: Props) {
               value={fields[key]}
               onChange={(e) => setFields((prev) => ({ ...prev, [key]: e.target.value }))}
               placeholder={placeholder}
-              rows={4}
+              rows={8}
               className="input resize-none"
             />
           </div>
@@ -79,15 +239,15 @@ export default function JobPostingEditForm({ initialData }: Props) {
       </div>
 
       <div className="flex items-center justify-between gap-3">
-        <Link href="/job-posting" className="btn-secondary">
-          ← 다시 입력
-        </Link>
+        <button onClick={() => setMode("view")} className="btn-secondary">
+          취소
+        </button>
         <button
           onClick={handleSave}
-          disabled={isLoading || !fields.responsibilities.trim() || !fields.requirements.trim()}
+          disabled={isSaving || !fields.responsibilities.trim() || !fields.requirements.trim()}
           className="btn-primary disabled:opacity-50"
         >
-          {isLoading ? "저장 중..." : "면접 시작하기 →"}
+          {isSaving ? "저장 중..." : "저장하기"}
         </button>
       </div>
     </div>

--- a/components/JobPostingForm.tsx
+++ b/components/JobPostingForm.tsx
@@ -31,14 +31,7 @@ export default function JobPostingForm() {
         return;
       }
 
-      const analyzeRes = await fetch("/api/job-posting/analyze", { method: "POST" });
-      if (!analyzeRes.ok) {
-        // 분석 실패해도 편집 페이지로 이동 (빈 폼으로)
-        router.push("/job-posting/edit");
-        return;
-      }
-
-      router.push("/job-posting/edit");
+      router.push("/job-posting/edit?analyzing=true");
     } catch {
       setErrorMessage("네트워크 오류가 발생했습니다");
       setStatus("error");
@@ -69,19 +62,6 @@ export default function JobPostingForm() {
         )}
       </div>
 
-      {isLoading && (
-        <div className="card p-8 text-center space-y-2">
-          <div className="flex justify-center">
-            <svg className="animate-spin h-6 w-6 text-blue-500" viewBox="0 0 24 24" fill="none">
-              <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
-              <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8v8z" />
-            </svg>
-          </div>
-          <p className="text-sm text-gray-400 dark:text-slate-500">채용공고를 분석하고 있습니다</p>
-          <p className="text-xs text-gray-300 dark:text-slate-600">최대 2분 정도 소요될 수 있습니다</p>
-        </div>
-      )}
-
       <div className="flex items-center justify-between gap-3">
         <Link href="/settings" className="btn-secondary">
           ← 프로필 수정
@@ -97,7 +77,7 @@ export default function JobPostingForm() {
                 <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
                 <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8v8z" />
               </svg>
-              분석 중...
+              이동 중...
             </span>
           ) : "분석하기"}
         </button>


### PR DESCRIPTION
## Summary
- 분석하기 클릭 시 즉시 `/job-posting/edit`으로 이동, 로딩은 편집 페이지에서 표시
- Toss 스타일 원형 로더 + 단계별 메시지 (페이드 전환)
- 결과 카드 구조의 스켈레톤 UI
- 분석 완료 후 읽기 전용 모드, 편집하기 버튼으로 편집 전환
- 분석 실패 시 사용자 친화적 안내 문구
- 채용공고 입력 페이지 설명 문구 개선

Closes #42

🤖 Generated with [Claude Code](https://claude.com/claude-code)