### PR TITLE
feat: 면접 UX 전반 개선 - 단계별 전환 + 평가/토론 분리 + 결과 화면 (Closes #39)

### DIFF
--- a/app/interview/page.tsx
+++ b/app/interview/page.tsx
@@ -39,18 +39,6 @@ export default async function InterviewPage() {
   return (
     <main className="min-h-screen py-8 px-4">
       <div className="max-w-2xl mx-auto space-y-6">
-        <div className="space-y-1">
-          <div className="flex items-center gap-2 text-xs text-gray-500 dark:text-slate-400">
-            <span className="bg-green-600 text-white font-bold px-2 py-0.5 rounded-md">AI 면접</span>
-            <span>맞춤 면접 연습</span>
-          </div>
-          <h1 className="text-2xl font-bold text-gray-900 dark:text-slate-50">
-            {name}님의 면접을 시작합니다
-          </h1>
-          <p className="text-sm text-gray-500 dark:text-slate-400">
-            프로필과 채용공고를 분석한 맞춤형 질문입니다. 실제 면접처럼 답변해보세요.
-          </p>
-        </div>
         <InterviewSession name={name!} />
       </div>
     </main>

--- a/components/DebateLoading.tsx
+++ b/components/DebateLoading.tsx
@@ -25,7 +25,6 @@ type ChatMsg = {
   text: string;
   stance?: "agree" | "disagree" | "partial";
   targetName?: string;
-  isSystem?: boolean;
 };
 
 const AGENT_META: Record<AgentId, { name: string; bgColor: string; color: string; bubble: string }> = {
@@ -51,6 +50,21 @@ const AGENT_META: Record<AgentId, { name: string; bgColor: string; color: string
 
 const AGENT_ORDER: AgentId[] = ["organization", "logic", "technical"];
 
+const EVAL_COLORS: Record<AgentId, { border: string; badge: string }> = {
+  organization: {
+    border: "border-l-purple-300 dark:border-l-purple-700",
+    badge: "bg-purple-100 dark:bg-purple-900/40 text-purple-700 dark:text-purple-300",
+  },
+  logic: {
+    border: "border-l-blue-300 dark:border-l-blue-700",
+    badge: "bg-blue-100 dark:bg-blue-900/40 text-blue-700 dark:text-blue-300",
+  },
+  technical: {
+    border: "border-l-green-300 dark:border-l-green-700",
+    badge: "bg-green-100 dark:bg-green-900/40 text-green-700 dark:text-green-300",
+  },
+};
+
 const STANCE_LABEL: Record<string, { label: string; color: string }> = {
   agree:    { label: "동의",     color: "text-green-600 dark:text-green-400 bg-green-50 dark:bg-green-900/20" },
   disagree: { label: "반박",     color: "text-red-500 dark:text-red-400 bg-red-50 dark:bg-red-900/20" },
@@ -61,6 +75,77 @@ function avatarUrl(seed: string, bgColor: string) {
   return `https://api.dicebear.com/9.x/notionists/svg?seed=${seed}&backgroundColor=${bgColor}`;
 }
 
+// ── 평가 카드 ─────────────────────────────────────────────────────────
+function EvalCard({
+  agentId,
+  evalData,
+  avatarSeeds,
+}: {
+  agentId: AgentId;
+  evalData: AgentEvaluation | undefined;
+  avatarSeeds: Record<AgentId, string>;
+}) {
+  const meta = AGENT_META[agentId];
+  const colors = EVAL_COLORS[agentId];
+
+  if (!evalData) {
+    return (
+      <div className={`card p-5 border-l-4 ${colors.border} space-y-3`}>
+        <div className="flex items-center gap-3">
+          <img
+            src={avatarUrl(avatarSeeds[agentId], meta.bgColor)}
+            alt={meta.name}
+            className="w-10 h-10 rounded-full shrink-0"
+          />
+          <div className="space-y-1">
+            <span className={`text-sm font-semibold ${meta.color}`}>{meta.name}</span>
+            <div className="flex gap-1">
+              <span className="w-1.5 h-1.5 rounded-full bg-gray-300 dark:bg-slate-600 animate-bounce [animation-delay:0ms]" />
+              <span className="w-1.5 h-1.5 rounded-full bg-gray-300 dark:bg-slate-600 animate-bounce [animation-delay:150ms]" />
+              <span className="w-1.5 h-1.5 rounded-full bg-gray-300 dark:bg-slate-600 animate-bounce [animation-delay:300ms]" />
+            </div>
+          </div>
+        </div>
+        <div className="space-y-2">
+          <div className="h-3 bg-gray-100 dark:bg-slate-700 rounded-full w-full" />
+          <div className="h-3 bg-gray-100 dark:bg-slate-700 rounded-full w-4/5" />
+          <div className="h-3 bg-gray-100 dark:bg-slate-700 rounded-full w-3/5" />
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className={`card p-5 border-l-4 ${colors.border} space-y-3 animate-fade-in-up`}>
+      <div className="flex items-center gap-3">
+        <img
+          src={avatarUrl(avatarSeeds[agentId], meta.bgColor)}
+          alt={meta.name}
+          className="w-10 h-10 rounded-full shrink-0"
+        />
+        <div className="space-y-0.5">
+          <span className={`text-xs font-semibold px-2 py-0.5 rounded-full ${colors.badge}`}>
+            {evalData.agentLabel}
+          </span>
+          <p className="text-xs text-gray-400 dark:text-slate-500 pt-0.5">{evalData.criterion}</p>
+        </div>
+      </div>
+      <p className="text-sm text-gray-700 dark:text-slate-300 leading-relaxed">{evalData.opinion}</p>
+      {evalData.highlights.length > 0 && (
+        <ul className="space-y-1">
+          {evalData.highlights.map((h, i) => (
+            <li key={i} className="text-xs text-gray-500 dark:text-slate-400 flex gap-1.5">
+              <span className="text-gray-300 dark:text-slate-600 shrink-0">•</span>
+              {h.replace(/\*\*/g, "")}
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}
+
+// ── 타이핑 인디케이터 ──────────────────────────────────────────────────
 function TypingIndicator({ agentId, avatarSeeds }: { agentId: AgentId; avatarSeeds: Record<AgentId, string> }) {
   const meta = AGENT_META[agentId];
   return (
@@ -81,17 +166,8 @@ function TypingIndicator({ agentId, avatarSeeds }: { agentId: AgentId; avatarSee
   );
 }
 
+// ── 채팅 말풍선 ────────────────────────────────────────────────────────
 function ChatBubble({ msg, avatarSeeds }: { msg: ChatMsg; avatarSeeds: Record<AgentId, string> }) {
-  if (msg.isSystem) {
-    return (
-      <div className="flex items-center gap-3 py-1 animate-fade-in">
-        <div className="flex-1 h-px bg-gray-200 dark:bg-slate-700" />
-        <span className="text-xs text-gray-400 dark:text-slate-500 shrink-0 px-2">{msg.text}</span>
-        <div className="flex-1 h-px bg-gray-200 dark:bg-slate-700" />
-      </div>
-    );
-  }
-
   if (!msg.agentId) return null;
   const meta = AGENT_META[msg.agentId];
 
@@ -103,7 +179,6 @@ function ChatBubble({ msg, avatarSeeds }: { msg: ChatMsg; avatarSeeds: Record<Ag
         className="w-8 h-8 rounded-full shrink-0"
       />
       <div className="flex flex-col gap-1 max-w-[85%]">
-        {/* 이름 + 수신자 + 스탠스 */}
         <div className="flex items-center gap-2 px-1">
           <span className={`text-xs font-semibold ${meta.color}`}>{meta.name}</span>
           {msg.targetName && (
@@ -117,7 +192,6 @@ function ChatBubble({ msg, avatarSeeds }: { msg: ChatMsg; avatarSeeds: Record<Ag
             </span>
           )}
         </div>
-        {/* 말풍선 */}
         <div className={`px-4 py-3 rounded-2xl rounded-bl-sm ${meta.bubble}`}>
           <p className="text-sm text-gray-700 dark:text-slate-200 leading-relaxed">{msg.text}</p>
         </div>
@@ -126,19 +200,20 @@ function ChatBubble({ msg, avatarSeeds }: { msg: ChatMsg; avatarSeeds: Record<Ag
   );
 }
 
+// ── 메인 컴포넌트 ──────────────────────────────────────────────────────
 export default function DebateLoading({ sessionId, avatarSeeds, onDone, onError }: Props) {
   const [currentStatus, setCurrentStatus] = useState("evaluating");
   const [agentEvaluations, setAgentEvaluations] = useState<AgentEvaluation[]>([]);
   const [debateReplies, setDebateReplies] = useState<AgentReply[]>([]);
+  const [viewPhase, setViewPhase] = useState<"evaluating" | "debating">("evaluating");
 
   const [visibleMsgs, setVisibleMsgs] = useState<ChatMsg[]>([]);
   const [typingAgentId, setTypingAgentId] = useState<AgentId | null>(null);
   const [showProceedButton, setShowProceedButton] = useState(false);
 
   const pendingQueue = useRef<ChatMsg[]>([]);
-  const queuedEvalCount = useRef(0);
   const queuedReplyCount = useRef(0);
-  const addedSystemMsg = useRef(false);
+  const transitionStarted = useRef(false);
   const popTimerRef = useRef<ReturnType<typeof setTimeout>>();
   const pollRef = useRef<ReturnType<typeof setInterval>>();
   const bottomRef = useRef<HTMLDivElement>(null);
@@ -159,7 +234,6 @@ export default function DebateLoading({ sessionId, avatarSeeds, onDone, onError 
 
         if (data.status === "done") {
           clearInterval(pollRef.current);
-          // 결과 저장 후 큐가 비면 버튼 표시 (onDone은 버튼 클릭 시 호출)
           pendingResult.current = {
             agentEvaluations: data.agentEvaluations ?? [],
             finalScore: data.finalScore ?? 0,
@@ -168,7 +242,6 @@ export default function DebateLoading({ sessionId, avatarSeeds, onDone, onError 
             improvementTips: data.improvementTips ?? [],
           };
           debateFinishedRef.current = true;
-          // 큐가 이미 비어있으면 즉시 버튼 표시 (모든 메시지가 이미 출력된 경우)
           if (pendingQueue.current.length === 0 && !popTimerRef.current) {
             setShowProceedButton(true);
           }
@@ -184,33 +257,13 @@ export default function DebateLoading({ sessionId, avatarSeeds, onDone, onError 
     return () => clearInterval(pollRef.current);
   }, [sessionId, onError]);
 
-  // Round 0 평가 → 큐 추가
-  useEffect(() => {
-    if (agentEvaluations.length <= queuedEvalCount.current) return;
-    const newEvals = agentEvaluations.slice(queuedEvalCount.current);
-    newEvals.forEach((e) => {
-      pendingQueue.current.push({
-        id: `eval-${e.agentId}`,
-        agentId: e.agentId,
-        text: e.opinion,
-      });
-    });
-    queuedEvalCount.current = agentEvaluations.length;
-    scheduleNext();
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [agentEvaluations]);
-
-  // Round 1 반론 → 큐 추가
+  // 토론 반론 → 큐 추가 + 1.5초 후 토론 뷰 전환
   useEffect(() => {
     if (debateReplies.length <= queuedReplyCount.current) return;
 
-    if (!addedSystemMsg.current) {
-      pendingQueue.current.push({
-        id: "system-debate",
-        isSystem: true,
-        text: "이제 면접관들이 서로 의견을 교환합니다",
-      });
-      addedSystemMsg.current = true;
+    if (!transitionStarted.current) {
+      transitionStarted.current = true;
+      setTimeout(() => setViewPhase("debating"), 1500);
     }
 
     const newReplies = debateReplies.slice(queuedReplyCount.current);
@@ -231,9 +284,8 @@ export default function DebateLoading({ sessionId, avatarSeeds, onDone, onError 
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [debateReplies]);
 
-  // 다음 메시지 팝
   function scheduleNext() {
-    if (popTimerRef.current) return; // 이미 타이머 실행 중
+    if (popTimerRef.current) return;
     popTimerRef.current = setTimeout(popNext, 300);
   }
 
@@ -242,31 +294,21 @@ export default function DebateLoading({ sessionId, avatarSeeds, onDone, onError 
     const next = pendingQueue.current.shift();
     if (!next) {
       setTypingAgentId(null);
-      // 큐 비었고 토론 완료면 버튼 표시
       if (debateFinishedRef.current) setShowProceedButton(true);
       return;
     }
 
-    // 시스템 메시지는 바로 표시, 타이핑 없음
-    if (next.isSystem) {
-      setTypingAgentId(null);
-      setVisibleMsgs((prev) => [...prev, next]);
-      popTimerRef.current = setTimeout(popNext, 800);
-      return;
-    }
-
-    // 다음 에이전트 타이핑 인디케이터 표시
-    const nextAgentId = next.agentId ?? null;
-    setTypingAgentId(nextAgentId);
+    setTypingAgentId(next.agentId ?? null);
 
     popTimerRef.current = setTimeout(() => {
       popTimerRef.current = undefined;
       setTypingAgentId(null);
       setVisibleMsgs((prev) => [...prev, next]);
 
-      // 큐에 더 있으면 이어서
       if (pendingQueue.current.length > 0) {
         popTimerRef.current = setTimeout(popNext, 600);
+      } else if (debateFinishedRef.current) {
+        setShowProceedButton(true);
       }
     }, 1800);
   }
@@ -276,24 +318,57 @@ export default function DebateLoading({ sessionId, avatarSeeds, onDone, onError 
     bottomRef.current?.scrollIntoView({ behavior: "smooth" });
   }, [visibleMsgs, typingAgentId]);
 
-  // 타이핑 에이전트 결정 (큐 없을 때 현재 상태 기반)
-  const nonSystemMsgCount = visibleMsgs.filter((m) => !m.isSystem).length;
+  const isActive = currentStatus !== "done" && currentStatus !== "error";
+  const allEvalsReceived = agentEvaluations.length >= 3;
+
+  // ── 평가 뷰 ──────────────────────────────────────────────────────────
+  if (viewPhase === "evaluating") {
+    return (
+      <div className="space-y-4">
+        <div className="flex items-center gap-2 px-1">
+          <span className="text-sm font-semibold text-gray-700 dark:text-slate-200">📋 개별 평가</span>
+          {isActive && !allEvalsReceived && (
+            <span className="text-xs text-gray-400 dark:text-slate-500">면접관들이 평가 중...</span>
+          )}
+        </div>
+
+        {AGENT_ORDER.map((aid) => {
+          const evalData = agentEvaluations.find((e) => e.agentId === aid);
+          return (
+            <EvalCard key={aid} agentId={aid} evalData={evalData} avatarSeeds={avatarSeeds} />
+          );
+        })}
+
+        {allEvalsReceived && (
+          <div className="text-center py-3 text-sm text-gray-500 dark:text-slate-400 animate-fade-in">
+            ✅ 평가 완료! 의견 교환으로 이동합니다...
+          </div>
+        )}
+      </div>
+    );
+  }
+
+  // ── 토론 뷰 ──────────────────────────────────────────────────────────
   const displayTypingId: AgentId | null =
     typingAgentId ??
-    ((currentStatus === "evaluating" || currentStatus === "debating") && nonSystemMsgCount < 3
-      ? (AGENT_ORDER[nonSystemMsgCount] ?? null)
-      : null);
-
-  const isActive = currentStatus !== "done" && currentStatus !== "error";
+    (currentStatus === "debating" && visibleMsgs.length === 0 ? AGENT_ORDER[0] : null);
 
   return (
     <div className="flex flex-col gap-4">
+      {/* 개별 평가 돌아보기 */}
+      <button
+        onClick={() => setViewPhase("evaluating")}
+        className="flex items-center gap-1.5 text-sm text-gray-400 dark:text-slate-500 hover:text-gray-600 dark:hover:text-slate-300 transition-colors self-start"
+      >
+        ← 개별 평가 돌아보기
+      </button>
+
       {/* 회의실 헤더 */}
       <div className="bg-slate-800 dark:bg-slate-900 rounded-2xl p-4 shadow-lg">
         <div className="flex items-center justify-between mb-3">
           <div className="flex items-center gap-2">
-            <span className="text-base">👁️</span>
-            <span className="text-sm font-semibold text-slate-200">면접관 전용 회의실</span>
+            <span className="text-base">💬</span>
+            <span className="text-sm font-semibold text-slate-200">면접관 의견 교환</span>
           </div>
           {isActive && (
             <div className="flex items-center gap-1.5">
@@ -303,7 +378,7 @@ export default function DebateLoading({ sessionId, avatarSeeds, onDone, onError 
           )}
         </div>
         <div className="flex items-center gap-2">
-          {(["organization", "logic", "technical"] as AgentId[]).map((aid) => (
+          {AGENT_ORDER.map((aid) => (
             <img
               key={aid}
               src={avatarUrl(avatarSeeds[aid], AGENT_META[aid].bgColor)}
@@ -321,7 +396,6 @@ export default function DebateLoading({ sessionId, avatarSeeds, onDone, onError 
           <ChatBubble key={msg.id} msg={msg} avatarSeeds={avatarSeeds} />
         ))}
 
-        {/* 타이핑 인디케이터 */}
         {isActive && displayTypingId && (
           <TypingIndicator agentId={displayTypingId} avatarSeeds={avatarSeeds} />
         )}
@@ -329,14 +403,12 @@ export default function DebateLoading({ sessionId, avatarSeeds, onDone, onError 
         <div ref={bottomRef} />
       </div>
 
-      {/* 소요 시간 안내 */}
       {isActive && (
         <p className="text-xs text-gray-400 dark:text-slate-500 text-center">
           Ollama 모델에 따라 1~3분 소요될 수 있습니다
         </p>
       )}
 
-      {/* 최종 평가 보기 버튼 */}
       {showProceedButton && pendingResult.current && (
         <button
           onClick={() => onDone(pendingResult.current!)}

--- a/components/DebateResult.tsx
+++ b/components/DebateResult.tsx
@@ -14,12 +14,46 @@ interface Props {
 }
 
 function ScoreRing({ score }: { score: number }) {
+  const radius = 52;
+  const stroke = 8;
+  const circumference = 2 * Math.PI * radius;
+  const offset = circumference * (1 - score / 100);
   const color =
+    score >= 80 ? "#22c55e" : score >= 60 ? "#3b82f6" : "#f97316";
+  const textColor =
     score >= 80 ? "text-green-500" : score >= 60 ? "text-blue-500" : "text-orange-500";
+
   return (
-    <div className={`text-5xl font-bold ${color}`}>
-      {score}
-      <span className="text-2xl text-gray-400 dark:text-slate-500 font-normal">/100</span>
+    <div className="flex flex-col items-center gap-3">
+      <div className="relative w-36 h-36">
+        <svg className="w-full h-full -rotate-90" viewBox="0 0 128 128">
+          <circle
+            cx="64" cy="64" r={radius}
+            fill="none"
+            stroke="currentColor"
+            strokeWidth={stroke}
+            className="text-gray-100 dark:text-slate-700"
+          />
+          <circle
+            cx="64" cy="64" r={radius}
+            fill="none"
+            stroke={color}
+            strokeWidth={stroke}
+            strokeLinecap="round"
+            strokeDasharray={circumference}
+            strokeDashoffset={offset}
+            style={{ transition: "stroke-dashoffset 1s ease-out" }}
+          />
+        </svg>
+        <div className="absolute inset-0 flex flex-col items-center justify-center">
+          <span className={`text-4xl font-bold ${textColor}`}>{score}</span>
+          <span className="text-xs text-gray-400 dark:text-slate-500 font-medium">/100</span>
+        </div>
+      </div>
+      <div className="text-center space-y-0.5">
+        <h2 className="text-xl font-bold text-gray-900 dark:text-slate-50">면접 완료!</h2>
+        <p className="text-sm text-gray-500 dark:text-slate-400">3명의 면접관 토론 결과입니다</p>
+      </div>
     </div>
   );
 }
@@ -58,100 +92,115 @@ export default function DebateResult({
         ← 면접관 토론 돌아보기
       </button>
 
-      {/* 최종 점수 */}
-      <div className="card p-6 text-center space-y-3">
-        <h2 className="text-xl font-bold text-gray-900 dark:text-slate-50">면접 완료!</h2>
-        <p className="text-sm text-gray-500 dark:text-slate-400">3명의 면접관 토론 결과입니다</p>
+      {/* 점수 링 */}
+      <div className="card p-8 flex justify-center">
         <ScoreRing score={finalScore} />
       </div>
 
-      {/* 에이전트별 평가 카드 (Round 0 의견) */}
+      {/* 면접관별 평가 — 아코디언 */}
       {agentEvaluations.length > 0 && (
         <div className="space-y-3">
           <h3 className="font-bold text-gray-900 dark:text-slate-50 px-1">면접관별 평가</h3>
           {agentEvaluations.map((e) => {
             const colors = AGENT_COLORS[e.agentId] ?? AGENT_COLORS.organization;
             return (
-              <div key={e.agentId} className={`card p-5 space-y-3 border-l-4 ${colors.border}`}>
-                <div className="flex items-start gap-2">
-                  <div className="space-y-0.5">
-                    <span
-                      className={`text-xs font-semibold px-2 py-0.5 rounded-full ${colors.badge}`}
-                    >
+              <details key={e.agentId} className={`card border-l-4 ${colors.border} group`}>
+                <summary className="p-5 cursor-pointer list-none flex items-center justify-between gap-3">
+                  <div className="flex items-center gap-2">
+                    <span className={`text-xs font-semibold px-2 py-0.5 rounded-full ${colors.badge}`}>
                       {e.agentLabel}
                     </span>
-                    <p className="text-xs text-gray-400 dark:text-slate-500 pt-1">{e.criterion}</p>
+                    <span className="text-xs text-gray-400 dark:text-slate-500">{e.criterion}</span>
                   </div>
+                  <span className="text-gray-400 dark:text-slate-500 text-xs shrink-0">▼</span>
+                </summary>
+                <div className="px-5 pb-5 space-y-3 border-t border-gray-50 dark:border-slate-700/50 pt-4">
+                  <p className="text-sm text-gray-700 dark:text-slate-300 leading-relaxed">{e.opinion}</p>
+                  {e.highlights.length > 0 && (
+                    <ul className="space-y-1">
+                      {e.highlights.map((h, i) => (
+                        <li key={i} className="text-xs text-gray-500 dark:text-slate-400 flex gap-1.5">
+                          <span className="text-gray-300 dark:text-slate-600 shrink-0">•</span>
+                          {h.replace(/\*\*/g, "")}
+                        </li>
+                      ))}
+                    </ul>
+                  )}
                 </div>
-                <p className="text-sm text-gray-700 dark:text-slate-300 leading-relaxed">
-                  {e.opinion}
-                </p>
-                {e.highlights.length > 0 && (
-                  <ul className="space-y-1">
-                    {e.highlights.map((h, i) => (
-                      <li key={i} className="text-xs text-gray-500 dark:text-slate-400 flex gap-1.5">
-                        <span className="text-gray-300 dark:text-slate-600 shrink-0">•</span>
-                        {h.replace(/\*\*/g, "")}
-                      </li>
-                    ))}
-                  </ul>
-                )}
-              </div>
+              </details>
             );
           })}
         </div>
       )}
 
-      {/* 종합 피드백 */}
+      {/* 종합 평가 */}
       <div className="card p-6 space-y-4">
         <h3 className="font-bold text-gray-900 dark:text-slate-50">종합 평가</h3>
-        <div className="space-y-3">
-          <div className="bg-green-50 dark:bg-green-900/20 rounded-xl p-4">
-            <p className="text-xs font-semibold text-green-600 dark:text-green-400 mb-1">강점</p>
-            <p className="text-sm text-gray-700 dark:text-slate-300 leading-relaxed">
+        <div className="space-y-4">
+          <div className="space-y-1.5">
+            <div className="flex items-center gap-2">
+              <span className="text-base">✅</span>
+              <span className="text-sm font-semibold text-gray-700 dark:text-slate-200">강점</span>
+            </div>
+            <p className="text-sm text-gray-600 dark:text-slate-300 leading-relaxed pl-6">
               {finalFeedback.strengths}
             </p>
           </div>
-          <div className="bg-orange-50 dark:bg-orange-900/20 rounded-xl p-4">
-            <p className="text-xs font-semibold text-orange-600 dark:text-orange-400 mb-1">약점</p>
-            <p className="text-sm text-gray-700 dark:text-slate-300 leading-relaxed">
+          <div className="h-px bg-gray-100 dark:bg-slate-700" />
+          <div className="space-y-1.5">
+            <div className="flex items-center gap-2">
+              <span className="text-base">⚠️</span>
+              <span className="text-sm font-semibold text-gray-700 dark:text-slate-200">약점</span>
+            </div>
+            <p className="text-sm text-gray-600 dark:text-slate-300 leading-relaxed pl-6">
               {finalFeedback.weaknesses}
             </p>
           </div>
-          <div className="bg-blue-50 dark:bg-blue-900/20 rounded-xl p-4">
-            <p className="text-xs font-semibold text-blue-600 dark:text-blue-400 mb-1">핵심 조언</p>
-            <p className="text-sm text-gray-700 dark:text-slate-300 leading-relaxed">
+          <div className="h-px bg-gray-100 dark:bg-slate-700" />
+          <div className="space-y-1.5">
+            <div className="flex items-center gap-2">
+              <span className="text-base">💡</span>
+              <span className="text-sm font-semibold text-gray-700 dark:text-slate-200">핵심 조언</span>
+            </div>
+            <p className="text-sm text-gray-600 dark:text-slate-300 leading-relaxed pl-6">
               {finalFeedback.advice}
             </p>
           </div>
         </div>
       </div>
 
-      {/* 개선 코멘트 */}
+      {/* 개선 포인트 */}
       {improvementTips.length > 0 && (
         <div className="card p-6 space-y-3">
           <h3 className="font-bold text-gray-900 dark:text-slate-50">개선 포인트</h3>
-          <ul className="space-y-2">
+          <ul className="space-y-3">
             {improvementTips.map((tip, i) => (
-              <li key={i} className="flex gap-2 text-sm text-gray-700 dark:text-slate-300">
-                <span className="text-blue-500 font-bold shrink-0">{i + 1}.</span>
-                {tip}
+              <li key={i} className="flex gap-3 text-sm text-gray-700 dark:text-slate-300">
+                <span className="w-6 h-6 rounded-full bg-blue-100 dark:bg-blue-900/40 text-blue-600 dark:text-blue-300 text-xs font-bold flex items-center justify-center shrink-0 mt-0.5">
+                  {i + 1}
+                </span>
+                <span className="leading-relaxed">{tip}</span>
               </li>
             ))}
           </ul>
         </div>
       )}
 
-      {/* 토론 요약 */}
+      {/* 토론 요약 — 기본 접힘 */}
       {debateSummary && (
-        <div className="card p-5 space-y-2 bg-gray-50 dark:bg-slate-800/50">
-          <h3 className="text-sm font-semibold text-gray-600 dark:text-slate-400">면접관 토론 요약</h3>
-          <p className="text-sm text-gray-600 dark:text-slate-400 leading-relaxed">{debateSummary}</p>
-        </div>
+        <details className="card overflow-hidden">
+          <summary className="p-5 cursor-pointer list-none flex items-center justify-between gap-3 text-sm font-semibold text-gray-600 dark:text-slate-400">
+            <span>면접관 토론 요약</span>
+            <span className="text-gray-400 dark:text-slate-500 text-xs">▼</span>
+          </summary>
+          <div className="px-5 pb-5 border-t border-gray-50 dark:border-slate-700/50 pt-4">
+            <p className="text-sm text-gray-600 dark:text-slate-400 leading-relaxed">{debateSummary}</p>
+          </div>
+        </details>
       )}
 
       {/* 액션 버튼 */}
-      <div className="flex flex-col sm:flex-row gap-3">
+      <div className="flex flex-col gap-3">
         <a href="/job-posting" className="btn-secondary text-center">
           채용공고 변경
         </a>

--- a/components/InterviewSession.tsx
+++ b/components/InterviewSession.tsx
@@ -17,7 +17,7 @@ import DebateResult from "@/components/DebateResult";
 
 const ANSWER_TIME_LIMIT = 80;
 
-type Phase = "selecting" | "interviewing" | "debating" | "done";
+type Phase = "selecting" | "interviewing" | "finished" | "debating" | "done";
 
 async function fetchQuestion(
   messages: Message[],
@@ -240,6 +240,7 @@ export default function InterviewSession({ name }: { name: string }) {
   });
 
   const [messages, setMessages] = useState<Message[]>([]);
+  const [finishedMessages, setFinishedMessages] = useState<Message[]>([]);
   const [currentHint, setCurrentHint] = useState("");
   const [hintVisible, setHintVisible] = useState(false);
   const [answer, setAnswer] = useState("");
@@ -330,14 +331,10 @@ export default function InterviewSession({ name }: { name: string }) {
     const nextAgentIndex = agentIndex + 1;
 
     if (nextAgentIndex >= TOTAL_AGENTS) {
-      // 면접 종료 → 토론 시작
-      setPhase("debating");
-      try {
-        const sid = await startDebate(currentMessages, difficulty);
-        setSessionId(sid);
-      } catch (e: unknown) {
-        setDebateError(e instanceof Error ? e.message : "토론을 시작할 수 없습니다");
-      }
+      // 면접 종료 → 800ms 대기 후 finished 카드 표시
+      setFinishedMessages(currentMessages);
+      await new Promise((resolve) => setTimeout(resolve, 800));
+      setPhase("finished");
       return;
     }
 
@@ -368,11 +365,49 @@ export default function InterviewSession({ name }: { name: string }) {
     setSessionId(null);
     setDebateResult(null);
     setDebateError("");
+    setFinishedMessages([]);
   }
 
   // 난이도 선택
   if (phase === "selecting") {
-    return <DifficultySelect onSelect={handleDifficultySelect} />;
+    return (
+      <div className="space-y-6">
+        <div className="space-y-1">
+          <h1 className="text-2xl font-bold text-gray-900 dark:text-slate-50">{name}님의 맞춤 면접</h1>
+          <p className="text-sm text-gray-500 dark:text-slate-400">
+            프로필과 채용공고를 분석한 맞춤형 질문입니다. 실제 면접처럼 답변해보세요.
+          </p>
+        </div>
+        <DifficultySelect onSelect={handleDifficultySelect} />
+      </div>
+    );
+  }
+
+  // 면접 완료 카드
+  if (phase === "finished") {
+    return (
+      <div className="card flex flex-col items-center py-16 px-6 space-y-5 text-center animate-fade-in-up">
+        <div className="text-4xl">🎉</div>
+        <div className="space-y-2">
+          <h2 className="text-xl font-bold text-gray-900 dark:text-slate-50">면접이 완료되었습니다!</h2>
+          <p className="text-sm text-gray-500 dark:text-slate-400">3명의 면접관이 답변을 종합 평가합니다</p>
+        </div>
+        <button
+          onClick={async () => {
+            setPhase("debating");
+            try {
+              const sid = await startDebate(finishedMessages, difficulty);
+              setSessionId(sid);
+            } catch (e: unknown) {
+              setDebateError(e instanceof Error ? e.message : "토론을 시작할 수 없습니다");
+            }
+          }}
+          className="btn-primary mt-2"
+        >
+          면접관 평가 시작하기 →
+        </button>
+      </div>
+    );
   }
 
   // 토론 중 or 결과 화면 (DebateLoading은 항상 마운트 유지 — 뒤로가기 시 상태 보존)
@@ -463,6 +498,13 @@ export default function InterviewSession({ name }: { name: string }) {
 
   return (
     <div className="space-y-4">
+      {/* 진행 상황 */}
+      <div className="flex items-center gap-2 text-xs text-gray-400 dark:text-slate-500 px-1">
+        <span className="font-medium">면접 진행 중</span>
+        <span>·</span>
+        <span>면접관 {agentIndex + 1} / {TOTAL_AGENTS}</span>
+      </div>
+
       {/* 면접관 패널 */}
       <InterviewerPanel agentIndex={agentIndex} isLoading={isLoading} isSpeaking={isSpeaking} avatarSeeds={avatarSeeds} />
 

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -26,12 +26,17 @@ const config: Config = {
         "card-md": "0 4px 6px -1px rgb(0 0 0 / 0.07), 0 2px 4px -2px rgb(0 0 0 / 0.07)",
       },
       keyframes: {
+        "fade-in": {
+          "0%": { opacity: "0" },
+          "100%": { opacity: "1" },
+        },
         "fade-in-up": {
           "0%": { opacity: "0", transform: "translateY(10px)" },
           "100%": { opacity: "1", transform: "translateY(0)" },
         },
       },
       animation: {
+        "fade-in": "fade-in 0.3s ease-out",
         "fade-in-up": "fade-in-up 0.4s ease-out",
       },
     },


### PR DESCRIPTION
## Summary

- **면접 종료 전환**: 마지막 답변 제출 후 800ms 유지 → '면접 완료!' 카드 fade-in (갑작스러운 전환 제거)
- **페이즈별 헤더**: 정적 헤더 제거, selecting/interviewing 각각 맞는 헤더 표시
- **평가/토론 뷰 분리**: DebateLoading을 EvalCard(개별 평가) → 1.5초 후 채팅(의견 교환) 순서로 물리적 분리
- **결과 화면 개선**: SVG 원형 점수 링, 면접관 평가 아코디언, 종합 평가 아이콘+구분선, 번호 배지, 토론 요약 접기

## 변경 파일

| 파일 | 변경 내용 |
|------|-----------|
| `app/interview/page.tsx` | 정적 헤더 제거 |
| `components/InterviewSession.tsx` | finished 페이즈 추가 + 페이즈별 헤더 |
| `components/DebateLoading.tsx` | 평가/토론 뷰 분리, EvalCard 신규 |
| `components/DebateResult.tsx` | 결과 화면 레이아웃 전면 개선 |
| `tailwind.config.ts` | animate-fade-in 추가 |

## Test plan

- [ ] 난이도 선택 화면에 이름 포함 헤더 표시 확인
- [ ] 면접 진행 중 'N/3' 진행 상황 표시 확인
- [ ] 마지막 답변 후 800ms 딜레이 → '면접 완료!' 카드 등장 확인
- [ ] '면접관 평가 시작하기' 클릭 → 개별 평가 카드 순차 등장 확인
- [ ] 평가 완료 후 1.5초 뒤 토론 뷰 자동 전환 확인
- [ ] '← 개별 평가 돌아보기' 버튼으로 뒤로가기 확인
- [ ] 결과 화면 SVG 링 / 아코디언 / 접기 동작 확인
- [ ] 다크모드 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)