### PR TITLE
fix: Round 0 평가 실패 시 undefined push 버그 수정 및 에러 로깅 추가

### DIFF
--- a/app/api/interview/debate/route.ts
+++ b/app/api/interview/debate/route.ts
@@ -25,21 +25,20 @@ async function runDebate(
     // Round 0: 에이전트 순차 평가 — 각자 완료 즉시 저장 (클라이언트에 실시간 표시)
     const evaluations: AgentEvaluation[] = [];
     for (const agentId of AGENT_ORDER) {
-      let evaluation: AgentEvaluation;
       try {
-        evaluation = await generateAgentEvaluation(agentId, messages, profile, jobPosting);
-      } catch {
-        continue;
+        const evaluation = await generateAgentEvaluation(agentId, messages, profile, jobPosting);
+        evaluations.push(evaluation);
+        await supabase
+          .from("interview_sessions")
+          .update({
+            agentEvaluations: evaluations as unknown as Json,
+            status: evaluations.length === 1 ? "evaluating" : "debating",
+            updatedAt: new Date().toISOString(),
+          })
+          .eq("id", sessionId);
+      } catch (e) {
+        console.error(`[Round 0] ${agentId} 평가 실패:`, e);
       }
-      evaluations.push(evaluation);
-      await supabase
-        .from("interview_sessions")
-        .update({
-          agentEvaluations: evaluations as unknown as Json,
-          status: evaluations.length === 1 ? "evaluating" : "debating",
-          updatedAt: new Date().toISOString(),
-        })
-        .eq("id", sessionId);
     }
 
     if (evaluations.length < 2) {
@@ -57,8 +56,8 @@ async function runDebate(
           .from("interview_sessions")
           .update({ debateReplies: replies as unknown as Json, updatedAt: new Date().toISOString() })
           .eq("id", sessionId);
-      } catch {
-        continue;
+      } catch (e) {
+        console.error(`[Round 1] ${myEval.agentId} 피드백 실패:`, e);
       }
     }
 
@@ -84,8 +83,8 @@ async function runDebate(
           .from("interview_sessions")
           .update({ agentRebuttals: rebuttals as unknown as Json, updatedAt: new Date().toISOString() })
           .eq("id", sessionId);
-      } catch {
-        continue;
+      } catch (e) {
+        console.error(`[Round 2] ${myEval.agentId} 재반박 실패:`, e);
       }
     }
 
@@ -111,8 +110,8 @@ async function runDebate(
           .from("interview_sessions")
           .update({ agentFinalOpinions: finalOpinions as unknown as Json, updatedAt: new Date().toISOString() })
           .eq("id", sessionId);
-      } catch {
-        continue;
+      } catch (e) {
+        console.error(`[Round 3] ${myEval.agentId} 최종 의견 실패:`, e);
       }
     }
 


### PR DESCRIPTION
## Summary

- Round 0의 `push` + DB update를 `try` 블록 밖에 두던 패턴을 `try` 안으로 이동 — Round 1~3과 동일한 구조로 통일
- 모든 라운드(`Round 0~3`) `catch` 블록에 `console.error` 추가하여 에이전트 개별 실패 원인 추적 가능하게 함

## Test plan

- [ ] 면접 완료 후 평가 흐름이 정상적으로 진행되는지 확인
- [ ] Ollama 응답 실패를 강제로 시뮬레이션했을 때 해당 에이전트만 skip되고 나머지가 정상 진행되는지 확인
- [ ] 서버 콘솔에 `[Round N] agentId 실패:` 형식으로 에러 로그가 출력되는지 확인

Closes #89

🤖 Generated with [Claude Code](https://claude.com/claude-code)