### PR TITLE
fix: Server Component DB 클라이언트 supabaseAdmin 교체 + interview readiness 체크 수정

### DIFF
--- a/app/interview/page.tsx
+++ b/app/interview/page.tsx
@@ -1,5 +1,5 @@
 import { redirect } from "next/navigation";
-import { supabase } from "@/lib/supabase";
+import { supabaseAdmin as supabase } from "@/lib/supabase-admin";
 import { getAuthUser } from "@/lib/auth";
 import InterviewSession from "@/components/InterviewSession";
 
@@ -17,13 +17,13 @@ async function checkReadiness() {
 
   const { data: jobPosting } = await supabase
     .from("job_postings")
-    .select("id, sourceUrl")
+    .select("id, responsibilities")
     .eq("userId", userId)
     .order("updatedAt", { ascending: false })
     .limit(1)
     .maybeSingle();
 
-  if (!jobPosting?.sourceUrl)
+  if (!jobPosting?.responsibilities)
     return { ready: false, reason: "jobPosting" as const, name: profile.name };
 
   return { ready: true, name: profile.name };

--- a/app/job-posting/edit/page.tsx
+++ b/app/job-posting/edit/page.tsx
@@ -1,4 +1,4 @@
-import { supabase } from "@/lib/supabase";
+import { supabaseAdmin as supabase } from "@/lib/supabase-admin";
 import { getAuthUser } from "@/lib/auth";
 import JobPostingEditForm from "@/components/JobPostingEditForm";
 import { redirect } from "next/navigation";

--- a/app/job-posting/page.tsx
+++ b/app/job-posting/page.tsx
@@ -1,5 +1,5 @@
 import { redirect } from "next/navigation";
-import { supabase } from "@/lib/supabase";
+import { supabaseAdmin as supabase } from "@/lib/supabase-admin";
 import { getAuthUser } from "@/lib/auth";
 import JobPostingForm from "@/components/JobPostingForm";
 

--- a/app/profile/detail/page.tsx
+++ b/app/profile/detail/page.tsx
@@ -1,5 +1,5 @@
 import { redirect } from "next/navigation";
-import { supabase } from "@/lib/supabase";
+import { supabaseAdmin as supabase } from "@/lib/supabase-admin";
 import { getAuthUser } from "@/lib/auth";
 import ProfileForm from "@/components/ProfileForm";
 

--- a/app/profile/page.tsx
+++ b/app/profile/page.tsx
@@ -1,5 +1,5 @@
 import { redirect } from "next/navigation";
-import { supabase } from "@/lib/supabase";
+import { supabaseAdmin as supabase } from "@/lib/supabase-admin";
 import { getAuthUser } from "@/lib/auth";
 import ProfileNameForm from "@/components/ProfileNameForm";
 

--- a/app/settings/page.tsx
+++ b/app/settings/page.tsx
@@ -1,5 +1,5 @@
 import { redirect } from "next/navigation";
-import { supabase } from "@/lib/supabase";
+import { supabaseAdmin as supabase } from "@/lib/supabase-admin";
 import { getAuthUser } from "@/lib/auth";
 import SettingsForm from "@/components/SettingsForm";
 


### PR DESCRIPTION
## Summary

- Server Component 페이지 6개(`interview`, `job-posting`, `job-posting/edit`, `profile`, `profile/detail`, `settings`)가 RLS 차단으로 DB 쿼리 결과가 항상 `null`을 반환하던 문제 수정 — `lib/supabase`(anon key) → `lib/supabase-admin`(service role key)으로 교체
- 채용공고 분석 완료 후 `/interview`에서 면접 준비 여부 체크 시 `sourceUrl` 유무로 판단하던 로직을 `responsibilities` 유무로 수정 — 수동 입력 케이스에서도 정상 동작

## Test plan

- [ ] 채용공고 URL 분석 후 "면접 시작하기" → 난이도 선택 페이지 정상 이동 확인
- [ ] 채용공고 수동 입력 후 "면접 시작하기" → 난이도 선택 페이지 정상 이동 확인
- [ ] 프로필 미작성 상태에서 `/interview` 접근 시 `/profile` 리다이렉트 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)