### PR TITLE
feat: 브라우저/앱 뒤로가기 시 면접 단계별 복귀 처리

### DIFF
--- a/components/InterviewSession.tsx
+++ b/components/InterviewSession.tsx
@@ -262,8 +262,32 @@ export default function InterviewSession({ name }: { name: string }) {
     setAgentIndex(0);
     setFollowUpCount(0);
     setPhase("interviewing");
+    history.pushState({ interviewPhase: "interviewing" }, "");
   }
 
+  function goToPhase(next: Phase) {
+    setPhase(next);
+    if (next !== "selecting") {
+      history.pushState({ interviewPhase: next }, "");
+    }
+  }
+
+  useEffect(() => {
+    const PREV: Partial<Record<Phase, Phase>> = {
+      interviewing: "selecting",
+      finished: "interviewing",
+      debating: "finished",
+      done: "debating",
+    };
+    function handlePopState() {
+      const prev = PREV[phase];
+      if (prev) {
+        setPhase(prev);
+      }
+    }
+    window.addEventListener("popstate", handlePopState);
+    return () => window.removeEventListener("popstate", handlePopState);
+  }, [phase]);
 
   useEffect(() => {
     setTimeLeft(ANSWER_TIME_LIMIT);
@@ -330,7 +354,7 @@ export default function InterviewSession({ name }: { name: string }) {
       // 면접 종료 → 800ms 대기 후 finished 카드 표시
       setFinishedMessages(currentMessages);
       await new Promise((resolve) => setTimeout(resolve, 800));
-      setPhase("finished");
+      goToPhase("finished");
       return;
     }
 
@@ -390,7 +414,7 @@ export default function InterviewSession({ name }: { name: string }) {
         </div>
         <button
           onClick={async () => {
-            setPhase("debating");
+            goToPhase("debating");
             try {
               const sid = await startDebate(finishedMessages, difficulty);
               setSessionId(sid);
@@ -441,7 +465,7 @@ export default function InterviewSession({ name }: { name: string }) {
             avatarSeeds={avatarSeeds}
             onDone={(result) => {
               setDebateResult(result);
-              setPhase("done");
+              goToPhase("done");
             }}
             onError={(msg) => setDebateError(msg)}
           />


### PR DESCRIPTION
## Summary

- 각 단계(interviewing/finished/debating/done) 진입 시 `history.pushState`로 히스토리 엔트리 추가
- `popstate` 핸들러에서 단계별 이전 단계로 복귀: `done→debating→finished→interviewing→selecting`
- `selecting` 단계에서 뒤로가기 시 이전 페이지(채용공고)로 정상 이동
- 앱 브라우저(카카오, 네이버 등) 뒤로가기 버튼에서도 동일하게 동작

## Test plan

- [ ] 난이도 선택 후 뒤로가기 → 난이도 선택 화면으로 복귀
- [ ] 면접 완료 후 뒤로가기 → 면접 화면으로 복귀
- [ ] 평가 시작 후 뒤로가기 → 면접 완료 카드로 복귀
- [ ] 결과 화면에서 뒤로가기 → 토론 화면으로 복귀
- [ ] 난이도 선택 화면에서 뒤로가기 → 채용공고 페이지로 이동

🤖 Generated with [Claude Code](https://claude.com/claude-code)