### PR TITLE
feat(debate): 면접관 평가·토론 Phase 1 고도화

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,6 @@ test-*.png
 # python cache
 server/__pycache__/
 **/*.pyc
+
+# planning docs
+*.txt

--- a/app/api/interview/debate/route.ts
+++ b/app/api/interview/debate/route.ts
@@ -2,7 +2,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { supabase } from "@/lib/supabase";
 import { getAuthUser } from "@/lib/auth";
 import type { Json } from "@/types/supabase";
-import { Message, Difficulty, AGENT_ORDER } from "@/lib/interview";
+import { Message, Difficulty, AGENT_ORDER, ProfileContext, JobPostingContext } from "@/lib/interview";
 import {
   generateAgentEvaluation,
   generateAgentReply,
@@ -14,6 +14,8 @@ import {
 async function runDebate(
   sessionId: string,
   messages: Message[],
+  profile: ProfileContext,
+  jobPosting: JobPostingContext,
 ) {
   try {
     // Round 0: 에이전트 순차 평가 — 각자 완료 즉시 저장 (클라이언트에 실시간 표시)
@@ -21,9 +23,9 @@ async function runDebate(
     for (const agentId of AGENT_ORDER) {
       let evaluation: AgentEvaluation;
       try {
-        evaluation = await generateAgentEvaluation(agentId, messages);
+        evaluation = await generateAgentEvaluation(agentId, messages, profile, jobPosting);
       } catch {
-        continue; // 한 에이전트 실패 시 다음으로
+        continue;
       }
       evaluations.push(evaluation);
       await supabase
@@ -40,12 +42,12 @@ async function runDebate(
       throw new Error("에이전트 평가 실패 (2개 미만 성공)");
     }
 
-    // Round 1: 순차 상호 반론 — 완료 즉시 저장 (클라이언트에 1명씩 표시)
+    // Round 1: 순차 상호 피드백 — 완료 즉시 저장 (클라이언트에 1명씩 표시)
     const replies: AgentReply[] = [];
     for (const myEval of evaluations) {
       const others = evaluations.filter((e) => e.agentId !== myEval.agentId);
       try {
-        const reply = await generateAgentReply(myEval.agentId, myEval, others, messages);
+        const reply = await generateAgentReply(myEval.agentId, myEval, others, messages, profile, jobPosting);
         replies.push(reply);
         await supabase
           .from("interview_sessions")
@@ -61,7 +63,6 @@ async function runDebate(
       .update({ status: "finalizing", updatedAt: new Date().toISOString() })
       .eq("id", sessionId);
 
-    // 중재자: 최종 결론
     const repliesForModerator: AgentReply[] =
       replies.length > 0
         ? replies
@@ -71,13 +72,22 @@ async function runDebate(
             replies: [],
           }));
 
-    const moderatorResult = await generateModeratorResult(evaluations, repliesForModerator, messages);
+    const moderatorResult = await generateModeratorResult(
+      evaluations,
+      repliesForModerator,
+      messages,
+      profile,
+      jobPosting,
+    );
 
     await supabase
       .from("interview_sessions")
       .update({
         finalScore: moderatorResult.score,
-        finalFeedback: moderatorResult.overall as unknown as Json,
+        finalFeedback: {
+          ...moderatorResult.overall,
+          recommendLevel: moderatorResult.recommendLevel,
+        } as unknown as Json,
         debateSummary: moderatorResult.debateSummary,
         improvementTips: moderatorResult.improvementTips as unknown as Json,
         status: "done",
@@ -110,6 +120,18 @@ export async function POST(request: NextRequest) {
       .maybeSingle();
     if (!profile) return NextResponse.json({ error: "프로필이 없습니다" }, { status: 404 });
 
+    const [
+      { data: educations },
+      { data: careers },
+      { data: certifications },
+      { data: activities },
+    ] = await Promise.all([
+      supabase.from("educations").select("*").eq("profileId", profile.id),
+      supabase.from("careers").select("*").eq("profileId", profile.id),
+      supabase.from("certifications").select("*").eq("profileId", profile.id),
+      supabase.from("activities").select("*").eq("profileId", profile.id),
+    ]);
+
     const { data: jobPosting } = await supabase
       .from("job_postings")
       .select("id, responsibilities, requirements, preferredQuals")
@@ -118,6 +140,20 @@ export async function POST(request: NextRequest) {
       .limit(1)
       .maybeSingle();
     if (!jobPosting) return NextResponse.json({ error: "채용공고가 없습니다" }, { status: 404 });
+
+    const profileContext: ProfileContext = {
+      name: profile.name,
+      educations: educations ?? [],
+      careers: careers ?? [],
+      certifications: certifications ?? [],
+      activities: activities ?? [],
+    };
+
+    const jobPostingContext: JobPostingContext = {
+      responsibilities: jobPosting.responsibilities ?? "",
+      requirements: jobPosting.requirements ?? "",
+      preferredQuals: jobPosting.preferredQuals ?? "",
+    };
 
     const sessionId = crypto.randomUUID();
 
@@ -133,7 +169,7 @@ export async function POST(request: NextRequest) {
     });
 
     // fire-and-forget
-    runDebate(sessionId, messages).catch(() => {});
+    runDebate(sessionId, messages, profileContext, jobPostingContext).catch(() => {});
 
     return NextResponse.json({ sessionId });
   } catch (error) {

--- a/components/DebateLoading.tsx
+++ b/components/DebateLoading.tsx
@@ -7,7 +7,7 @@ import type { AgentId } from "@/lib/interview";
 export interface DebateResultData {
   agentEvaluations: AgentEvaluation[];
   finalScore: number;
-  finalFeedback: ModeratorResult["overall"];
+  finalFeedback: ModeratorResult["overall"] & { recommendLevel?: string };
   debateSummary: string;
   improvementTips: string[];
 }
@@ -117,18 +117,26 @@ function EvalCard({
 
   return (
     <div className={`card p-5 border-l-4 ${colors.border} space-y-3 animate-fade-in-up`}>
-      <div className="flex items-center gap-3">
-        <img
-          src={avatarUrl(avatarSeeds[agentId], meta.bgColor)}
-          alt={meta.name}
-          className="w-10 h-10 rounded-full shrink-0"
-        />
-        <div className="space-y-0.5">
-          <span className={`text-xs font-semibold px-2 py-0.5 rounded-full ${colors.badge}`}>
-            {evalData.agentLabel}
-          </span>
-          <p className="text-xs text-gray-400 dark:text-slate-500 pt-0.5">{evalData.criterion}</p>
+      <div className="flex items-center justify-between gap-3">
+        <div className="flex items-center gap-3">
+          <img
+            src={avatarUrl(avatarSeeds[agentId], meta.bgColor)}
+            alt={meta.name}
+            className="w-10 h-10 rounded-full shrink-0"
+          />
+          <div className="space-y-0.5">
+            <span className={`text-xs font-semibold px-2 py-0.5 rounded-full ${colors.badge}`}>
+              {evalData.agentLabel}
+            </span>
+            <p className="text-xs text-gray-400 dark:text-slate-500 pt-0.5">{evalData.criterion}</p>
+          </div>
         </div>
+        {evalData.verdict && (
+          <div className="text-right shrink-0">
+            <p className="text-xs text-gray-400 dark:text-slate-500">{evalData.verdictLabel}</p>
+            <p className={`text-xs font-bold mt-0.5 ${meta.color}`}>{evalData.verdict}</p>
+          </div>
+        )}
       </div>
       <p className="text-sm text-gray-700 dark:text-slate-300 leading-relaxed">{evalData.opinion}</p>
       {evalData.highlights.length > 0 && (

--- a/components/DebateResult.tsx
+++ b/components/DebateResult.tsx
@@ -6,12 +6,19 @@ import type { AgentId } from "@/lib/interview";
 interface Props {
   finalScore: number;
   agentEvaluations: AgentEvaluation[];
-  finalFeedback: { strengths: string; weaknesses: string; advice: string };
+  finalFeedback: { strengths: string; weaknesses: string; advice: string; recommendLevel?: string };
   debateSummary: string;
   improvementTips: string[];
   onRestart: () => void;
   onBack: () => void;
 }
+
+const RECOMMEND_STYLE: Record<string, { bg: string; text: string }> = {
+  "강력 추천": { bg: "bg-green-100 dark:bg-green-900/40", text: "text-green-700 dark:text-green-300" },
+  "추천":     { bg: "bg-blue-100 dark:bg-blue-900/40",  text: "text-blue-700 dark:text-blue-300" },
+  "보류":     { bg: "bg-orange-100 dark:bg-orange-900/40", text: "text-orange-700 dark:text-orange-300" },
+  "비추천":   { bg: "bg-red-100 dark:bg-red-900/40",    text: "text-red-700 dark:text-red-300" },
+};
 
 function ScoreRing({ score }: { score: number }) {
   const radius = 52;
@@ -92,9 +99,19 @@ export default function DebateResult({
         ← 면접관 토론 돌아보기
       </button>
 
-      {/* 점수 링 */}
-      <div className="card p-8 flex justify-center">
+      {/* 점수 링 + 채용 권고 */}
+      <div className="card p-8 flex flex-col items-center gap-4">
         <ScoreRing score={finalScore} />
+        {finalFeedback.recommendLevel && (() => {
+          const style = RECOMMEND_STYLE[finalFeedback.recommendLevel!] ?? RECOMMEND_STYLE["보류"];
+          return (
+            <div className={`px-5 py-2 rounded-full ${style.bg}`}>
+              <span className={`text-sm font-bold ${style.text}`}>
+                채용 권고: {finalFeedback.recommendLevel}
+              </span>
+            </div>
+          );
+        })()}
       </div>
 
       {/* 면접관별 평가 — 아코디언 */}
@@ -106,11 +123,16 @@ export default function DebateResult({
             return (
               <details key={e.agentId} className={`card border-l-4 ${colors.border} group`}>
                 <summary className="p-5 cursor-pointer list-none flex items-center justify-between gap-3">
-                  <div className="flex items-center gap-2">
+                  <div className="flex items-center gap-2 flex-wrap">
                     <span className={`text-xs font-semibold px-2 py-0.5 rounded-full ${colors.badge}`}>
                       {e.agentLabel}
                     </span>
                     <span className="text-xs text-gray-400 dark:text-slate-500">{e.criterion}</span>
+                    {e.verdict && (
+                      <span className={`text-xs font-semibold px-2 py-0.5 rounded-full ${colors.badge} opacity-80`}>
+                        {e.verdictLabel}: {e.verdict}
+                      </span>
+                    )}
                   </div>
                   <span className="text-gray-400 dark:text-slate-500 text-xs shrink-0">▼</span>
                 </summary>
@@ -186,12 +208,12 @@ export default function DebateResult({
         </div>
       )}
 
-      {/* 토론 요약 — 기본 접힘 */}
+      {/* 토론 요약 — 기본 펼침 */}
       {debateSummary && (
-        <details className="card overflow-hidden">
+        <details className="card overflow-hidden" open>
           <summary className="p-5 cursor-pointer list-none flex items-center justify-between gap-3 text-sm font-semibold text-gray-600 dark:text-slate-400">
-            <span>면접관 토론 요약</span>
-            <span className="text-gray-400 dark:text-slate-500 text-xs">▼</span>
+            <span>💬 면접관 토론 요약</span>
+            <span className="text-gray-400 dark:text-slate-500 text-xs">▲</span>
           </summary>
           <div className="px-5 pb-5 border-t border-gray-50 dark:border-slate-700/50 pt-4">
             <p className="text-sm text-gray-600 dark:text-slate-400 leading-relaxed">{debateSummary}</p>

--- a/lib/agents.ts
+++ b/lib/agents.ts
@@ -1,4 +1,4 @@
-import { AgentId, AGENTS, Message } from "@/lib/interview";
+import { AgentId, AGENTS, Message, ProfileContext, JobPostingContext, buildProfileSummary } from "@/lib/interview";
 
 const OLLAMA_BASE_URL = process.env.OLLAMA_BASE_URL ?? "http://localhost:11434";
 const OLLAMA_MODEL = process.env.OLLAMA_MODEL ?? "exaone3.5:2.4b";
@@ -7,8 +7,10 @@ export interface AgentEvaluation {
   agentId: AgentId;
   agentLabel: string;
   criterion: string;
-  opinion: string;      // 3~5 문장
-  highlights: string[]; // 2~3개 핵심 포인트
+  opinion: string;
+  highlights: string[];
+  verdict?: string;      // 에이전트별 핵심 판정 값 (예: "즉시 가능", "신뢰도: 보통", "2단계")
+  verdictLabel?: string; // 판정 항목명 (예: "즉시투입 판정", "종합 신뢰도", "자기변화")
 }
 
 export interface AgentReply {
@@ -23,6 +25,7 @@ export interface AgentReply {
 
 export interface ModeratorResult {
   score: number;
+  recommendLevel: "강력 추천" | "추천" | "보류" | "비추천";
   overall: { strengths: string; weaknesses: string; advice: string };
   improvementTips: string[];
   debateSummary: string;
@@ -70,56 +73,230 @@ function buildConversationText(messages: Message[]): string {
     .join("\n\n");
 }
 
-// Round 0: 에이전트별 독립 평가
+function buildContextBlock(profile: ProfileContext, jobPosting: JobPostingContext): string {
+  const profileSummary = buildProfileSummary(profile);
+  const jobParts = [
+    jobPosting.responsibilities ? `담당 업무: ${jobPosting.responsibilities}` : "",
+    jobPosting.requirements ? `자격 요건: ${jobPosting.requirements}` : "",
+    jobPosting.preferredQuals ? `우대 사항: ${jobPosting.preferredQuals}` : "",
+  ].filter(Boolean);
+  return `[지원자 배경]\n${profileSummary}\n\n[채용 직무]\n${jobParts.join("\n")}`;
+}
+
+// ── 에이전트별 시스템 프롬프트 ────────────────────────────────────────────
+
+const AGENT_SYSTEM_PROMPTS: Record<AgentId, string> = {
+  logic: `당신은 [논리전문가] 에이전트입니다.
+판단 철학: "이건 사실인가? 아니면 그럴듯하게 포장된 말인가?"
+칭찬은 최소화하고, 의심을 기본값으로 합니다.
+
+평가 기준:
+1. 주장·근거 구조: 근거 없이 주장만 있는 문장은 직접 인용해서 지적하세요.
+2. 검증 가능성: "좋아졌다", "성과가 있었다" 같은 표현은 직접 인용 후 확인 불가로 표시하세요. 수치가 있어도 기간·기준·모집단이 없으면 신뢰도 낮음으로 판정하세요.
+3. 인과 관계: "열심히 했고 결과가 좋았다"는 인과 불명확으로 판정하세요. 본인 기여인지 팀 기여인지 불분명하면 지적하세요.
+4. 압박 내성: 가장 취약한 지점 1개를 선정하고 예상 후속 질문 형태로 반드시 제시하세요.
+5. 모순·과장 탐지: "많이", "잘", "좋았다" 같은 추상어는 직접 인용 후 지적하세요. 모순 없으면 반드시 "없음"으로 명시하세요.
+
+반드시 유효한 JSON만 응답하세요 — 다른 텍스트 없이.`,
+
+  technical: `당신은 [기술전문가] 에이전트입니다.
+판단 철학: "그래서 이 사람, 내일 당장 써먹을 수 있냐?"
+잠재력·인성은 다른 에이전트가 봅니다. 오직 지금 당장 업무 수행 가능한가만 판단합니다.
+
+평가 기준:
+1. 직무 기술 매칭: 툴 이름이 명시되어야 확인 가능. "데이터 분석"만 있고 툴이 없으면 기술 수준 불명확으로 판정하세요.
+2. 경험 주도성: "저는 분석했다" vs "팀이 결정했다"를 구분. 단독 주도/팀 참여/제안 수준/불명확 중 하나로 판정하고 근거 표현을 직접 인용하세요.
+3. STAR 구조: 상황(S)·과제(T)·행동(A)·결과(R) 각각 있는지 확인. 빠진 항목과 이유를 명시하세요.
+4. 성과 실질성: 수치 + 기간 + 기준이 모두 있어야 실질적 성과. "좋은 결과를 냈다"는 직접 인용 후 실질성 없음으로 표시하세요.
+5. 즉시 투입 판정: 즉시 가능/온보딩 후 가능/추가 경험 필요 중 하나로 판정하고 예상 실무 리스크를 서술하세요.
+
+반드시 유효한 JSON만 응답하세요 — 다른 텍스트 없이.`,
+
+  organization: `당신은 [조직전문가] 에이전트입니다.
+판단 철학: "이 사람, 같이 일하면 좋은가? 오래 갈 사람인가?"
+현재 실력보다 변화 궤적과 팀 안에서의 존재 방식을 더 중요하게 봅니다.
+
+평가 기준:
+1. 자기변화 속도: 인식(1단계)/행동변화(2단계)/결과변화(3단계) 중 하나로 판정. 근거 인용 필수.
+2. 피드백 수용: 피드백을 먼저 구한 흔적이 있으면 능동적. "받아들이는 연습을 하고 있다"면 수동적.
+3. 성장 설계: "열심히 하겠다" 선언만 있으면 설계 없음. 구체적인 루틴이 있으면 설계 있음.
+4. 협업 역할: 주도형/지원형/불명확 중 하나로 판정. 공을 나누는 표현 vs 독점 표현을 분석하세요.
+5. 갈등 대응: 구체적 갈등 사례와 해결 행동이 있는지 확인. "잘 해결했다"는 빈 표현으로 직접 인용 후 지적하세요. 갈등 사례 없으면 "사례 없음"으로 명시하세요.
+6. 기여 지향성: "배우고 싶다" = 수혜, "기여하고 싶다" = 기여. 두 표현의 비율을 서술하세요.
+
+반드시 유효한 JSON만 응답하세요 — 다른 텍스트 없이.`,
+};
+
+// 피드백 공통 규칙 (Round 1 상호 피드백에 적용)
+const FEEDBACK_RULES = `피드백 시 반드시 지킬 규칙:
+1. 상대 에이전트 출력의 특정 문장을 직접 인용한 뒤, 그 판단이 당신 기준으로 왜 부족하거나 다른지 설명하세요. 인용 없는 피드백은 무효입니다.
+2. "지원자가 ~할 의무는 없다", "지원자는 ~했을 수 있다", "지원자를 변호하면" 같은 표현은 금지입니다. 오직 상대 에이전트의 판단 논리만 비판하세요.
+3. "동의합니다" 또는 "잘 분석하셨습니다"로 시작하지 마세요. 동의하더라도 상대가 놓친 부분을 반드시 1개 이상 지적하세요.
+4. 피드백은 반드시 당신 에이전트의 평가 기준으로만 작성하세요.
+5. 각 지적 사항은 3문장 이내로 간결하게 작성하세요. 서론, 요약, 맺음말을 쓰지 마세요.`;
+
+// ── Round 0: 에이전트별 독립 평가 ────────────────────────────────────────
+
 export async function generateAgentEvaluation(
   agentId: AgentId,
   messages: Message[],
+  profile: ProfileContext,
+  jobPosting: JobPostingContext,
 ): Promise<AgentEvaluation> {
   const agent = AGENTS[agentId];
   const conversationText = buildConversationText(messages);
+  const contextBlock = buildContextBlock(profile, jobPosting);
 
-  const systemPrompt = `당신은 ${agent.label}입니다. 면접이 방금 끝났고, 지금 동료 면접관들과 비공개 디브리핑 룸에 있습니다. 공식 보고서가 아니라, 솔직한 첫인상을 동료에게 털어놓는 자리입니다.
-당신의 평가 영역: ${agent.criterion}.
-동료에게 말하듯 자연스럽고 직접적으로 이야기하세요. 지원자가 실제로 한 말을 인용하거나 바꿔 말하면서 구체적인 순간을 언급하세요. 확신이 없거나 복잡한 감정도 표현해도 됩니다.
-반드시 유효한 JSON만 응답하세요 — 다른 텍스트 없이.`;
+  let jsonSchema: string;
 
-  const userContent = `[면접 대화 기록]
+  if (agentId === "logic") {
+    jsonSchema = `{
+  "unverifiable": "<확인 불가 표현 직접 인용 + 이유. 없으면 '없음'>",
+  "logicErrors": "<모순/인과오류 문장 인용 + 설명. 없으면 '없음'>",
+  "weakestPoint": "<가장 취약한 지점 + 예상 후속 질문 형태>",
+  "reliabilityVerdict": "<높음 | 보통 | 낮음>",
+  "opinion": "<전체 평가 요약 3~4문장. 답변 직접 인용 포함>"
+}`;
+  } else if (agentId === "technical") {
+    jsonSchema = `{
+  "leadershipVerdict": "<단독 주도 | 팀 참여 | 제안 수준 | 불명확>",
+  "leadershipEvidence": "<위 판정의 근거가 된 답변 직접 인용>",
+  "starMissing": "<빠진 STAR 항목과 이유. 없으면 '없음'>",
+  "practicalRisks": "<채용 시 예상 실무 리스크 1~2개>",
+  "deployVerdict": "<즉시 가능 | 온보딩 후 가능 | 추가 경험 필요>",
+  "opinion": "<전체 평가 요약 3~4문장. 답변 직접 인용 및 직무 요건과 대조 포함>"
+}`;
+  } else {
+    jsonSchema = `{
+  "changeStage": "<1 | 2 | 3>",
+  "changeEvidence": "<위 판정 근거가 된 답변 직접 인용>",
+  "feedbackDirection": "<능동적 | 수동적 | 판단 불가>",
+  "growthDesign": "<설계 있음 | 설계 없음>",
+  "collaborationRole": "<주도형 | 지원형 | 불명확>",
+  "collaborationEvidence": "<위 판정의 근거가 된 답변 직접 인용>",
+  "contributionBalance": "<수혜/기여 비율 서술>",
+  "opinion": "<전체 평가 요약 3~4문장. 답변 직접 인용 포함>"
+}`;
+  }
+
+  const userContent = `${contextBlock}
+
+[면접 대화 기록]
 ${conversationText}
 
-${agent.label}로서 당신의 평가 영역인 "${agent.criterion}" 관점에서 솔직한 첫인상을 공유해주세요.
+당신의 평가 기준에 따라 위 지원자의 답변을 평가하세요.
 
 다음 JSON 형식으로 응답하세요:
-{
-  "opinion": "<솔직한 첫인상을 3-5문장으로. '솔직히...', '사실 저는...', '면접 보면서 느낀 건데...' 같은 표현으로 시작하세요. 지원자가 실제로 한 말을 인용하거나 바꿔 말하며 특정 질문-답변 순간을 언급하세요. 확신이 없는 부분도 솔직하게 표현하세요.>",
-  "highlights": [
-    "<기억에 남는 순간 또는 지원자가 한 구체적인 말 — 긍정적이거나 부정적인 것 모두>",
-    "<확신이 없거나 더 파악하고 싶은 부분>",
-    "<전체적인 인상을 결정지은 결정적인 요소>"
-  ]
-}
+${jsonSchema}
 문자열 값 안에 마크다운 서식(**, *, #)을 사용하지 마세요.`;
 
-  const raw = await callOllama(systemPrompt, userContent);
-  const parsed = extractJSON<{ opinion: string; highlights: string[] }>(raw);
+  const raw = await callOllama(AGENT_SYSTEM_PROMPTS[agentId], userContent);
+
+  if (agentId === "logic") {
+    const parsed = extractJSON<{
+      unverifiable: string;
+      logicErrors: string;
+      weakestPoint: string;
+      reliabilityVerdict: string;
+      opinion: string;
+    }>(raw);
+
+    const highlights = [
+      parsed.unverifiable && parsed.unverifiable !== "없음"
+        ? `검증 불가: ${parsed.unverifiable}`
+        : null,
+      parsed.logicErrors && parsed.logicErrors !== "없음"
+        ? `논리 오류: ${parsed.logicErrors}`
+        : null,
+      parsed.weakestPoint ? `취약점: ${parsed.weakestPoint}` : null,
+    ].filter(Boolean) as string[];
+
+    return {
+      agentId,
+      agentLabel: agent.label,
+      criterion: agent.criterion,
+      opinion: parsed.opinion ?? "",
+      highlights: highlights.slice(0, 3),
+      verdict: parsed.reliabilityVerdict ?? "",
+      verdictLabel: "종합 신뢰도",
+    };
+  }
+
+  if (agentId === "technical") {
+    const parsed = extractJSON<{
+      leadershipVerdict: string;
+      leadershipEvidence: string;
+      starMissing: string;
+      practicalRisks: string;
+      deployVerdict: string;
+      opinion: string;
+    }>(raw);
+
+    const highlights = [
+      parsed.leadershipVerdict
+        ? `경험 주도성: ${parsed.leadershipVerdict}${parsed.leadershipEvidence ? ` — "${parsed.leadershipEvidence}"` : ""}`
+        : null,
+      parsed.starMissing && parsed.starMissing !== "없음"
+        ? `STAR 미충족: ${parsed.starMissing}`
+        : null,
+      parsed.practicalRisks ? `실무 리스크: ${parsed.practicalRisks}` : null,
+    ].filter(Boolean) as string[];
+
+    return {
+      agentId,
+      agentLabel: agent.label,
+      criterion: agent.criterion,
+      opinion: parsed.opinion ?? "",
+      highlights: highlights.slice(0, 3),
+      verdict: parsed.deployVerdict ?? "",
+      verdictLabel: "즉시투입 판정",
+    };
+  }
+
+  // organization
+  const parsed = extractJSON<{
+    changeStage: string;
+    changeEvidence: string;
+    feedbackDirection: string;
+    growthDesign: string;
+    collaborationRole: string;
+    collaborationEvidence: string;
+    contributionBalance: string;
+    opinion: string;
+  }>(raw);
+
+  const highlights = [
+    parsed.changeStage
+      ? `자기변화 ${parsed.changeStage}단계${parsed.changeEvidence ? ` — "${parsed.changeEvidence}"` : ""}`
+      : null,
+    [parsed.feedbackDirection, parsed.growthDesign].filter(Boolean).join(", ") || null,
+    parsed.contributionBalance ? `기여 성향: ${parsed.contributionBalance}` : null,
+  ].filter(Boolean) as string[];
 
   return {
     agentId,
     agentLabel: agent.label,
     criterion: agent.criterion,
-    opinion: parsed.opinion,
-    highlights: (parsed.highlights ?? []).slice(0, 3),
+    opinion: parsed.opinion ?? "",
+    highlights: highlights.slice(0, 3),
+    verdict: parsed.changeStage ? `${parsed.changeStage}단계` : "",
+    verdictLabel: "자기변화",
   };
 }
 
-// Round 1: 상호 반론 + 점수 재검토
+// ── Round 1: 상호 피드백 ─────────────────────────────────────────────────
+
 export async function generateAgentReply(
   agentId: AgentId,
   myEvaluation: AgentEvaluation,
   otherEvaluations: AgentEvaluation[],
   messages: Message[],
+  profile: ProfileContext,
+  jobPosting: JobPostingContext,
 ): Promise<AgentReply> {
   const agent = AGENTS[agentId];
   const conversationText = buildConversationText(messages);
+  const contextBlock = buildContextBlock(profile, jobPosting);
 
   const othersText = otherEvaluations
     .map(
@@ -130,32 +307,29 @@ export async function generateAgentReply(
 
   const replySchema = otherEvaluations
     .map((e) =>
-      `    {\n      "targetAgentId": "${e.agentId}",\n      "stance": "<agree|disagree|partial>",\n      "comment": "<동료의 의견에 대한 자연스러운 구어체 반응 2-3문장. 지원자가 실제로 한 말을 언급하세요. 리뷰가 아니라 동료에게 말하는 톤으로.>"\n    }`
+      `    {\n      "targetAgentId": "${e.agentId}",\n      "stance": "<agree|disagree|partial>",\n      "comment": "<상대 에이전트의 특정 문장을 직접 인용한 뒤, 당신 기준에서 왜 부족하거나 다른지 3문장 이내로 설명. 동의하더라도 반드시 놓친 부분 1개 이상 지적>"\n    }`
     )
     .join(",\n");
 
-  const systemPrompt = `당신은 ${agent.label}입니다. 지금 동료 면접관들과 비공개 디브리핑 룸에 있습니다. 동료들의 의견을 방금 들었고, 이제 당신이 반응할 차례입니다.
-당신의 평가 영역: ${agent.criterion}.
-자연스럽게 반응하세요 — 진심으로 동의하면 동의하고, 당신이 관찰한 것과 다르면 구체적인 이유와 함께 반박하세요.
+  const systemPrompt = `당신은 ${agent.label}입니다. 동료 면접관들의 평가를 방금 들었고, 이제 당신이 반응할 차례입니다.
+당신의 평가 기준: ${agent.criterion}.
+
+${FEEDBACK_RULES}
+
 반드시 유효한 JSON만 응답하세요 — 다른 텍스트 없이.`;
 
-  const userContent = `[면접 대화 기록]
+  const userContent = `${contextBlock}
+
+[면접 대화 기록]
 ${conversationText}
 
-[당신의 Round 0 평가]
+[내 평가]
 ${myEvaluation.opinion}
 
-[다른 면접관들의 의견]
+[다른 면접관들의 평가]
 ${othersText}
 
-동료들이 방금 한 말에 반응하세요.
-
-가이드라인:
-- 동료의 관찰이 당신과 일치하면, 동의하면서 당신이 "${agent.criterion}" 관점에서 직접 본 것을 추가하세요.
-- 동료가 당신 관점에서 중요한 것을 놓쳤다면, 무엇을 왜 놓쳤는지 설명하며 반박하세요.
-- 진짜로 확신이 없다면 솔직하게 말해도 됩니다 — "저도 그 부분이 좀 애매했는데..." 같은 반응도 괜찮습니다.
-- 리뷰를 쓰는 게 아니라 동료에게 말하는 것처럼 하세요.
-- 지원자가 실제로 한 말을 인용하거나 바꿔 말하세요.
+동료들의 평가에 반응하세요.
 
 다음 JSON 형식으로 응답하세요:
 {
@@ -166,14 +340,14 @@ ${replySchema}
 문자열 값 안에 마크다운 서식(**, *, #)을 사용하지 마세요.`;
 
   const raw = await callOllama(systemPrompt, userContent);
-  const parsed = extractJSON<{
+  const parsedReply = extractJSON<{
     replies: { targetAgentId: string; stance: string; comment: string }[];
   }>(raw);
 
   return {
     agentId,
     agentLabel: agent.label,
-    replies: (parsed.replies ?? []).map((r) => ({
+    replies: (parsedReply.replies ?? []).map((r) => ({
       targetAgentId: r.targetAgentId,
       stance: (["agree", "disagree", "partial"].includes(r.stance)
         ? r.stance
@@ -183,16 +357,23 @@ ${replySchema}
   };
 }
 
-// 중재자: 최종 종합
+// ── 중재자: 최종 종합 ────────────────────────────────────────────────────
+
 export async function generateModeratorResult(
   evaluations: AgentEvaluation[],
   replies: AgentReply[],
   messages: Message[],
+  profile: ProfileContext,
+  jobPosting: JobPostingContext,
 ): Promise<ModeratorResult> {
   const conversationText = buildConversationText(messages);
+  const contextBlock = buildContextBlock(profile, jobPosting);
 
   const evaluationsText = evaluations
-    .map((e) => `[${e.agentLabel}] 평가 영역: ${e.criterion}\n${e.opinion}\n핵심 포인트: ${e.highlights.join(" / ")}`)
+    .map((e) => {
+      const verdictLine = e.verdict ? `판정: ${e.verdictLabel} — ${e.verdict}` : "";
+      return `[${e.agentLabel}] 평가 영역: ${e.criterion}\n${e.opinion}\n핵심 포인트: ${e.highlights.join(" / ")}${verdictLine ? `\n${verdictLine}` : ""}`;
+    })
     .join("\n\n");
 
   const repliesText = replies
@@ -204,56 +385,65 @@ export async function generateModeratorResult(
     })
     .join("\n\n");
 
-  const systemPrompt = `당신은 중립적인 중재자입니다. 면접 패널의 토론이 방금 끝났고, 그 논의를 종합하여 최종 평가를 내리는 것이 당신의 역할입니다.
-당신은 면접관이 아닙니다 — 각 면접관의 전문 영역에 따라 의견을 공정하게 조율하는 조정자입니다.
+  const systemPrompt = `당신은 중립적인 중재자입니다. 면접 패널의 토론이 끝났고, 3명 에이전트의 평가와 상호 피드백을 종합하여 최종 채용 판정을 내리는 것이 역할입니다.
 반드시 유효한 JSON만 응답하세요 — 다른 텍스트 없이.`;
 
-  const userContent = `[면접 대화 기록]
+  const userContent = `${contextBlock}
+
+[면접 대화 기록]
 ${conversationText}
 
-[Round 0 — 면접관 독립 평가]
+[Round 0 — 에이전트 독립 평가]
 ${evaluationsText}
 
-[Round 1 — 면접관 토론]
+[Round 1 — 에이전트 상호 피드백]
 ${repliesText}
 
-위 평가와 토론 전체를 바탕으로 최종 점수를 산정하고 결과를 종합하세요.
+위 평가와 토론 전체를 바탕으로 최종 채용 판정과 결과를 종합하세요.
 
 다음 JSON 형식으로 응답하세요:
 {
-  "score": <0-100 사이 정수. 채점 기준:
-    90-100: 탁월 — 수치 포함 구체적 사례, 강한 자기 인식, 직무 요건을 명확히 상회
+  "score": <0-100 정수.
+    90-100: 탁월 — 구체적 사례와 수치, 강한 자기 인식, 직무 요건 명확히 상회
     75-89: 우수 — 구체적 사례, 좋은 구조, 사소한 빈틈만 있음
-    60-74: 보통 — 일부 구체적 사례 있으나 일관성 부족, 잠재력은 보임
-    45-59: 미흡 — 주로 추상적인 답변, 구체성 부족, 핵심 역량 빈틈
-    0-44: 부족 — 모호하거나 회피적인 답변, 직무 요건과 심각한 불일치
-    비중: 조직 전문가 30% + 논리 전문가 30% + 기술 전문가 40%>,
+    60-74: 보통 — 일부 구체성 있으나 일관성 부족, 잠재력은 보임
+    45-59: 미흡 — 추상적 답변 위주, 직무 구체성 부족
+    0-44: 부족 — 모호하거나 회피적 답변, 직무 요건과 심각한 불일치
+    비중: 조직전문가 30% + 논리전문가 30% + 기술전문가 40%>,
+  "recommendLevel": "<강력 추천 | 추천 | 보류 | 비추천. 90이상=강력 추천, 75-89=추천, 45-74=보류, 44이하=비추천>",
   "overall": {
-    "strengths": "<지원자가 잘한 점 2-3문장. 구체적인 답변을 인용하세요.>",
-    "weaknesses": "<명확한 약점이나 빈틈 2-3문장.>",
-    "advice": "<이 지원자가 면접 답변에서 바꿔야 할 가장 중요한 것 하나를 명확히 말하고, 더 나은 답변이 어떻게 들렸을지 구체적인 예시를 제시하세요. 2-3문장.>"
+    "strengths": "<잘한 점 2~3문장. 구체적인 답변을 인용하세요>",
+    "weaknesses": "<명확한 약점이나 빈틈 2~3문장>",
+    "advice": "<가장 중요한 개선점 하나 + 더 나은 답변의 구체적 예시. 2~3문장>"
   },
   "improvementTips": [
-    "<팁 1: 구체적인 연습 방법. 형식 '[연습명]: [단계별 방법]. [잘된 예시].' 예: 'STAR 구조 훈련: 본인의 경험 3가지를 골라 각각 상황→과제→행동→결과 형식으로 2분 안에 말할 수 있도록 소리 내어 연습하세요. 결과에는 수치나 팀 반응 같은 구체적 증거를 포함하세요.' '더 구체적으로 말하세요' 같은 추상적 조언은 금지.>",
-    "<팁 2: 이번 면접에서 나타난 다른 약점을 타겟으로 한 연습 방법. 같은 형식.>",
-    "<팁 3: 패널이 발견한 기술적 또는 직무 관련 빈틈을 타겟으로 한 연습 방법. 같은 형식.>"
+    "<팁 1: 구체적인 연습 방법. 형식 '[연습명]: [단계별 방법]. [잘된 예시].' 추상적 조언 금지>",
+    "<팁 2: 이번 면접에서 나타난 다른 약점 타겟 연습법>",
+    "<팁 3: 기술적/직무 관련 빈틈 타겟 연습법>"
   ],
-  "debateSummary": "<패널 토론에서 가장 흥미로웠던 의견 충돌이나 긴장을 설명하고, 최종 점수에 결정적으로 영향을 준 것이 무엇인지 서술하세요. 공식 보고서가 아니라 누군가에게 '오늘 토론이 어땠는지' 말해주는 것처럼 구어체로 2-3문장.>"
+  "debateSummary": "<패널 토론에서 가장 흥미로웠던 의견 충돌이나 쟁점, 최종 점수에 결정적으로 영향을 준 것. 구어체로 2~3문장>"
 }
 문자열 값 안에 마크다운 서식(**, *, #)을 사용하지 마세요.`;
 
   const raw = await callOllama(systemPrompt, userContent);
-  const parsed = extractJSON<{
+  const parsedMod = extractJSON<{
     score: number;
+    recommendLevel: string;
     overall: { strengths: string; weaknesses: string; advice: string };
     improvementTips: string[];
     debateSummary: string;
   }>(raw);
 
+  const validLevels = ["강력 추천", "추천", "보류", "비추천"];
+  const recommendLevel = validLevels.includes(parsedMod.recommendLevel)
+    ? (parsedMod.recommendLevel as ModeratorResult["recommendLevel"])
+    : "보류";
+
   return {
-    score: Math.max(0, Math.min(100, Math.round(parsed.score ?? 0))),
-    overall: parsed.overall,
-    improvementTips: (parsed.improvementTips ?? []).slice(0, 3),
-    debateSummary: parsed.debateSummary ?? "",
+    score: Math.max(0, Math.min(100, Math.round(parsedMod.score ?? 0))),
+    recommendLevel,
+    overall: parsedMod.overall,
+    improvementTips: (parsedMod.improvementTips ?? []).slice(0, 3),
+    debateSummary: parsedMod.debateSummary ?? "",
   };
 }

--- a/lib/interview.ts
+++ b/lib/interview.ts
@@ -76,7 +76,7 @@ export interface JobPostingContext {
   preferredQuals: string;
 }
 
-function buildProfileSummary(profile: ProfileContext): string {
+export function buildProfileSummary(profile: ProfileContext): string {
   const lines: string[] = [`이름: ${profile.name}`];
 
   if (profile.educations.length > 0) {


### PR DESCRIPTION
## Summary

- 에이전트별 전문화된 시스템 프롬프트 적용: 논리/기술/조직 각각 5~6개 세부 평가 기준으로 고도화 (기존: 1~2단어 기준)
- 상호 피드백 5대 규칙 추가: 상대 문장 인용 강제, "지원자를 주어로" 금지, "동의합니다" 시작 금지 등 — 할루시네이션 및 공허한 동의 방지
- 프로필·채용공고 컨텍스트 주입: 기술전문가가 JD 자격요건과 직접 대조해서 평가 가능 (기존엔 대화 기록만 전달)
- 에이전트별 핵심 판정값 + UI 배지: 즉시투입 판정(즉시 가능/온보딩 후/추가 경험 필요), 종합 신뢰도(높음/보통/낮음), 자기변화 단계(1~3단계)
- 채용 권고 수준 추가: 강력 추천 / 추천 / 보류 / 비추천 — 점수 링 하단에 색상 배지로 표시
- 토론 요약(`debateSummary`) 기본 펼침으로 변경: 기존에 숨겨져 있던 핵심 콘텐츠를 기본 노출

## Test plan

- [ ] 면접 완료 후 "면접관 평가 시작하기" 클릭 → 3개 EvalCard 순서대로 실시간 등장 확인
- [ ] 각 EvalCard 우측 상단에 판정값 배지 표시 확인 (예: "즉시투입 판정 — 온보딩 후 가능")
- [ ] 토론 뷰 채팅 버블이 상호 피드백 내용과 함께 순서대로 등장 확인
- [ ] 최종 결과 화면에 채용 권고 배지 표시 확인 (강력 추천/추천/보류/비추천)
- [ ] 면접관 평가 아코디언에 판정값 배지 표시 확인
- [ ] 토론 요약 섹션이 기본 펼침 상태인지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)