### PR TITLE
feat(interview): 꼬리질문 흐름 전면 개선 (이슈 #77)

### DIFF
--- a/app/api/interview/follow-up/route.ts
+++ b/app/api/interview/follow-up/route.ts
@@ -2,12 +2,10 @@ import { NextRequest, NextResponse } from "next/server";
 import { supabase } from "@/lib/supabase";
 import { getAuthUser } from "@/lib/auth";
 import {
-  generateParallelFollowUpThoughts,
-  AgentThoughtResult,
+  findFollowUpAgent,
   AgentId,
   Difficulty,
   Message,
-  AGENT_ORDER,
 } from "@/lib/interview";
 
 export async function POST(request: NextRequest) {
@@ -18,9 +16,11 @@ export async function POST(request: NextRequest) {
     }
 
     const body = await request.json();
-    const { messages, difficulty } = body as {
+    const { messages, difficulty, currentAgentId, followUpRound = 0 } = body as {
       messages: Message[];
       difficulty: Difficulty;
+      currentAgentId: AgentId;
+      followUpRound?: number;
     };
 
     const { data: profile } = await supabase
@@ -77,20 +77,16 @@ export async function POST(request: NextRequest) {
       preferredQuals: jobPosting.preferredQuals ?? "",
     };
 
-    const thoughts: AgentThoughtResult[] = await generateParallelFollowUpThoughts(
+    const { thought, selectedAgentId } = await findFollowUpAgent(
       profileContext,
       jobPostingContext,
       messages,
       difficulty,
+      currentAgentId,
+      followUpRound,
     );
 
-    // 우선순위(조직→논리→기술) 순서로 첫 번째 shouldAsk=true 에이전트 선택
-    const selectedAgentId: AgentId | null =
-      AGENT_ORDER.find((agentId) =>
-        thoughts.find((t) => t.agentId === agentId && t.shouldAsk && t.question),
-      ) ?? null;
-
-    return NextResponse.json({ thoughts, selectedAgentId });
+    return NextResponse.json({ thought, selectedAgentId });
   } catch (error) {
     console.error("Follow-up thought error:", error);
     return NextResponse.json(

--- a/components/InterviewSession.tsx
+++ b/components/InterviewSession.tsx
@@ -38,11 +38,13 @@ async function fetchQuestion(
 async function fetchFollowUp(
   messages: Message[],
   difficulty: Difficulty,
-): Promise<{ thoughts: AgentThoughtResult[]; selectedAgentId: AgentId | null }> {
+  currentAgentId: AgentId,
+  followUpRound: number,
+): Promise<{ thought: AgentThoughtResult | null; selectedAgentId: AgentId | null }> {
   const res = await fetch("/api/interview/follow-up", {
     method: "POST",
     headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({ messages, difficulty }),
+    body: JSON.stringify({ messages, difficulty, currentAgentId, followUpRound }),
   });
   const data = await res.json();
   if (!res.ok) throw new Error(data.error ?? "속마음 생성에 실패했습니다");
@@ -144,12 +146,16 @@ function InterviewerPanel({
   isThinkingPhase,
   isSpeaking,
   avatarSeeds,
+  currentThought,
+  onThoughtDone,
 }: {
   agentIndex: number;
   isLoading: boolean;
   isThinkingPhase: boolean;
   isSpeaking: boolean;
   avatarSeeds: Record<AgentId, string>;
+  currentThought: AgentThoughtResult | null;
+  onThoughtDone: () => void;
 }) {
   return (
     <div className="grid grid-cols-3 gap-3">
@@ -161,10 +167,21 @@ function InterviewerPanel({
         const avatarUrl = makeAvatarUrl(avatarSeeds[aid], meta.bgColor);
         // isThinkingPhase: 3명 모두 로딩 dots
         const showLoading = isThinkingPhase ? true : (isActive && isLoading);
+        const showThought = currentThought?.agentId === aid;
 
         return (
+          <div key={aid} className="flex flex-col">
+            {/* 속마음 말풍선 (해당 에이전트 위에만) */}
+            {showThought ? (
+              <ThoughtSpeechBubble
+                agentId={aid}
+                thought={currentThought!.thought}
+                onDone={onThoughtDone}
+              />
+            ) : (
+              <div className="mb-1 min-h-[38px]" /> // 높이 유지용 spacer
+            )}
           <div
-            key={aid}
             className={`flex flex-col items-center gap-2 p-3 rounded-2xl transition-all duration-300 ${
               isActive
                 ? "bg-white dark:bg-slate-800 border border-gray-100 dark:border-slate-700 shadow-md"
@@ -222,6 +239,7 @@ function InterviewerPanel({
               </p>
             </div>
           </div>
+          </div>
         );
       })}
     </div>
@@ -250,23 +268,18 @@ function QuestionBubble({ agentId, question }: { agentId: AgentId; question: str
   );
 }
 
-// 단일 에이전트 속마음 버블 (타이핑 애니메이션 포함)
-function AgentThoughtCard({
+// 속마음 말풍선 (에이전트 위에 표시, 아래 방향 꼬리)
+function ThoughtSpeechBubble({
   agentId,
   thought,
-  isSelected,
-  avatarSeed,
   onDone,
 }: {
   agentId: AgentId;
-  thought: { reaction: string; judgment: string; curiosity: string };
-  isSelected: boolean;
-  avatarSeed: string;
+  thought: { reaction: string };
   onDone: () => void;
 }) {
   const meta = AGENT_META[agentId];
-  const fullText = thought.reaction || "";
-  const { displayed, done } = useTypewriter(fullText, 14);
+  const { displayed, done } = useTypewriter(thought.reaction || "", 14);
 
   const onDoneRef = useRef(onDone);
   onDoneRef.current = onDone;
@@ -279,79 +292,42 @@ function AgentThoughtCard({
     }
   }, [done]);
 
+  // 에이전트별 말풍선 색상
+  const bubbleColors: Record<AgentId, string> = {
+    organization: "bg-purple-50 dark:bg-purple-900/30 border-purple-200 dark:border-purple-700",
+    logic:        "bg-blue-50   dark:bg-blue-900/30   border-blue-200   dark:border-blue-700",
+    technical:    "bg-green-50  dark:bg-green-900/30  border-green-200  dark:border-green-700",
+  };
+  const tailColors: Record<AgentId, string> = {
+    organization: "border-t-purple-200 dark:border-t-purple-700",
+    logic:        "border-t-blue-200   dark:border-t-blue-700",
+    technical:    "border-t-green-200  dark:border-t-green-700",
+  };
+  const tailFills: Record<AgentId, string> = {
+    organization: "border-t-purple-50 dark:border-t-purple-900/30",
+    logic:        "border-t-blue-50   dark:border-t-blue-900/30",
+    technical:    "border-t-green-50  dark:border-t-green-900/30",
+  };
+
   return (
-    <div className="relative pb-3">
-      <div
-        className={`rounded-2xl p-3 border-2 transition-all duration-300 ${
-          isSelected
-            ? `bg-white dark:bg-slate-800 ${meta.border} shadow-md`
-            : "bg-gray-50 dark:bg-slate-800/40 border-transparent opacity-40"
-        }`}
-      >
-        <div className="flex items-center gap-1.5 mb-1.5">
-          <div className="w-5 h-5 rounded-full overflow-hidden shrink-0">
-            <img src={makeAvatarUrl(avatarSeed, meta.bgColor)} alt={meta.name} className="w-full h-full object-cover" />
-          </div>
-          <span className={`text-[11px] font-semibold ${meta.color}`}>{meta.name}</span>
-        </div>
-        <p className="text-gray-500 dark:text-slate-400 text-[12px] leading-relaxed italic">
+    <div className="relative mb-1">
+      {/* 말풍선 본체 */}
+      <div className={`rounded-2xl border px-3 py-2 shadow-sm ${bubbleColors[agentId]}`}>
+        <p className={`text-[11px] leading-relaxed italic ${meta.color}`}>
           {displayed}
           {!done && (
-            <span className="inline-block w-0.5 h-3 bg-gray-300 dark:bg-slate-600 ml-0.5 animate-pulse align-middle" />
+            <span className="inline-block w-0.5 h-3 bg-current ml-0.5 animate-pulse align-middle opacity-60" />
           )}
         </p>
       </div>
-      {/* 아래를 향하는 말풍선 꼭지 */}
-      <div className={`absolute bottom-0 left-1/2 -translate-x-1/2 w-4 h-4 rotate-45 transition-all duration-300 ${
-        isSelected
-          ? `bg-white dark:bg-slate-800 border-b border-r ${meta.border}`
-          : "bg-gray-50 dark:bg-slate-800/40"
-      }`} />
-    </div>
-  );
-}
-
-// 3개 에이전트 병렬 속마음 버블 컨테이너
-function ParallelThoughtBubbles({
-  thoughts,
-  selectedAgentId,
-  avatarSeeds,
-  onAllDone,
-}: {
-  thoughts: AgentThoughtResult[];
-  selectedAgentId: AgentId | null;
-  avatarSeeds: Record<AgentId, string>;
-  onAllDone: () => void;
-}) {
-  const [doneCount, setDoneCount] = useState(0);
-  const onAllDoneRef = useRef(onAllDone);
-  onAllDoneRef.current = onAllDone;
-  const calledRef = useRef(false);
-
-  useEffect(() => {
-    if (!calledRef.current && doneCount >= thoughts.length) {
-      calledRef.current = true;
-      const timer = setTimeout(() => onAllDoneRef.current(), 600);
-      return () => clearTimeout(timer);
-    }
-  }, [doneCount, thoughts.length]);
-
-  return (
-    <div className="grid grid-cols-3 gap-2">
-      {AGENT_ORDER.map((agentId) => {
-        const t = thoughts.find((th) => th.agentId === agentId);
-        if (!t) return null;
-        return (
-          <AgentThoughtCard
-            key={agentId}
-            agentId={agentId}
-            thought={t.thought}
-            isSelected={selectedAgentId === null || selectedAgentId === agentId}
-            avatarSeed={avatarSeeds[agentId]}
-            onDone={() => setDoneCount((c) => c + 1)}
-          />
-        );
-      })}
+      {/* 아래 방향 삼각형 꼬리 (테두리) */}
+      <div className={`absolute -bottom-[9px] left-1/2 -translate-x-1/2 w-0 h-0
+        border-l-[8px] border-r-[8px] border-t-[9px]
+        border-l-transparent border-r-transparent ${tailColors[agentId]}`} />
+      {/* 아래 방향 삼각형 꼬리 (채우기) */}
+      <div className={`absolute -bottom-[7px] left-1/2 -translate-x-1/2 w-0 h-0
+        border-l-[7px] border-r-[7px] border-t-[8px]
+        border-l-transparent border-r-transparent ${tailFills[agentId]}`} />
     </div>
   );
 }
@@ -377,10 +353,8 @@ export default function InterviewSession({ name }: { name: string }) {
   const [error, setError] = useState("");
   const [timeLeft, setTimeLeft] = useState(ANSWER_TIME_LIMIT);
 
-  const [parallelThoughts, setParallelThoughts] = useState<AgentThoughtResult[] | null>(null);
-  const [selectedFollowUpAgentId, setSelectedFollowUpAgentId] = useState<AgentId | null>(null);
+  const [currentThought, setCurrentThought] = useState<AgentThoughtResult | null>(null);
   const [questionReady, setQuestionReady] = useState(true);
-  const pendingAdvanceMsgsRef = useRef<Message[] | null>(null);
 
   const [sessionId, setSessionId] = useState<string | null>(null);
   const [debateResult, setDebateResult] = useState<DebateResultData | null>(null);
@@ -394,8 +368,7 @@ export default function InterviewSession({ name }: { name: string }) {
     setHintVisible(false);
     setAgentIndex(0);
     setFollowUpRound(0);
-    setParallelThoughts(null);
-    setSelectedFollowUpAgentId(null);
+    setCurrentThought(null);
     setQuestionReady(true);
     setPhase("interviewing");
     history.pushState({ interviewPhase: "interviewing" }, "");
@@ -453,33 +426,32 @@ export default function InterviewSession({ name }: { name: string }) {
     setAnswer("");
     setIsLoading(true);
     setError("");
-    setParallelThoughts(null);
-    setSelectedFollowUpAgentId(null);
+    setCurrentThought(null);
     setQuestionReady(true);
 
     try {
-      const canFollowUp = difficulty !== "tutorial" && followUpRound < MAX_FOLLOWUP_ROUNDS;
+      const canFollowUp = difficulty !== "tutorial" && followUpRound < MAX_FOLLOWUP_ROUNDS[difficulty];
 
       if (canFollowUp) {
         setIsLoading(false);
         setIsThinkingPhase(true);
 
-        const result = await fetchFollowUp(updatedMessages, difficulty);
+        const { thought: selected, selectedAgentId } = await fetchFollowUp(
+          updatedMessages, difficulty, currentAgentId, followUpRound,
+        );
         setIsThinkingPhase(false);
 
-        if (result.selectedAgentId && result.thoughts.find(t => t.agentId === result.selectedAgentId && t.question)) {
-          const selected = result.thoughts.find(t => t.agentId === result.selectedAgentId)!;
+        if (selectedAgentId && selected) {
 
-          // easy/normal: 속마음 버블 표시 후 질문 등장
+          // easy/normal: 선택 에이전트 버블만 표시, 타이핑 완료 후 질문 등장
           if (difficulty !== "hard") {
-            setParallelThoughts(result.thoughts);
-            setSelectedFollowUpAgentId(result.selectedAgentId);
-            setQuestionReady(false); // 버블 타이핑 완료 후 questionReady=true
+            setCurrentThought(selected);
+            setQuestionReady(false);
           }
 
           setMessages([
             ...updatedMessages,
-            { role: "interviewer", content: selected.question, agentId: result.selectedAgentId },
+            { role: "interviewer", content: selected.question, agentId: selectedAgentId },
           ]);
           setCurrentHint(selected.hint ?? "");
           setHintVisible(false);
@@ -489,16 +461,8 @@ export default function InterviewSession({ name }: { name: string }) {
             setQuestionReady(true);
           }
         } else {
-          // 아무도 shouldAsk=false → 다음 에이전트
-          if (difficulty !== "hard" && result.thoughts.length > 0) {
-            // easy/normal: 속마음 버블 보여준 뒤 advanceToNextAgent
-            pendingAdvanceMsgsRef.current = updatedMessages;
-            setParallelThoughts(result.thoughts);
-            setSelectedFollowUpAgentId(null);
-            setQuestionReady(false);
-          } else {
-            await advanceToNextAgent(updatedMessages);
-          }
+          // 아무도 shouldAsk=false → 버블 없이 다음 에이전트로 바로 이동
+          await advanceToNextAgent(updatedMessages);
         }
       } else {
         await advanceToNextAgent(updatedMessages);
@@ -511,22 +475,9 @@ export default function InterviewSession({ name }: { name: string }) {
     }
   }
 
-  // 속마음 버블 타이핑 완료 콜백
+  // 속마음 버블 타이핑 완료 콜백 (꼬리질문 있을 때만 호출됨)
   async function handleThoughtsAllDone() {
     setQuestionReady(true);
-    // 아무도 shouldAsk=false였던 경우 → 다음 에이전트로
-    if (pendingAdvanceMsgsRef.current) {
-      const msgs = pendingAdvanceMsgsRef.current;
-      pendingAdvanceMsgsRef.current = null;
-      setParallelThoughts(null);
-      setSelectedFollowUpAgentId(null);
-      setIsLoading(true);
-      try {
-        await advanceToNextAgent(msgs);
-      } finally {
-        setIsLoading(false);
-      }
-    }
   }
 
   async function advanceToNextAgent(currentMessages: Message[]) {
@@ -550,8 +501,7 @@ export default function InterviewSession({ name }: { name: string }) {
       setHintVisible(false);
       setAgentIndex(nextAgentIndex);
       setFollowUpRound(0);
-      setParallelThoughts(null);
-      setSelectedFollowUpAgentId(null);
+      setCurrentThought(null);
       setQuestionReady(true);
     }
   }
@@ -566,11 +516,9 @@ export default function InterviewSession({ name }: { name: string }) {
     setError("");
     setCurrentHint("");
     setHintVisible(false);
-    setParallelThoughts(null);
-    setSelectedFollowUpAgentId(null);
+    setCurrentThought(null);
     setQuestionReady(true);
     setIsThinkingPhase(false);
-    pendingAdvanceMsgsRef.current = null;
     setSessionId(null);
     setDebateResult(null);
     setDebateError("");
@@ -709,24 +657,15 @@ export default function InterviewSession({ name }: { name: string }) {
         <span className="font-medium">면접 진행 중</span>
       </div>
 
-      {/* 병렬 속마음 버블 (easy/normal 전용) */}
-      {parallelThoughts && difficulty !== "hard" && difficulty !== "tutorial" && (
-        <ParallelThoughtBubbles
-          key={parallelThoughts[0]?.thought.reaction}
-          thoughts={parallelThoughts}
-          selectedAgentId={selectedFollowUpAgentId}
-          avatarSeeds={avatarSeeds}
-          onAllDone={handleThoughtsAllDone}
-        />
-      )}
-
-      {/* 면접관 패널 */}
+      {/* 면접관 패널 (속마음 말풍선 포함) */}
       <InterviewerPanel
         agentIndex={agentIndex}
         isLoading={isLoading}
         isThinkingPhase={isThinkingPhase}
         isSpeaking={isSpeaking}
         avatarSeeds={avatarSeeds}
+        currentThought={difficulty !== "hard" && difficulty !== "tutorial" ? currentThought : null}
+        onThoughtDone={handleThoughtsAllDone}
       />
 
       {/* 현재 질문 말풍선 */}

--- a/lib/interview.ts
+++ b/lib/interview.ts
@@ -4,7 +4,13 @@ const OLLAMA_MODEL = process.env.OLLAMA_MODEL ?? "exaone3.5:2.4b";
 export type AgentId = "organization" | "logic" | "technical";
 export type Difficulty = "tutorial" | "easy" | "normal" | "hard";
 
-export const MAX_FOLLOWUP_ROUNDS = 4; // 무한루프 방지용 안전 캡
+// 난이도별 에이전트당 최대 꼬리질문 횟수
+export const MAX_FOLLOWUP_ROUNDS: Record<Difficulty, number> = {
+  tutorial: 0,
+  easy: 1,
+  normal: 2,
+  hard: 3,
+};
 
 export const AGENT_ORDER: AgentId[] = ["organization", "logic", "technical"];
 export const TOTAL_AGENTS = AGENT_ORDER.length;
@@ -384,7 +390,7 @@ STAR, S, T, A, R 같은 영어 약어를 출력에 사용하지 마세요.`,
 const DIFFICULTY_FOLLOWUP_HINT: Record<Difficulty, string> = {
   tutorial: "", // 사용 안 함 — tutorial 모드는 꼬리질문 없음
   easy: "핵심을 완전히 빠뜨린 경우에만 shouldAsk를 true로 설정하세요.",
-  normal: "구체적인 사례나 핵심 내용이 부족해서 공정한 평가가 어렵다면 shouldAsk를 true로 설정하세요.",
+  normal: "답변에 구체적인 경험 사례가 하나 이상 포함됐다면 shouldAsk를 false로 설정하세요. 경험이 전혀 언급되지 않거나 답변 전체가 추상적인 경우에만 true로 설정하세요.",
   hard: "수치, 프로젝트명, 구체적 깊이가 포함된 경우에만 shouldAsk를 false로 설정하세요. 모호하거나 추상적인 답변은 항상 shouldAsk를 true로 설정하세요.",
 };
 
@@ -461,6 +467,7 @@ async function generateSingleAgentThought(
   jobPosting: JobPostingContext,
   messages: Message[],
   difficulty: Difficulty,
+  followUpRound: number = 0,
 ): Promise<AgentThoughtResult> {
   const profileSummary = buildProfileSummary(profile);
   const conversationText = messages
@@ -479,6 +486,12 @@ ${profileSummary}
 
 반드시 유효한 JSON만 응답하세요 — 다른 텍스트 없이.`;
 
+  const roundPressure = followUpRound >= 2
+    ? `\n⚠️ 이미 꼬리질문을 ${followUpRound}번 했습니다. 치명적인 논리 오류나 완전한 답변 회피가 아닌 이상 shouldAsk를 false로 설정하세요.`
+    : followUpRound === 1
+    ? `\n이미 꼬리질문을 1번 했습니다. 답변에 구체적인 내용이 조금이라도 있다면 shouldAsk를 false로 설정하세요.`
+    : "";
+
   const userContent = `[면접 대화 기록]
 ${conversationText}
 
@@ -486,7 +499,7 @@ ${conversationText}
 
 꼬리질문 트리거 기준: ${AGENT_FOLLOWUP_CRITERIA[agentId]}
 
-난이도 가이드: ${DIFFICULTY_FOLLOWUP_HINT[difficulty]}
+난이도 가이드: ${DIFFICULTY_FOLLOWUP_HINT[difficulty]}${roundPressure}
 
 꼬리질문을 한다면, 반드시 지원자의 마지막 답변에서 구체적인 부분을 언급하고 질문은 1개만 하세요.
 
@@ -547,16 +560,24 @@ ${conversationText}
   }
 }
 
-// 3개 에이전트 병렬 속마음 생성 (easy/normal/hard 모드용, tutorial은 호출하지 않음)
-export async function generateParallelFollowUpThoughts(
+// 현재 에이전트 우선으로 순차 호출, shouldAsk=true 발견 즉시 반환 (불필요한 호출 최소화)
+export async function findFollowUpAgent(
   profile: ProfileContext,
   jobPosting: JobPostingContext,
   messages: Message[],
   difficulty: Difficulty,
-): Promise<AgentThoughtResult[]> {
-  return Promise.all(
-    AGENT_ORDER.map((agentId) =>
-      generateSingleAgentThought(agentId, profile, jobPosting, messages, difficulty),
-    ),
-  );
+  currentAgentId: AgentId,
+  followUpRound: number = 0,
+): Promise<{ thought: AgentThoughtResult | null; selectedAgentId: AgentId | null }> {
+  // 현재 에이전트 + 아직 차례가 안 온 에이전트만 (이미 끝난 에이전트는 제외)
+  const priority: AgentId[] = AGENT_ORDER.slice(AGENT_ORDER.indexOf(currentAgentId));
+
+  for (const agentId of priority) {
+    const thought = await generateSingleAgentThought(agentId, profile, jobPosting, messages, difficulty, followUpRound);
+    if (thought.shouldAsk && thought.question) {
+      return { thought, selectedAgentId: agentId };
+    }
+  }
+
+  return { thought: null, selectedAgentId: null };
 }


### PR DESCRIPTION
## Summary
- 난이도별 에이전트당 꼬리질문 횟수 캡 (easy 1 / normal 2 / hard 3)
- cross-follow-up: 현재 에이전트 우선, 아직 차례 안 온 에이전트도 가능 (이미 끝난 에이전트 제외)
- LLM 호출 최소화: 순차 호출 + early exit (기존 항상 3번 → 평균 1~2번)
- 속마음 버블: 꼬리질문 에이전트 1개만, 해당 면접관 칼럼 위에 말풍선 모양으로 표시

Closes #77

## Test plan
- [ ] normal 모드에서 구체적인 답변 시 꼬리질문 2회 이하로 제한되는지 확인
- [ ] 면접관 2/3 구간에서 cross-follow-up 발생하는지 확인
- [ ] 꼬리질문 시 해당 면접관 위에 말풍선 버블 표시 확인
- [ ] 꼬리질문 없을 때 버블 없이 바로 다음으로 넘어가는지 확인
- [ ] easy / hard 모드 정상 동작 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)