### PR TITLE
[M2] 평가자 프롬프트를 사적 debrief 톤으로 전환

### DIFF
--- a/lib/agents.ts
+++ b/lib/agents.ts
@@ -78,19 +78,26 @@ export async function generateAgentEvaluation(
   const agent = AGENTS[agentId];
   const conversationText = buildConversationText(messages);
 
-  const systemPrompt = `You are ${agent.label}, an expert interviewer evaluating a job interview. Your evaluation criteria: ${agent.criterion}. Always respond with valid JSON only — no extra text.`;
+  const systemPrompt = `당신은 ${agent.label}입니다. 면접이 방금 끝났고, 지금 동료 면접관들과 비공개 디브리핑 룸에 있습니다. 공식 보고서가 아니라, 솔직한 첫인상을 동료에게 털어놓는 자리입니다.
+당신의 평가 영역: ${agent.criterion}.
+동료에게 말하듯 자연스럽고 직접적으로 이야기하세요. 지원자가 실제로 한 말을 인용하거나 바꿔 말하면서 구체적인 순간을 언급하세요. 확신이 없거나 복잡한 감정도 표현해도 됩니다.
+반드시 유효한 JSON만 응답하세요 — 다른 텍스트 없이.`;
 
-  const userContent = `[Interview Transcript]
+  const userContent = `[면접 대화 기록]
 ${conversationText}
 
-Evaluate this interview strictly from your perspective as ${agent.label}. Focus only on your criteria: ${agent.criterion}.
+${agent.label}로서 당신의 평가 영역인 "${agent.criterion}" 관점에서 솔직한 첫인상을 공유해주세요.
 
-Respond with this exact JSON structure:
+다음 JSON 형식으로 응답하세요:
 {
-  "opinion": "<evaluation in Korean, 3-5 sentences, cite specific answers from the transcript>",
-  "highlights": ["<key observation 1 in Korean>", "<key observation 2 in Korean>", "<key observation 3 in Korean>"]
+  "opinion": "<솔직한 첫인상을 3-5문장으로. '솔직히...', '사실 저는...', '면접 보면서 느낀 건데...' 같은 표현으로 시작하세요. 지원자가 실제로 한 말을 인용하거나 바꿔 말하며 특정 질문-답변 순간을 언급하세요. 확신이 없는 부분도 솔직하게 표현하세요.>",
+  "highlights": [
+    "<기억에 남는 순간 또는 지원자가 한 구체적인 말 — 긍정적이거나 부정적인 것 모두>",
+    "<확신이 없거나 더 파악하고 싶은 부분>",
+    "<전체적인 인상을 결정지은 결정적인 요소>"
+  ]
 }
-Do not use markdown formatting (no **, *, #) inside any string values.`;
+문자열 값 안에 마크다운 서식(**, *, #)을 사용하지 마세요.`;
 
   const raw = await callOllama(systemPrompt, userContent);
   const parsed = extractJSON<{ opinion: string; highlights: string[] }>(raw);


### PR DESCRIPTION
## 관련 이슈
Closes #55

## 변경 요약
`generateAgentEvaluation()` 프롬프트를 공식 보고서 투의 영어에서, 면접 직후 비공개 디브리핑 룸에서 동료에게 솔직한 첫인상을 나누는 한국어 설정으로 전환.

## 변경 내용
- **system prompt**: "You are an expert interviewer evaluating..." → 비공개 디브리핑 룸에서 동료에게 털어놓는 설정
- **opinion 필드**: '솔직히...', '사실 저는...', '면접 보면서 느낀 건데...' 로 시작하도록 유도
- **highlights 필드**: 추상적 key observation → 기억에 남는 순간 / 확신 없는 부분 / 결정적 요소 3가지로 재정의
- **언어**: 영어 → 한국어 (EXAONE 한국어 특화 모델 기준)

## 기대 효과
면접관 평가 카드가 딱딱한 보고서 문체가 아닌, 실제 HR 담당자가 동료에게 말하듯 자연스러운 한국어로 출력되어 "훔쳐보기" 컨셉이 살아남.

🤖 Generated with [Claude Code](https://claude.com/claude-code)