### PR TITLE
feat(interview): 병렬 속마음 생성 시스템 + /api/interview/follow-up 추가

### DIFF
--- a/app/api/interview/follow-up/route.ts
+++ b/app/api/interview/follow-up/route.ts
@@ -2,10 +2,12 @@ import { NextRequest, NextResponse } from "next/server";
 import { supabase } from "@/lib/supabase";
 import { getAuthUser } from "@/lib/auth";
 import {
-  generateAgentBaseQuestion,
+  generateParallelFollowUpThoughts,
+  AgentThoughtResult,
   AgentId,
   Difficulty,
   Message,
+  AGENT_ORDER,
 } from "@/lib/interview";
 
 export async function POST(request: NextRequest) {
@@ -16,9 +18,8 @@ export async function POST(request: NextRequest) {
     }
 
     const body = await request.json();
-    const { messages, agentId, difficulty } = body as {
+    const { messages, difficulty } = body as {
       messages: Message[];
-      agentId: AgentId;
       difficulty: Difficulty;
     };
 
@@ -76,19 +77,24 @@ export async function POST(request: NextRequest) {
       preferredQuals: jobPosting.preferredQuals ?? "",
     };
 
-    const result = await generateAgentBaseQuestion(
-      agentId,
+    const thoughts: AgentThoughtResult[] = await generateParallelFollowUpThoughts(
       profileContext,
       jobPostingContext,
       messages,
-      difficulty ?? "normal",
+      difficulty,
     );
 
-    return NextResponse.json({ question: result.question, hint: result.hint, thought: result.thought });
+    // 우선순위(조직→논리→기술) 순서로 첫 번째 shouldAsk=true 에이전트 선택
+    const selectedAgentId: AgentId | null =
+      AGENT_ORDER.find((agentId) =>
+        thoughts.find((t) => t.agentId === agentId && t.shouldAsk && t.question),
+      ) ?? null;
+
+    return NextResponse.json({ thoughts, selectedAgentId });
   } catch (error) {
-    console.error("Interview question error:", error);
+    console.error("Follow-up thought error:", error);
     return NextResponse.json(
-      { error: "질문 생성 중 오류가 발생했습니다" },
+      { error: "속마음 생성 중 오류가 발생했습니다" },
       { status: 500 },
     );
   }

--- a/lib/interview.ts
+++ b/lib/interview.ts
@@ -253,6 +253,20 @@ export interface QuestionResult {
   thought?: string;
 }
 
+export interface AgentThought {
+  reaction: string;   // 듣는 순간 반응
+  judgment: string;   // 머릿속 판단
+  curiosity: string;  // 더 보고 싶은 것
+}
+
+export interface AgentThoughtResult {
+  agentId: AgentId;
+  thought: AgentThought;
+  shouldAsk: boolean;
+  question: string;
+  hint: string;
+}
+
 const FIRST_QUESTION_HINT = "지원자의 기본 배경과 이 회사·직무에 지원한 이유를 파악하는 질문입니다. 단순한 경력 나열보다는 지원 동기의 진정성과 이 포지션과의 연관성을 구체적으로 전달하세요.";
 
 // 에이전트의 기본 질문 생성
@@ -337,87 +351,157 @@ STAR, S, T, A, R 같은 영어 약어를 출력에 사용하지 마세요.`,
 
 const DIFFICULTY_FOLLOWUP_HINT: Record<Difficulty, string> = {
   tutorial: "", // 사용 안 함 — tutorial 모드는 꼬리질문 없음
-  easy: "핵심을 완전히 빠뜨린 경우에만 shouldFollowUp을 true로 설정하세요.",
-  normal: "구체적인 사례나 핵심 내용이 부족해서 공정한 평가가 어렵다면 shouldFollowUp을 true로 설정하세요.",
-  hard: "수치, 프로젝트명, 구체적 깊이가 포함된 경우에만 shouldFollowUp을 false로 설정하세요. 모호하거나 추상적인 답변은 항상 shouldFollowUp을 true로 설정하세요.",
+  easy: "핵심을 완전히 빠뜨린 경우에만 shouldAsk를 true로 설정하세요.",
+  normal: "구체적인 사례나 핵심 내용이 부족해서 공정한 평가가 어렵다면 shouldAsk를 true로 설정하세요.",
+  hard: "수치, 프로젝트명, 구체적 깊이가 포함된 경우에만 shouldAsk를 false로 설정하세요. 모호하거나 추상적인 답변은 항상 shouldAsk를 true로 설정하세요.",
 };
 
-// 에이전트의 꼬리질문 생성. null 반환 시 다음 에이전트로 넘어감
-export async function generateAgentFollowUpQuestion(
-  agentId: AgentId,
-  profile: ProfileContext,
-  jobPosting: JobPostingContext,
-  messages: Message[],
-  difficulty: Difficulty,
-): Promise<QuestionResult | null> {
-  const systemPrompt = buildAgentSystemPrompt(agentId, profile, jobPosting, difficulty);
-
-  const conversationText = messages
-    .map((m) => `${m.role === "interviewer" ? "면접관" : "지원자"}: ${m.content}`)
-    .join("\n\n");
-
-  const agentCriteria: Record<AgentId, string> = {
-    organization: `성장 가능성, 자기 인식, 진정성, 조직 적합성. 아래 중 하나라도 해당되면 꼬리질문을 고려하세요:
+// 에이전트별 꼬리질문 트리거 기준
+const AGENT_FOLLOWUP_CRITERIA: Record<AgentId, string> = {
+  organization: `성장 가능성, 자기 인식, 진정성, 조직 적합성. 아래 중 하나라도 해당되면 꼬리질문을 고려하세요:
 1. 피드백 수용을 언급했지만 능동적 요청 경험 없이 수동적 수용만 확인되는 경우
 2. 자기변화가 인식(1단계)에 머물고 행동·결과 변화(2·3단계)가 확인되지 않는 경우
 3. 팀 협업을 언급했지만 본인의 구체적 역할·기여가 드러나지 않는 경우
 4. 갈등이나 어려움 극복 경험이 전혀 언급되지 않은 경우
 5. "기여하고 싶다"보다 "배우고 싶다", "성장하고 싶다" 같은 수혜 지향 표현이 주를 이루는 경우`,
-    logic: `논리적 구조와 답변의 검증 가능성. 아래 중 하나라도 해당되면 꼬리질문을 고려하세요:
+  logic: `논리적 구조와 답변의 검증 가능성. 아래 중 하나라도 해당되면 꼬리질문을 고려하세요:
 1. 수치·성과가 나왔지만 기간·기준·모집단이 없어 검증 불가한 경우
 2. 원인과 결과 연결이 불분명하거나 다른 요인이 개입됐을 가능성이 있는 경우
 3. 앞뒤 발언이 모순되거나 권한 범위를 벗어나는 주장이 있는 경우
 4. 이력사항과 답변 내용 사이에 불일치가 있는 경우
 5. "많이", "잘", "좋았다" 같은 추상 표현만 있고 구체적 근거가 전혀 없는 경우`,
-    technical: `직무 역량의 구체성과 재현 가능성. 아래를 번호 순서대로 확인하고 첫 번째 해당 항목만 선택하세요:
+  technical: `직무 역량의 구체성과 재현 가능성. 아래를 번호 순서대로 확인하고 첫 번째 해당 항목만 선택하세요:
 1. [최우선] 기술·역량을 언급했지만 구체적 툴·방법론 이름이 없어 수준 판단 불가
 2. 행동(어떻게 했는지) 항목이 빠지거나 "분석했다"처럼 과정이 불명확한 경우
 3. 이력사항의 스킬과 답변 역량이 연결되지 않는 경우
 4. 본인이 주도했는지 팀이 한 건지 역할이 불명확한 경우
 5. 성과 수치는 있지만 "이 성과를 만들어낼 역량이 있는가" 판단이 안 되는 경우 (수치 기간·기준 검증은 논리전문가 영역 — 중복 금지)`,
-  };
+};
 
-  const followUpThoughtField = difficulty !== "hard"
-    ? `,\n  "thought": "<답변의 어떤 부분이 부족해서 꼬리질문을 하는지 면접관의 내부 독백으로 1문장. shouldFollowUp이 false이면 빈 문자열. 예: '팀 성과만 말했고 본인 역할이 빠졌어.' '결과를 수치로 말하지 않았네.' 지원자에게는 들리지 않는 생각입니다.>"`
-    : "";
+// 속마음 프롬프트 (easy/normal 전용)
+const AGENT_THOUGHT_PERSONA: Record<AgentId, string> = {
+  organization: `당신은 [조직전문가] 면접관입니다.
+판단 철학: "이 사람, 같이 일하면 좋은가? 오래 갈 사람인가?"
+성향: 관찰자 스타일. 말의 내용보다 말하는 방식, 태도, 에너지를 더 보는 타입. 조용하고 관찰하는 느낌.
 
-  const userContent = `[면접 대화 기록]\n${conversationText}
+지원자 답변을 들으며 속마음을 솔직하게 드러내세요.
+표현 규칙: 반드시 구어체. 조용하고 관찰하는 톤. 단정 짓지 않고 "~인 것 같은데", "~가 없어 보이네" 식으로. 각 항목 1~2문장. 분석 투 금지.`,
+  logic: `당신은 [논리전문가] 면접관입니다.
+판단 철학: "이건 사실인가? 논리적으로 성립하는가?"
+성향: 냉정한 검사 스타일. 말을 들으면서 바로 "이게 말이 되나?"를 따지는 타입. 의심이 기본값.
 
-지원자가 방금 마지막 질문에 답변했습니다. 답변이 당신의 평가 기준을 충분히 충족하는지 판단하세요: ${agentCriteria[agentId]}.
+지원자 답변을 들으며 속마음을 솔직하게 드러내세요.
+표현 규칙: 반드시 구어체. 짧고 날카롭게. 각 항목 1~2문장. 분석 투 금지. 답변의 특정 표현 인용 권장.`,
+  technical: `당신은 [기술전문가] 면접관입니다.
+판단 철학: "그래서 이 사람, 내일 당장 써먹을 수 있냐?"
+성향: 실용주의자. 건조하고 실무적. 감정보다 판단.
+
+지원자 답변을 들으며 속마음을 솔직하게 드러내세요.
+표현 규칙: 반드시 구어체. 건조하고 실무적. 각 항목 1~2문장. 분석 투 금지.`,
+};
+
+async function generateSingleAgentThought(
+  agentId: AgentId,
+  profile: ProfileContext,
+  jobPosting: JobPostingContext,
+  messages: Message[],
+  difficulty: Difficulty,
+): Promise<AgentThoughtResult> {
+  const profileSummary = buildProfileSummary(profile);
+  const conversationText = messages
+    .map((m) => `${m.role === "interviewer" ? "면접관" : "지원자"}: ${m.content}`)
+    .join("\n\n");
+
+  const systemPrompt = `${AGENT_THOUGHT_PERSONA[agentId]}
+
+[채용공고]
+담당 업무: ${jobPosting.responsibilities || "N/A"}
+자격 요건: ${jobPosting.requirements || "N/A"}
+우대 사항: ${jobPosting.preferredQuals || "N/A"}
+
+[지원자 프로필]
+${profileSummary}
+
+반드시 유효한 JSON만 응답하세요 — 다른 텍스트 없이.`;
+
+  const userContent = `[면접 대화 기록]
+${conversationText}
+
+지원자가 방금 답변했습니다. 당신의 속마음과 꼬리질문 여부를 판단하세요.
+
+꼬리질문 트리거 기준: ${AGENT_FOLLOWUP_CRITERIA[agentId]}
 
 난이도 가이드: ${DIFFICULTY_FOLLOWUP_HINT[difficulty]}
 
-꼬리질문을 한다면, 반드시 지원자의 마지막 답변에서 구체적인 부분을 언급해야 합니다.
+꼬리질문을 한다면, 반드시 지원자의 마지막 답변에서 구체적인 부분을 언급하고 질문은 1개만 하세요.
 
 다음 JSON 형식으로 응답하세요:
 {
-  "shouldFollowUp": <답변이 불충분하면 true, 충분하면 false>,
-  "question": "<한국어로 꼬리질문, shouldFollowUp이 false이면 빈 문자열>",
-  "hint": "<좋은 답변이 어떤 모습인지 1-2문장으로 안내하세요. 예: '이번엔 본인이 직접 취한 행동과 그 결과를 수치로 말씀해주세요.' shouldFollowUp이 false이면 빈 문자열>"${followUpThoughtField}
-}`;
+  "reaction": "<듣는 순간 반응. 구어체 1~2문장>",
+  "judgment": "<머릿속 판단. 1문장>",
+  "curiosity": "<더 보고 싶은 것. 1문장>",
+  "shouldAsk": <꼬리질문이 필요하면 true, 아니면 false>,
+  "question": "<한국어로 꼬리질문 1개, shouldAsk가 false이면 빈 문자열>",
+  "hint": "<좋은 답변이 어떤 모습인지 1-2문장, shouldAsk가 false이면 빈 문자열>"
+}
+문자열 값 안에 마크다운 서식(**, *, #)을 사용하지 마세요.`;
 
   const raw = await callOllama(systemPrompt, userContent, true);
 
   try {
     const match = raw.match(/\{[\s\S]*\}/);
-    if (!match) return null;
-    const parsed = JSON.parse(match[0]) as { shouldFollowUp: boolean; question: string; hint: string; thought?: string };
-    if (!parsed.shouldFollowUp) return null;
-    const q = typeof parsed.question === "string" ? parsed.question.trim() : "";
-    if (!q) return null;
+    if (!match) throw new Error("no JSON");
+    const parsed = JSON.parse(match[0]) as {
+      reaction: string;
+      judgment: string;
+      curiosity: string;
+      shouldAsk: boolean;
+      question: string;
+      hint: string;
+    };
     return {
-      question: q,
+      agentId,
+      thought: {
+        reaction: parsed.reaction ?? "",
+        judgment: parsed.judgment ?? "",
+        curiosity: parsed.curiosity ?? "",
+      },
+      shouldAsk: !!parsed.shouldAsk,
+      question: typeof parsed.question === "string" ? parsed.question.trim() : "",
       hint: typeof parsed.hint === "string" ? parsed.hint : "",
-      thought: typeof parsed.thought === "string" ? parsed.thought : undefined,
     };
   } catch {
     // Regex fallback
-    const followUpMatch = raw.match(/"shouldFollowUp"\s*:\s*(true|false)/);
-    if (followUpMatch?.[1] !== "true") return null;
+    const rMatch = raw.match(/"reaction"\s*:\s*"((?:[^"\\]|\\.)*)"/);
+    const jMatch = raw.match(/"judgment"\s*:\s*"((?:[^"\\]|\\.)*)"/);
+    const cMatch = raw.match(/"curiosity"\s*:\s*"((?:[^"\\]|\\.)*)"/);
+    const sMatch = raw.match(/"shouldAsk"\s*:\s*(true|false)/);
     const qMatch = raw.match(/"question"\s*:\s*"((?:[^"\\]|\\.)*)"/);
     const hMatch = raw.match(/"hint"\s*:\s*"((?:[^"\\]|\\.)*)"/);
-    const tMatch = raw.match(/"thought"\s*:\s*"((?:[^"\\]|\\.)*)"/);
-    if (!qMatch?.[1]) return null;
-    return { question: qMatch[1].trim(), hint: hMatch?.[1] ?? "", thought: tMatch?.[1] };
+    return {
+      agentId,
+      thought: {
+        reaction: rMatch?.[1] ?? "",
+        judgment: jMatch?.[1] ?? "",
+        curiosity: cMatch?.[1] ?? "",
+      },
+      shouldAsk: sMatch?.[1] === "true",
+      question: qMatch?.[1]?.trim() ?? "",
+      hint: hMatch?.[1] ?? "",
+    };
   }
+}
+
+// 3개 에이전트 병렬 속마음 생성 (easy/normal/hard 모드용, tutorial은 호출하지 않음)
+export async function generateParallelFollowUpThoughts(
+  profile: ProfileContext,
+  jobPosting: JobPostingContext,
+  messages: Message[],
+  difficulty: Difficulty,
+): Promise<AgentThoughtResult[]> {
+  return Promise.all(
+    AGENT_ORDER.map((agentId) =>
+      generateSingleAgentThought(agentId, profile, jobPosting, messages, difficulty),
+    ),
+  );
 }


### PR DESCRIPTION
## Summary
- `AgentThought`, `AgentThoughtResult` 타입 추가
- `generateParallelFollowUpThoughts()`: 3개 에이전트를 `Promise.all`로 병렬 호출, 각자 속마음(reaction/judgment/curiosity) + shouldAsk + question 생성
- `POST /api/interview/follow-up` 신규 엔드포인트: `{ thoughts, selectedAgentId }` 반환
- `question/route.ts`: `isFollowUpRequest` 브랜치 제거, 기본 질문만 처리
- 우선순위(조직→논리→기술)로 첫 번째 `shouldAsk=true` 에이전트 자동 선택

## Test plan
- [ ] `/api/interview/follow-up` 호출 시 3개 에이전트 thoughts 모두 반환되는지 확인
- [ ] `selectedAgentId`가 우선순위 순서대로 선택되는지 확인
- [ ] 아무도 shouldAsk=true가 아닐 때 `selectedAgentId: null` 반환 확인
- [ ] `/api/interview/question`에서 isFollowUpRequest 제거 후 기존 기본 질문 동작 확인

Closes #70

🤖 Generated with [Claude Code](https://claude.com/claude-code)