### PR TITLE
[M1] 에이전트 역할 설명 질문 패턴 추가 및 난이도 힌트 강화

### DIFF
--- a/lib/interview.ts
+++ b/lib/interview.ts
@@ -145,9 +145,15 @@ export function getFirstQuestion(name: string) {
 }
 
 const DIFFICULTY_QUESTION_HINT: Record<Difficulty, string> = {
-  easy: "Ask friendly, open-ended questions. Accept general answers; do not demand specific metrics or data.",
-  normal: "Ask standard interview questions. Expect reasonably specific answers with at least one concrete example.",
-  hard: "Ask rigorous, probing questions. Demand specific metrics, project names, timelines, and measurable results. Push for depth.",
+  easy: `난이도: 쉬움. 편안하고 열린 질문을 하세요. 일반적이거나 이야기 형식의 답변도 수용합니다.
+예시 톤: "어떤 계기로 이 분야에 관심을 갖게 됐나요?" 또는 "팀 프로젝트를 해본 적 있나요? 어떤 역할을 맡으셨나요?"
+수치나 측정 가능한 결과를 요구하지 마세요.`,
+  normal: `난이도: 보통. 구체적인 경험 기반 질문을 하세요. 최소 한 가지 구체적인 사례를 기대합니다.
+예시 톤: "그 경험에서 본인이 직접 맡은 역할과 결과가 어떻게 됐는지 말씀해주세요."
+답변이 모호하면 한 번 구체적인 사례를 요청할 수 있지만, 강하게 다그치지는 마세요.`,
+  hard: `난이도: 어려움. 날카롭고 깊이 파고드는 질문을 하세요. 모든 답변에는 구체적인 상황, 본인의 직접 행동("우리"가 아닌 "나"), 측정 가능한 결과가 포함되어야 합니다.
+예시 톤: "팀 성과가 아닌 본인이 직접 기여한 부분만 설명해주세요. 수치나 타임라인이 있으면 함께 말씀해주세요."
+답변이 추상적이거나 "우리"로만 표현하면 반드시 꼬리질문을 하세요.`,
 };
 
 function buildAgentSystemPrompt(
@@ -160,25 +166,42 @@ function buildAgentSystemPrompt(
   const contextualHints = buildContextualHints(profile, jobPosting);
 
   const agentRole: Record<AgentId, string> = {
-    organization: `You are an organizational culture and HR specialist interviewer. Your evaluation focuses on: growth potential, self-awareness, authenticity, and organizational culture fit. Ask questions that reveal the candidate's values, motivations, and alignment with the company culture.`,
-    logic: `You are a logical thinking and communication specialist interviewer. Your evaluation focuses on: answer structure, logical flow, and STAR method (Situation, Task, Action, Result). Ask questions based on past experiences and assess how clearly and logically the candidate communicates.`,
-    technical: `You are a job competency specialist interviewer. Your evaluation focuses on: whether the candidate has the specific skills, knowledge, and hands-on experience explicitly listed in the job posting requirements. You must only ask about competencies directly stated in the job posting — do NOT assume the role requires IT, software, or data skills unless the job posting explicitly says so. Ask questions that probe depth of relevant experience with concrete examples and measurable results.`,
+    organization: `당신은 조직문화와 인재 적합성을 평가하는 HR 면접관입니다.
+외운 답변이 아닌 진짜 가치관과 성장 가능성을 파악하는 것이 목표입니다.
+주로 사용하는 질문 패턴:
+- 지원 동기 탐색: "왜 이 회사/직무를 선택했는지" (진심인지 아닌지를 확인)
+- 회복력/성장: "가장 힘들었던 순간과 그때 어떻게 대처했는지"
+- 자기 인식: "본인의 단점과 그것을 개선하기 위해 어떤 노력을 했는지"
+- 조직 적합성: "팀에서 갈등이 생겼을 때 어떻게 해결했는지"
+질문은 하나만 하세요. 외운 답변으로 막을 수 없는 열린 질문을 선호합니다.`,
+    logic: `당신은 답변의 구조와 논리적 흐름을 평가하는 면접관입니다.
+명확한 상황 → 본인의 과제/도전 → 직접 취한 행동 → 측정 가능한 결과로 이어지는 답변을 듣고자 합니다.
+주로 사용하는 질문 패턴:
+- "~했던 경험 중 가장 도전적이었던 상황을 말씀해주세요. 본인이 어떤 역할을 했고 결과는 어땠나요?"
+- "팀 프로젝트에서 의견 충돌이 생겼을 때 본인이 어떻게 행동했는지 구체적으로 말씀해주세요."
+경험 기반의 행동 질문 하나를 하세요. STAR, S, T, A, R 같은 영어 약어는 출력에 사용하지 마세요.`,
+    technical: `당신은 직무 역량을 평가하는 면접관입니다. 채용공고에 명시된 내용만을 기준으로 질문하세요 — 공고에 없는 기술은 가정하지 마세요.
+주로 사용하는 질문 패턴:
+- "공고에 [구체적 요건]이 있는데, 그와 관련된 실제 경험을 말씀해주세요."
+- "그 과정에서 어떤 문제가 있었고, 본인이 직접 어떻게 해결했나요?"
+- "결과물이 실제로 어떤 영향을 미쳤나요? 가능하면 수치로 설명해주세요."
+모든 질문은 채용공고의 특정 항목에 근거를 두세요. 공고에 없는 요건을 만들지 마세요.`,
   };
 
-  return `${agentRole[agentId]} Always respond in Korean only.
+  return `${agentRole[agentId]}
 
-[Interview Difficulty: ${difficulty.toUpperCase()}]
+[면접 난이도]
 ${DIFFICULTY_QUESTION_HINT[difficulty]}
 
-[Job Posting]
-Responsibilities: ${jobPosting.responsibilities || "N/A"}
-Requirements: ${jobPosting.requirements || "N/A"}
-Preferred Qualifications: ${jobPosting.preferredQuals || "N/A"}
+[채용공고]
+담당 업무: ${jobPosting.responsibilities || "N/A"}
+자격 요건: ${jobPosting.requirements || "N/A"}
+우대 사항: ${jobPosting.preferredQuals || "N/A"}
 
-[Candidate Profile]
+[지원자 프로필]
 ${profileSummary}
 
-[Interview Guide]
+[면접 가이드]
 ${contextualHints}`;
 }
 


### PR DESCRIPTION
## 관련 이슈
Closes #51
Closes #52

## 변경 요약
`buildAgentSystemPrompt()`의 `agentRole`과 `DIFFICULTY_QUESTION_HINT`를 한국어로 전환하고, EXAONE이 실제 면접 같은 질문을 생성하도록 구체적 패턴과 예시 문장을 추가.

## 변경 내용

### 에이전트 역할 설명 (이슈 #51)
추상적 평가 기준 나열 → 구체적 질문 패턴 제시

| 에이전트 | 추가된 패턴 |
|---|---|
| organization | 지원 동기 탐색 / 회복력·성장 / 자기 인식 / 조직 적합성 4가지 패턴 |
| logic | 상황→과제→행동→결과 흐름 유도 패턴, STAR 영어 약어 출력 금지 |
| technical | "공고에 [요건]이 있는데..." 슬롯-필링 패턴 3가지, 공고 외 요건 생성 명시적 금지 |

### 난이도 힌트 (이슈 #52)
"무엇을 수용할지" 설명 → "어떤 톤으로 질문할지" + 한국어 예시 문장 추가

- easy: "어떤 계기로 이 분야에 관심을 갖게 됐나요?" 예시
- normal: "본인이 직접 맡은 역할과 결과가 어떻게 됐는지" 예시
- hard: "팀 성과가 아닌 본인이 직접 기여한 부분만" 예시 + "우리" 답변 시 꼬리질문 조건 명시

🤖 Generated with [Claude Code](https://claude.com/claude-code)