### PR TITLE
fix: 채용공고 자동 분석 실패 시 수동 입력 모드로 자동 전환

### DIFF
--- a/components/JobPostingEditForm.tsx
+++ b/components/JobPostingEditForm.tsx
@@ -37,6 +37,7 @@ export default function JobPostingEditForm({ initialData, isAnalyzing = false }:
   const [fadeIn, setFadeIn] = useState(true);
   const [isSaving, setIsSaving] = useState(false);
   const [errorMessage, setErrorMessage] = useState("");
+  const [analysisError, setAnalysisError] = useState("");
   const analyzeCalledRef = useRef(false);
 
   // 분석 단계 메시지 타이머
@@ -66,19 +67,24 @@ export default function JobPostingEditForm({ initialData, isAnalyzing = false }:
     analyzeCalledRef.current = true;
 
     fetch("/api/job-posting/analyze", { method: "POST" })
-      .then((res) => res.json())
-      .then((data) => {
-        if (data.jobPosting) {
+      .then(async (res) => {
+        const data = await res.json();
+        if (!res.ok || !data.jobPosting) {
+          setAnalysisError("URL에서 공고 내용을 자동으로 가져오지 못했어요. 직접 입력해 주세요.");
+          setMode("editing");
+        } else {
           setFields({
             responsibilities: data.jobPosting.responsibilities ?? "",
             requirements:     data.jobPosting.requirements     ?? "",
             preferredQuals:   data.jobPosting.preferredQuals   ?? "",
           });
+          setMode("view");
         }
+        router.replace("/job-posting/edit");
       })
-      .catch(() => {})
-      .finally(() => {
-        setMode("view");
+      .catch(() => {
+        setAnalysisError("URL에서 공고 내용을 자동으로 가져오지 못했어요. 직접 입력해 주세요.");
+        setMode("editing");
         router.replace("/job-posting/edit");
       });
   }, [mode, router]);
@@ -215,6 +221,11 @@ export default function JobPostingEditForm({ initialData, isAnalyzing = false }:
   // 편집 UI
   return (
     <div className="space-y-4">
+      {analysisError && (
+        <div className="bg-amber-50 border border-amber-200 text-amber-800 text-sm rounded-xl px-4 py-3 dark:bg-amber-900/20 dark:border-amber-700 dark:text-amber-300">
+          {analysisError}
+        </div>
+      )}
       <div className="card p-5 space-y-4">
         {FIELDS.map(({ key, label, required, placeholder }) => (
           <div key={key} className="space-y-1">


### PR DESCRIPTION
## Summary

- 분석 API 실패(500) 또는 네트워크 오류 시 빈 view 모드 대신 editing 모드로 자동 전환
- 편집 폼 상단에 "URL에서 공고 내용을 자동으로 가져오지 못했어요. 직접 입력해 주세요." 안내 배너 표시
- 사용자가 "편집하기" 버튼을 별도로 누를 필요 없이 바로 입력 가능

## Test plan

- [ ] 크롤러 차단 사이트 URL(e.g. kofia.or.kr) 입력 → 분석 실패 후 자동으로 편집 폼 전환 확인
- [ ] 상단 주황 배너 메시지 표시 확인
- [ ] 편집 폼에 내용 입력 후 저장 정상 동작 확인
- [ ] 정상 분석 가능한 URL은 기존대로 view 모드로 결과 표시 확인

Closes #107

🤖 Generated with [Claude Code](https://claude.com/claude-code)