### PR TITLE
fix: 개별평가 탭에서 토론 탭으로 돌아오는 버튼 추가

### DIFF
--- a/app/api/interview/debate/route.ts
+++ b/app/api/interview/debate/route.ts
@@ -25,21 +25,20 @@ async function runDebate(
     // Round 0: 에이전트 순차 평가 — 각자 완료 즉시 저장 (클라이언트에 실시간 표시)
     const evaluations: AgentEvaluation[] = [];
     for (const agentId of AGENT_ORDER) {
-      let evaluation: AgentEvaluation;
       try {
-        evaluation = await generateAgentEvaluation(agentId, messages, profile, jobPosting);
-      } catch {
-        continue;
+        const evaluation = await generateAgentEvaluation(agentId, messages, profile, jobPosting);
+        evaluations.push(evaluation);
+        await supabase
+          .from("interview_sessions")
+          .update({
+            agentEvaluations: evaluations as unknown as Json,
+            status: evaluations.length === 1 ? "evaluating" : "debating",
+            updatedAt: new Date().toISOString(),
+          })
+          .eq("id", sessionId);
+      } catch (e) {
+        console.error(`[Round 0] ${agentId} 평가 실패:`, e);
       }
-      evaluations.push(evaluation);
-      await supabase
-        .from("interview_sessions")
-        .update({
-          agentEvaluations: evaluations as unknown as Json,
-          status: evaluations.length === 1 ? "evaluating" : "debating",
-          updatedAt: new Date().toISOString(),
-        })
-        .eq("id", sessionId);
     }
 
     if (evaluations.length < 2) {
@@ -57,8 +56,8 @@ async function runDebate(
           .from("interview_sessions")
           .update({ debateReplies: replies as unknown as Json, updatedAt: new Date().toISOString() })
           .eq("id", sessionId);
-      } catch {
-        continue;
+      } catch (e) {
+        console.error(`[Round 1] ${myEval.agentId} 피드백 실패:`, e);
       }
     }
 
@@ -84,8 +83,8 @@ async function runDebate(
           .from("interview_sessions")
           .update({ agentRebuttals: rebuttals as unknown as Json, updatedAt: new Date().toISOString() })
           .eq("id", sessionId);
-      } catch {
-        continue;
+      } catch (e) {
+        console.error(`[Round 2] ${myEval.agentId} 재반박 실패:`, e);
       }
     }
 
@@ -111,8 +110,8 @@ async function runDebate(
           .from("interview_sessions")
           .update({ agentFinalOpinions: finalOpinions as unknown as Json, updatedAt: new Date().toISOString() })
           .eq("id", sessionId);
-      } catch {
-        continue;
+      } catch (e) {
+        console.error(`[Round 3] ${myEval.agentId} 최종 의견 실패:`, e);
       }
     }
 

--- a/components/DebateLoading.tsx
+++ b/components/DebateLoading.tsx
@@ -409,10 +409,20 @@ export default function DebateLoading({ sessionId, avatarSeeds, onDone, onProcee
   if (viewPhase === "evaluating") {
     return (
       <div className="space-y-4">
-        <div className="flex items-center gap-2 px-1">
-          <span className="text-sm font-semibold text-gray-700 dark:text-slate-200">📋 개별 평가</span>
-          {isActive && !allEvalsReceived && (
-            <span className="text-xs text-gray-400 dark:text-slate-500">면접관들이 평가 중...</span>
+        <div className="flex items-center justify-between px-1">
+          <div className="flex items-center gap-2">
+            <span className="text-sm font-semibold text-gray-700 dark:text-slate-200">📋 개별 평가</span>
+            {isActive && !allEvalsReceived && (
+              <span className="text-xs text-gray-400 dark:text-slate-500">면접관들이 평가 중...</span>
+            )}
+          </div>
+          {!isActive && (
+            <button
+              onClick={() => setViewPhase("debating")}
+              className="flex items-center gap-1.5 text-sm text-gray-400 dark:text-slate-500 hover:text-gray-600 dark:hover:text-slate-300 transition-colors"
+            >
+              의견 교환 보기 →
+            </button>
           )}
         </div>
 


### PR DESCRIPTION
## Summary

- 개별평가 화면에서 토론(의견 교환) 탭으로 돌아오는 버튼 추가
- 토론이 완료된 상태(`isActive=false`)일 때만 버튼 노출 — 진행 중에는 자동 전환 흐름을 방해하지 않음
- 기존 토론 → 개별평가 버튼과 대칭 구조로 배치

## Test plan

- [ ] 면접 종료 후 개별평가 → 토론 탭 자동 전환 흐름이 정상 동작하는지 확인
- [ ] 토론 완료 후 개별평가 탭에서 '의견 교환 보기 →' 버튼이 노출되는지 확인
- [ ] 버튼 클릭 시 토론 탭으로 정상 전환되는지 확인
- [ ] 토론 탭에서 '← 개별 평가 돌아보기' 버튼도 정상 동작하는지 확인

Closes #94

🤖 Generated with [Claude Code](https://claude.com/claude-code)