### PR TITLE
fix: Supabase RLS 보안 취약점 수정 - service role key 교체 및 RLS 마이그레이션 추가

### DIFF
--- a/app/api/account/route.ts
+++ b/app/api/account/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from "next/server";
 import { getAuthUser } from "@/lib/auth";
-import { supabase } from "@/lib/supabase";
 import { supabaseAdmin } from "@/lib/supabase-admin";
+const supabase = supabaseAdmin;
 
 export async function DELETE() {
   const userId = await getAuthUser();

--- a/app/api/interview/debate/[sessionId]/status/route.ts
+++ b/app/api/interview/debate/[sessionId]/status/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
-import { supabase } from "@/lib/supabase";
+import { supabaseAdmin as supabase } from "@/lib/supabase-admin";
 import { getAuthUser } from "@/lib/auth";
 
 export async function GET(

--- a/app/api/interview/debate/route.ts
+++ b/app/api/interview/debate/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
-import { supabase } from "@/lib/supabase";
+import { supabaseAdmin as supabase } from "@/lib/supabase-admin";
 import { getAuthUser } from "@/lib/auth";
 import type { Json } from "@/types/supabase";
 import { Message, Difficulty, AGENT_ORDER } from "@/lib/interview";

--- a/app/api/interview/feedback/route.ts
+++ b/app/api/interview/feedback/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { getAuthUser } from "@/lib/auth";
-import { supabase } from "@/lib/supabase";
+import { supabaseAdmin as supabase } from "@/lib/supabase-admin";
 
 const OLLAMA_BASE_URL = process.env.OLLAMA_BASE_URL ?? "http://localhost:11434";
 const OLLAMA_MODEL = process.env.OLLAMA_MODEL ?? "exaone3.5:2.4b";

--- a/app/api/interview/follow-up/route.ts
+++ b/app/api/interview/follow-up/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
-import { supabase } from "@/lib/supabase";
+import { supabaseAdmin as supabase } from "@/lib/supabase-admin";
 import { getAuthUser } from "@/lib/auth";
 import {
   generateParallelFollowUpThoughts,

--- a/app/api/interview/question/route.ts
+++ b/app/api/interview/question/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
-import { supabase } from "@/lib/supabase";
+import { supabaseAdmin as supabase } from "@/lib/supabase-admin";
 import { getAuthUser } from "@/lib/auth";
 import {
   generateAgentBaseQuestion,

--- a/app/api/job-posting/analyze/route.ts
+++ b/app/api/job-posting/analyze/route.ts
@@ -1,5 +1,5 @@
 import { NextResponse } from "next/server";
-import { supabase } from "@/lib/supabase";
+import { supabaseAdmin as supabase } from "@/lib/supabase-admin";
 import { getAuthUser } from "@/lib/auth";
 
 const OLLAMA_BASE_URL = process.env.OLLAMA_BASE_URL ?? "http://localhost:11434";

--- a/app/api/job-posting/manual/route.ts
+++ b/app/api/job-posting/manual/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
-import { supabase } from "@/lib/supabase";
+import { supabaseAdmin as supabase } from "@/lib/supabase-admin";
 import { getAuthUser } from "@/lib/auth";
 import { jobPostingManualSchema } from "@/lib/schemas";
 

--- a/app/api/job-posting/route.ts
+++ b/app/api/job-posting/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
-import { supabase } from "@/lib/supabase";
+import { supabaseAdmin as supabase } from "@/lib/supabase-admin";
 import { getAuthUser } from "@/lib/auth";
 import { jobPostingSchema } from "@/lib/schemas";
 

--- a/app/api/profile/route.ts
+++ b/app/api/profile/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
-import { supabase } from "@/lib/supabase";
+import { supabaseAdmin as supabase } from "@/lib/supabase-admin";
 import { getAuthUser } from "@/lib/auth";
 import { profileSchema } from "@/lib/schemas";
 

--- a/supabase-rls-setup.sql
+++ b/supabase-rls-setup.sql
@@ -1,0 +1,124 @@
+-- ============================================================
+-- RLS (Row Level Security) 설정 마이그레이션
+-- Supabase 대시보드 > SQL Editor 에서 실행하세요
+-- ============================================================
+
+-- 1. 모든 테이블에 RLS 활성화
+ALTER TABLE profiles              ENABLE ROW LEVEL SECURITY;
+ALTER TABLE educations            ENABLE ROW LEVEL SECURITY;
+ALTER TABLE careers               ENABLE ROW LEVEL SECURITY;
+ALTER TABLE certifications        ENABLE ROW LEVEL SECURITY;
+ALTER TABLE activities            ENABLE ROW LEVEL SECURITY;
+ALTER TABLE job_postings          ENABLE ROW LEVEL SECURITY;
+ALTER TABLE interview_sessions    ENABLE ROW LEVEL SECURITY;
+
+-- ============================================================
+-- 2. profiles 테이블 정책
+-- ============================================================
+CREATE POLICY "profiles: 본인만 접근"
+  ON profiles
+  FOR ALL
+  USING (auth.uid()::text = "userId")
+  WITH CHECK (auth.uid()::text = "userId");
+
+-- ============================================================
+-- 3. educations 테이블 정책 (profiles.userId 통해 확인)
+-- ============================================================
+CREATE POLICY "educations: 본인만 접근"
+  ON educations
+  FOR ALL
+  USING (
+    EXISTS (
+      SELECT 1 FROM profiles
+      WHERE profiles.id = educations."profileId"
+        AND profiles."userId" = auth.uid()::text
+    )
+  )
+  WITH CHECK (
+    EXISTS (
+      SELECT 1 FROM profiles
+      WHERE profiles.id = educations."profileId"
+        AND profiles."userId" = auth.uid()::text
+    )
+  );
+
+-- ============================================================
+-- 4. careers 테이블 정책
+-- ============================================================
+CREATE POLICY "careers: 본인만 접근"
+  ON careers
+  FOR ALL
+  USING (
+    EXISTS (
+      SELECT 1 FROM profiles
+      WHERE profiles.id = careers."profileId"
+        AND profiles."userId" = auth.uid()::text
+    )
+  )
+  WITH CHECK (
+    EXISTS (
+      SELECT 1 FROM profiles
+      WHERE profiles.id = careers."profileId"
+        AND profiles."userId" = auth.uid()::text
+    )
+  );
+
+-- ============================================================
+-- 5. certifications 테이블 정책
+-- ============================================================
+CREATE POLICY "certifications: 본인만 접근"
+  ON certifications
+  FOR ALL
+  USING (
+    EXISTS (
+      SELECT 1 FROM profiles
+      WHERE profiles.id = certifications."profileId"
+        AND profiles."userId" = auth.uid()::text
+    )
+  )
+  WITH CHECK (
+    EXISTS (
+      SELECT 1 FROM profiles
+      WHERE profiles.id = certifications."profileId"
+        AND profiles."userId" = auth.uid()::text
+    )
+  );
+
+-- ============================================================
+-- 6. activities 테이블 정책
+-- ============================================================
+CREATE POLICY "activities: 본인만 접근"
+  ON activities
+  FOR ALL
+  USING (
+    EXISTS (
+      SELECT 1 FROM profiles
+      WHERE profiles.id = activities."profileId"
+        AND profiles."userId" = auth.uid()::text
+    )
+  )
+  WITH CHECK (
+    EXISTS (
+      SELECT 1 FROM profiles
+      WHERE profiles.id = activities."profileId"
+        AND profiles."userId" = auth.uid()::text
+    )
+  );
+
+-- ============================================================
+-- 7. job_postings 테이블 정책
+-- ============================================================
+CREATE POLICY "job_postings: 본인만 접근"
+  ON job_postings
+  FOR ALL
+  USING (auth.uid()::text = "userId")
+  WITH CHECK (auth.uid()::text = "userId");
+
+-- ============================================================
+-- 8. interview_sessions 테이블 정책
+-- ============================================================
+CREATE POLICY "interview_sessions: 본인만 접근"
+  ON interview_sessions
+  FOR ALL
+  USING (auth.uid()::text = "userId")
+  WITH CHECK (auth.uid()::text = "userId");


### PR DESCRIPTION
## Summary

- 모든 API 라우트에서 anon key 기반 `supabase` 클라이언트를 `supabaseAdmin`(service role key)으로 교체
- Supabase 경고(`rls_disabled_in_public`) 대응 및 anon key를 통한 직접 DB 접근 차단
- 7개 테이블 전체 RLS 활성화 + 정책 SQL 스크립트(`supabase-rls-setup.sql`) 추가

## 변경 파일

- `app/api/account/route.ts`
- `app/api/interview/debate/[sessionId]/status/route.ts`
- `app/api/interview/debate/route.ts`
- `app/api/interview/feedback/route.ts`
- `app/api/interview/follow-up/route.ts`
- `app/api/interview/question/route.ts`
- `app/api/job-posting/analyze/route.ts`
- `app/api/job-posting/manual/route.ts`
- `app/api/job-posting/route.ts`
- `app/api/profile/route.ts`
- `supabase-rls-setup.sql` (신규)

## 머지 후 필수 작업

**Supabase 대시보드 > SQL Editor 에서 `supabase-rls-setup.sql` 실행 필요**

RLS를 활성화하지 않으면 anon key를 통한 직접 DB 접근이 여전히 가능합니다.

## Test plan

- [ ] 로그인 후 프로필 저장/조회 정상 동작 확인
- [ ] 채용공고 URL 입력 및 분석 정상 동작 확인
- [ ] 면접 진행 (질문 생성, 꼬리질문, 토론 평가) 정상 동작 확인
- [ ] Supabase SQL Editor에서 `supabase-rls-setup.sql` 실행
- [ ] RLS 활성화 후 anon key로 직접 DB 접근 시 차단되는지 확인

https://claude.ai/code/session_01FcMY11DU4tBEixhqmwFENJ