### PR TITLE
fix: Round 1 피드백에 verdict 추가 및 Round 3에 상대방 재반박 컨텍스트 전달

### DIFF
--- a/app/api/interview/debate/route.ts
+++ b/app/api/interview/debate/route.ts
@@ -101,9 +101,17 @@ async function runDebate(
           }))
       );
       const myRebuttal = rebuttals.find((r) => r.agentId === myEval.agentId);
+      // 다른 에이전트들이 내 Round 1 피드백에 반박한 내용 (Round 2)
+      const othersRebuttalsToMyFeedback = rebuttals
+        .filter((r) => r.agentId !== myEval.agentId)
+        .flatMap((r) =>
+          r.rebuttals
+            .filter((rb) => rb.fromAgentId === myEval.agentId)
+            .map((rb) => ({ fromAgentLabel: r.agentLabel, comment: rb.comment }))
+        );
       try {
         const finalOpinion = await generateAgentFinalOpinion(
-          myEval.agentId, myEval, repliesAboutMe, myRebuttal, messages, profile, jobPosting
+          myEval.agentId, myEval, repliesAboutMe, myRebuttal, othersRebuttalsToMyFeedback, messages, profile, jobPosting
         );
         finalOpinions.push(finalOpinion);
         await supabase

--- a/lib/agents.ts
+++ b/lib/agents.ts
@@ -326,7 +326,7 @@ export async function generateAgentReply(
   const othersText = otherEvaluations
     .map(
       (e) =>
-        `[${e.agentLabel}] ${e.opinion}\n핵심 포인트: ${e.highlights.join(" | ")}`,
+        `[${e.agentLabel}]${e.verdictLabel && e.verdict ? ` 판정: ${e.verdictLabel} — ${e.verdict}` : ""}\n${e.opinion}\n핵심 포인트: ${e.highlights.join(" | ")}`,
     )
     .join("\n\n");
 
@@ -458,6 +458,7 @@ export async function generateAgentFinalOpinion(
   myEvaluation: AgentEvaluation,
   repliesAboutMe: { fromAgentLabel: string; stance: string; comment: string }[],
   myRebuttal: AgentRebuttal | undefined,
+  othersRebuttalsToMyFeedback: { fromAgentLabel: string; comment: string }[],
   messages: Message[],
   profile: ProfileContext,
   jobPosting: JobPostingContext,
@@ -472,6 +473,10 @@ export async function generateAgentFinalOpinion(
 
   const rebuttalText = myRebuttal
     ? myRebuttal.rebuttals.map((r) => `→ ${r.fromAgentId}에게: ${r.comment}`).join("\n")
+    : "없음";
+
+  const othersRebuttalText = othersRebuttalsToMyFeedback.length > 0
+    ? othersRebuttalsToMyFeedback.map((r) => `[${r.fromAgentLabel}]: ${r.comment}`).join("\n\n")
     : "없음";
 
   // 에이전트별 JSON 스키마 (Round 0와 동일)
@@ -520,11 +525,14 @@ ${conversationText}
 [나의 Round 0 평가]
 ${myEvaluation.opinion}
 
-[내가 받은 피드백]
+[내가 받은 피드백 — Round 1]
 ${feedbackText}
 
-[내 재반박]
+[내 재반박 — Round 2]
 ${rebuttalText}
+
+[상대방이 내 피드백에 반박한 내용 — Round 2]
+${othersRebuttalText}
 
 위 토론 전체를 반영하여 최종 의견을 작성하세요.
 수정된 판단이 있으면 왜 바꿨는지, 유지한 판단이 있으면 왜 유지하는지 opinion에 1문장으로 밝히세요.


### PR DESCRIPTION
## Summary

- **#87** Round 1 `othersText`에 `verdictLabel + verdict` 추가 — 에이전트가 상대의 최종 판정값("즉시 가능", "높음" 등)을 알고 반박할 수 있도록 개선
- **#90** Round 3에 `othersRebuttalsToMyFeedback` 파라미터 추가 — 상대방이 내 Round 1 피드백에 반박한 내용을 함께 전달하여 토론 전체 흐름을 반영한 최종 의견 생성

## 변경 파일

- `lib/agents.ts` — Round 1 othersText 빌드 로직, Round 3 함수 시그니처 및 userContent
- `app/api/interview/debate/route.ts` — Round 3 호출 시 othersRebuttalsToMyFeedback 추출 및 전달

## Test plan

- [ ] 면접 완료 후 Round 1 토론 내용에 상대 에이전트의 판정값이 표시되는지 서버 로그로 확인
- [ ] Round 3 최종 의견이 토론 흐름을 더 잘 반영하는지 확인
- [ ] TypeScript 타입 오류 없음 (`npx tsc --noEmit` 통과)

Closes #87
Closes #90

🤖 Generated with [Claude Code](https://claude.com/claude-code)