### PR TITLE
design: 줌인터뷰 브랜딩 적용

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -4,8 +4,8 @@ import Header from "@/components/Header";
 import ProgressBarProvider from "@/components/ProgressBarProvider";
 
 export const metadata: Metadata = {
-  title: "AI 면접 코치",
-  description: "AI 기반 면접 연습 서비스",
+  title: "줌인터뷰",
+  description: "면접관을 보다 가까이서 바라보다",
 };
 
 export default function RootLayout({

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -14,10 +14,10 @@ export default async function HomePage() {
             AI 기반 면접 연습
           </div>
           <h1 className="text-4xl sm:text-5xl font-extrabold text-gray-900 leading-tight tracking-tight dark:text-slate-50">
-            AI 면접 코치
+            줌인터뷰
           </h1>
           <p className="text-lg text-gray-500 dark:text-slate-400 max-w-md mx-auto leading-relaxed">
-            내 이력서와 채용공고를 분석하고<br />개인 맞춤 면접 질문을 받아보세요
+            면접관을 보다 가까이서 바라보다
           </p>
         </div>
 

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -35,11 +35,14 @@ export default function Header() {
     <header className="sticky top-0 z-50 bg-white/80 backdrop-blur-md border-b border-gray-100 dark:bg-slate-900/80 dark:border-slate-800">
       <div className="max-w-3xl mx-auto px-4 h-14 flex items-center justify-between">
         <Link href="/" className="flex items-center gap-2 group">
-          <div className="w-7 h-7 bg-blue-600 rounded-lg flex items-center justify-center">
-            <span className="text-white font-bold text-xs">AI</span>
+          <div className="w-7 h-7 rounded-lg flex items-center justify-center bg-gradient-to-br from-blue-500 to-blue-700 shadow-md shadow-blue-500/40">
+            <svg xmlns="http://www.w3.org/2000/svg" width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="white" strokeWidth="2.2" strokeLinecap="round" strokeLinejoin="round">
+              <path d="M15 10l4.553-2.069A1 1 0 0 1 21 8.82v6.36a1 1 0 0 1-1.447.889L15 14v-4z"/>
+              <rect x="2" y="7" width="13" height="10" rx="2" ry="2"/>
+            </svg>
           </div>
           <span className="text-sm font-bold text-gray-900 dark:text-slate-100 group-hover:text-blue-600 dark:group-hover:text-blue-400 transition-colors">
-            AI 면접 코치
+            줌인터뷰
           </span>
         </Link>
         <div className="flex items-center gap-2">


### PR DESCRIPTION
## Summary

서비스 명칭 및 브랜드 아이덴티티를 'AI 면접 코치'에서 '줌인터뷰'로 변경합니다.

## Changes

- `app/page.tsx` — 홈 제목 및 서브타이틀 변경
- `app/layout.tsx` — 메타데이터 title/description 업데이트
- `components/Header.tsx` — 로고 비디오 카메라 SVG 아이콘 + 그라데이션 적용, 서비스명 변경

## Test plan

- [ ] 홈 화면에서 제목 "줌인터뷰" 확인
- [ ] 서브타이틀 "면접관을 보다 가까이서 바라보다" 확인
- [ ] 헤더 로고 및 서비스명 확인
- [ ] 브라우저 탭 제목 "줌인터뷰" 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)