### PR TITLE
[M3] 중재자 프롬프트 개선 — 채점 루브릭·연습형 팁·구어체 요약

### DIFF
--- a/lib/agents.ts
+++ b/lib/agents.ts
@@ -184,43 +184,55 @@ export async function generateModeratorResult(
   const conversationText = buildConversationText(messages);
 
   const evaluationsText = evaluations
-    .map((e) => `[${e.agentLabel}] Criteria: ${e.criterion}\n${e.opinion}\nKey points: ${e.highlights.join(" / ")}`)
+    .map((e) => `[${e.agentLabel}] 평가 영역: ${e.criterion}\n${e.opinion}\n핵심 포인트: ${e.highlights.join(" / ")}`)
     .join("\n\n");
 
   const repliesText = replies
     .map((r) => {
       const replyLines = r.replies
-        .map((reply) => `  → To ${reply.targetAgentId} [${reply.stance}]: ${reply.comment}`)
+        .map((reply) => `  → ${reply.targetAgentId}에게 [${reply.stance}]: ${reply.comment}`)
         .join("\n");
       return `[${r.agentLabel}]\n${replyLines}`;
     })
     .join("\n\n");
 
-  const systemPrompt = `You are a neutral moderator synthesizing an interview panel debate into a final assessment. Always respond with valid JSON only — no extra text.`;
+  const systemPrompt = `당신은 중립적인 중재자입니다. 면접 패널의 토론이 방금 끝났고, 그 논의를 종합하여 최종 평가를 내리는 것이 당신의 역할입니다.
+당신은 면접관이 아닙니다 — 각 면접관의 전문 영역에 따라 의견을 공정하게 조율하는 조정자입니다.
+반드시 유효한 JSON만 응답하세요 — 다른 텍스트 없이.`;
 
-  const userContent = `[Interview Transcript]
+  const userContent = `[면접 대화 기록]
 ${conversationText}
 
-[Round 0 — Independent Evaluations]
+[Round 0 — 면접관 독립 평가]
 ${evaluationsText}
 
-[Round 1 — Panel Debate]
+[Round 1 — 면접관 토론]
 ${repliesText}
 
-Based on all evaluator opinions and the full debate above, assign a comprehensive final score and synthesize the findings.
+위 평가와 토론 전체를 바탕으로 최종 점수를 산정하고 결과를 종합하세요.
 
-Respond with this exact JSON:
+다음 JSON 형식으로 응답하세요:
 {
-  "score": <integer 0-100 reflecting the candidate's overall performance across all criteria>,
+  "score": <0-100 사이 정수. 채점 기준:
+    90-100: 탁월 — 수치 포함 구체적 사례, 강한 자기 인식, 직무 요건을 명확히 상회
+    75-89: 우수 — 구체적 사례, 좋은 구조, 사소한 빈틈만 있음
+    60-74: 보통 — 일부 구체적 사례 있으나 일관성 부족, 잠재력은 보임
+    45-59: 미흡 — 주로 추상적인 답변, 구체성 부족, 핵심 역량 빈틈
+    0-44: 부족 — 모호하거나 회피적인 답변, 직무 요건과 심각한 불일치
+    비중: 조직 전문가 30% + 논리 전문가 30% + 기술 전문가 40%>,
   "overall": {
-    "strengths": "<2-3 sentences in Korean about what the candidate did well, citing specific answers>",
-    "weaknesses": "<2-3 sentences in Korean about clear gaps>",
-    "advice": "<2-3 sentences in Korean of actionable improvement advice>"
+    "strengths": "<지원자가 잘한 점 2-3문장. 구체적인 답변을 인용하세요.>",
+    "weaknesses": "<명확한 약점이나 빈틈 2-3문장.>",
+    "advice": "<이 지원자가 면접 답변에서 바꿔야 할 가장 중요한 것 하나를 명확히 말하고, 더 나은 답변이 어떻게 들렸을지 구체적인 예시를 제시하세요. 2-3문장.>"
   },
-  "improvementTips": ["<specific tip 1 in Korean>", "<specific tip 2 in Korean>", "<specific tip 3 in Korean>"],
-  "debateSummary": "<2-3 sentences in Korean summarizing the key discussion points and what influenced the final score>"
+  "improvementTips": [
+    "<팁 1: 구체적인 연습 방법. 형식 '[연습명]: [단계별 방법]. [잘된 예시].' 예: 'STAR 구조 훈련: 본인의 경험 3가지를 골라 각각 상황→과제→행동→결과 형식으로 2분 안에 말할 수 있도록 소리 내어 연습하세요. 결과에는 수치나 팀 반응 같은 구체적 증거를 포함하세요.' '더 구체적으로 말하세요' 같은 추상적 조언은 금지.>",
+    "<팁 2: 이번 면접에서 나타난 다른 약점을 타겟으로 한 연습 방법. 같은 형식.>",
+    "<팁 3: 패널이 발견한 기술적 또는 직무 관련 빈틈을 타겟으로 한 연습 방법. 같은 형식.>"
+  ],
+  "debateSummary": "<패널 토론에서 가장 흥미로웠던 의견 충돌이나 긴장을 설명하고, 최종 점수에 결정적으로 영향을 준 것이 무엇인지 서술하세요. 공식 보고서가 아니라 누군가에게 '오늘 토론이 어땠는지' 말해주는 것처럼 구어체로 2-3문장.>"
 }
-Do not use markdown formatting (no **, *, #) inside any string values.`;
+문자열 값 안에 마크다운 서식(**, *, #)을 사용하지 마세요.`;
 
   const raw = await callOllama(systemPrompt, userContent);
   const parsed = extractJSON<{


### PR DESCRIPTION
## 관련 이슈
Closes #57
Closes #58
Closes #59

## 변경 요약
`generateModeratorResult()` 프롬프트를 전면 한국어로 전환하고, 최종 평가 품질을 높이기 위한 3가지 개선 적용.

## 변경 내용

### 채점 루브릭 추가 (이슈 #57)
기존에는 루브릭 없이 "0-100 사이 정수"만 요구 → 점수가 실행마다 일관성 없음.
5단계 기준 추가 (탁월/우수/보통/미흡/부족) + 비중 조직30%·논리30%·기술40% 명시.

### improvementTips 연습 문제 형식 (이슈 #58)
기존: "specific tip" → "더 구체적으로 말하세요" 같은 추상적 결과만 나옴.
변경: `[연습명]: [단계별 방법]. [잘된 예시]` 형식 강제. 추상적 조언 명시적 금지.

### overall.advice + debateSummary 구체화 (이슈 #59)
- `advice`: 바꿔야 할 것 하나 + 더 나은 답변이 어떻게 들렸을지 구체적 예시 요구
- `debateSummary`: 공식 보고서 투 → "오늘 토론이 어땠는지 말해주는" 구어체로 전환

🤖 Generated with [Claude Code](https://claude.com/claude-code)