### PR TITLE
fix: displayEvaluations undefined 및 finalFeedback null 방어 처리

### DIFF
--- a/components/DebateResult.tsx
+++ b/components/DebateResult.tsx
@@ -102,7 +102,7 @@ export default function DebateResult({
 }: Props) {
   // 최종 의견이 있으면 최종 의견 기준으로 표시, 없으면 Round 0 평가 사용
   const displayEvaluations: (AgentEvaluation | AgentFinalOpinion)[] =
-    agentFinalOpinions && agentFinalOpinions.length > 0 ? agentFinalOpinions : agentEvaluations;
+    (agentFinalOpinions && agentFinalOpinions.length > 0 ? agentFinalOpinions : agentEvaluations) ?? [];
   const isFinalOpinion = agentFinalOpinions && agentFinalOpinions.length > 0;
   return (
     <div className="space-y-6">
@@ -182,7 +182,7 @@ export default function DebateResult({
               <span className="text-sm font-semibold text-gray-700 dark:text-slate-200">강점</span>
             </div>
             <p className="text-sm text-gray-600 dark:text-slate-300 leading-relaxed pl-6">
-              {stripMd(finalFeedback.strengths)}
+              {stripMd(finalFeedback.strengths ?? "")}
             </p>
           </div>
           <div className="h-px bg-gray-100 dark:bg-slate-700" />
@@ -192,7 +192,7 @@ export default function DebateResult({
               <span className="text-sm font-semibold text-gray-700 dark:text-slate-200">약점</span>
             </div>
             <p className="text-sm text-gray-600 dark:text-slate-300 leading-relaxed pl-6">
-              {stripMd(finalFeedback.weaknesses)}
+              {stripMd(finalFeedback.weaknesses ?? "")}
             </p>
           </div>
           <div className="h-px bg-gray-100 dark:bg-slate-700" />
@@ -202,7 +202,7 @@ export default function DebateResult({
               <span className="text-sm font-semibold text-gray-700 dark:text-slate-200">핵심 조언</span>
             </div>
             <p className="text-sm text-gray-600 dark:text-slate-300 leading-relaxed pl-6">
-              {stripMd(finalFeedback.advice)}
+              {stripMd(finalFeedback.advice ?? "")}
             </p>
           </div>
         </div>


### PR DESCRIPTION
## Summary
- `agentFinalOpinions`, `agentEvaluations` 둘 다 없을 때 `displayEvaluations`가 `undefined`가 되어 `.map()` 호출 시 TypeError 발생하던 버그 수정 (`?? []` 추가)
- `finalFeedback.strengths/weaknesses/advice` 필드 null 가능성에 `?? ""` 추가

## Test plan
- [ ] 폴링 실패 / DB null 반환 상황에서 결과 화면이 에러 없이 빈 상태로 렌더링되는지 확인
- [ ] 정상 케이스에서 기존 동작 그대로인지 확인

Closes #92

🤖 Generated with [Claude Code](https://claude.com/claude-code)