### PR TITLE
feat: 면접 답변 음성 입력 (STT) 추가

### DIFF
--- a/components/InterviewSession.tsx
+++ b/components/InterviewSession.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, useRef, useEffect } from "react";
+import { useSpeechRecognition } from "@/hooks/useSpeechRecognition";
 import {
   Message,
   Difficulty,
@@ -359,6 +360,28 @@ export default function InterviewSession({ name }: { name: string }) {
   const [debateError, setDebateError] = useState("");
   const proceededRef = useRef(false);
 
+  const [interimTranscript, setInterimTranscript] = useState("");
+  const finalTranscriptRef = useRef("");
+
+  const { isRecording, isSupported, start, stop } = useSpeechRecognition(
+    (interim) => setInterimTranscript(interim),
+    (final) => {
+      finalTranscriptRef.current += final;
+      setAnswer(finalTranscriptRef.current);
+      setInterimTranscript("");
+    },
+  );
+
+  function toggleRecording() {
+    if (isRecording) {
+      stop();
+      setInterimTranscript("");
+    } else {
+      finalTranscriptRef.current = answer;
+      start();
+    }
+  }
+
   function handleDifficultySelect(d: Difficulty) {
     setDifficulty(d);
     setAvatarSeeds({ organization: randomSeed(), logic: randomSeed(), technical: randomSeed() });
@@ -404,6 +427,10 @@ export default function InterviewSession({ name }: { name: string }) {
   }, [timeLeft, isLoading, isThinkingPhase, phase]);
 
   async function handleSubmit() {
+    if (isRecording) {
+      stop();
+      setInterimTranscript("");
+    }
     const trimmed = answer.trim();
     if (!trimmed || isLoading || isThinkingPhase) return;
 
@@ -493,6 +520,9 @@ export default function InterviewSession({ name }: { name: string }) {
   }
 
   function handleRestart() {
+    if (isRecording) stop();
+    setInterimTranscript("");
+    finalTranscriptRef.current = "";
     setPhase("selecting");
     setMessages([]);
     setAgentIndex(0);
@@ -721,15 +751,16 @@ export default function InterviewSession({ name }: { name: string }) {
       )}
 
       {/* 답변 입력 */}
-      <div className="card p-4 space-y-3">
+      <div className={`card p-4 space-y-3 transition-all ${isRecording ? "ring-2 ring-red-400 dark:ring-red-500" : ""}`}>
         <textarea
-          value={answer}
-          onChange={(e) => setAnswer(e.target.value)}
+          value={isRecording ? answer + interimTranscript : answer}
+          onChange={(e) => { if (!isRecording) setAnswer(e.target.value); }}
           onKeyDown={(e) => {
             if (e.key === "Enter" && (e.ctrlKey || e.metaKey)) handleSubmit();
           }}
-          placeholder="답변을 입력하세요 (Ctrl+Enter로 제출)"
+          placeholder={isRecording ? "말씀해주세요..." : "답변을 입력하세요 (Ctrl+Enter로 제출)"}
           disabled={isLoading || isThinkingPhase}
+          readOnly={isRecording}
           rows={8}
           className="w-full resize-none border-0 outline-none text-sm text-gray-800 dark:text-slate-200 placeholder-gray-400 dark:placeholder-slate-500 bg-transparent disabled:opacity-50"
         />
@@ -743,13 +774,45 @@ export default function InterviewSession({ name }: { name: string }) {
           }`}>
             {formatTime(timeLeft)}
           </span>
-          <button
-            onClick={handleSubmit}
-            disabled={isLoading || isThinkingPhase || !answer.trim()}
-            className="btn-primary py-2 px-5"
-          >
-            {isThinkingPhase ? "생각 중..." : "제출 →"}
-          </button>
+          <div className="flex items-center gap-2">
+            {isSupported && (
+              <button
+                onClick={toggleRecording}
+                disabled={isLoading || isThinkingPhase}
+                className={`flex items-center gap-1.5 text-xs px-3 py-2 rounded-lg transition-colors disabled:opacity-40 ${
+                  isRecording
+                    ? "text-red-600 dark:text-red-400 bg-red-50 dark:bg-red-900/30"
+                    : "text-gray-500 dark:text-slate-400 hover:bg-gray-100 dark:hover:bg-slate-700"
+                }`}
+              >
+                {isRecording ? (
+                  <>
+                    <span className="relative flex h-2 w-2">
+                      <span className="animate-ping absolute inline-flex h-full w-full rounded-full bg-red-400 opacity-75" />
+                      <span className="relative inline-flex rounded-full h-2 w-2 bg-red-500" />
+                    </span>
+                    녹음 중지
+                  </>
+                ) : (
+                  <>
+                    <svg xmlns="http://www.w3.org/2000/svg" className="w-3.5 h-3.5" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                      <path d="M12 2a3 3 0 0 0-3 3v7a3 3 0 0 0 6 0V5a3 3 0 0 0-3-3z" />
+                      <path d="M19 10v2a7 7 0 0 1-14 0v-2" />
+                      <line x1="12" y1="19" x2="12" y2="22" />
+                    </svg>
+                    음성 입력
+                  </>
+                )}
+              </button>
+            )}
+            <button
+              onClick={handleSubmit}
+              disabled={isLoading || isThinkingPhase || !answer.trim()}
+              className="btn-primary py-2 px-5"
+            >
+              {isThinkingPhase ? "생각 중..." : "제출 →"}
+            </button>
+          </div>
         </div>
       </div>
     </div>

--- a/hooks/useSpeechRecognition.ts
+++ b/hooks/useSpeechRecognition.ts
@@ -1,0 +1,112 @@
+import { useEffect, useRef, useState } from "react";
+
+interface SpeechRecognition extends EventTarget {
+  lang: string;
+  continuous: boolean;
+  interimResults: boolean;
+  onresult: ((event: SpeechRecognitionEvent) => void) | null;
+  onend: (() => void) | null;
+  onerror: ((event: SpeechRecognitionErrorEvent) => void) | null;
+  start(): void;
+  stop(): void;
+}
+
+interface SpeechRecognitionEvent extends Event {
+  resultIndex: number;
+  results: SpeechRecognitionResultList;
+}
+
+interface SpeechRecognitionErrorEvent extends Event {
+  error: string;
+}
+
+declare global {
+  interface Window {
+    SpeechRecognition?: new () => SpeechRecognition;
+    webkitSpeechRecognition?: new () => SpeechRecognition;
+  }
+}
+
+interface UseSpeechRecognitionReturn {
+  isRecording: boolean;
+  isSupported: boolean;
+  start: () => void;
+  stop: () => void;
+}
+
+export function useSpeechRecognition(
+  onInterim: (text: string) => void,
+  onFinal: (text: string) => void,
+): UseSpeechRecognitionReturn {
+  const [isRecording, setIsRecording] = useState(false);
+  const recognitionRef = useRef<SpeechRecognition | null>(null); // eslint-disable-line no-undef
+  const isRecordingRef = useRef(false);
+  const onInterimRef = useRef(onInterim);
+  const onFinalRef = useRef(onFinal);
+  onInterimRef.current = onInterim;
+  onFinalRef.current = onFinal;
+
+  const SpeechRecognitionAPI =
+    typeof window !== "undefined"
+      ? (window.SpeechRecognition ?? window.webkitSpeechRecognition)
+      : undefined;
+
+  const isSupported = !!SpeechRecognitionAPI;
+
+  function start() {
+    if (!SpeechRecognitionAPI || isRecordingRef.current) return;
+
+    const recognition = new SpeechRecognitionAPI();
+    recognition.lang = "ko-KR";
+    recognition.continuous = true;
+    recognition.interimResults = true;
+
+    recognition.onresult = (event: SpeechRecognitionEvent) => {
+      let interim = "";
+      let final = "";
+      for (let i = event.resultIndex; i < event.results.length; i++) {
+        if (event.results[i].isFinal) {
+          final += event.results[i][0].transcript;
+        } else {
+          interim += event.results[i][0].transcript;
+        }
+      }
+      if (final) onFinalRef.current(final);
+      onInterimRef.current(interim);
+    };
+
+    // 긴 침묵으로 자동 종료 시 재시작
+    recognition.onend = () => {
+      if (isRecordingRef.current) {
+        recognition.start();
+      }
+    };
+
+    recognition.onerror = (event: SpeechRecognitionErrorEvent) => {
+      if (event.error === "aborted") return;
+      isRecordingRef.current = false;
+      setIsRecording(false);
+    };
+
+    recognitionRef.current = recognition;
+    recognition.start();
+    isRecordingRef.current = true;
+    setIsRecording(true);
+  }
+
+  function stop() {
+    isRecordingRef.current = false;
+    recognitionRef.current?.stop();
+    recognitionRef.current = null;
+    setIsRecording(false);
+  }
+
+  useEffect(() => {
+    return () => {
+      isRecordingRef.current = false;
+      recognitionRef.current?.stop();
+    };
+  }, []);
+
+  return { isRecording, isSupported, start, stop };
+}


### PR DESCRIPTION
## Summary

- `hooks/useSpeechRecognition.ts` 신규 추가 — Web Speech API 래핑 커스텀 훅
  - `ko-KR` 실시간 스트리밍 STT (`continuous + interimResults`)
  - 침묵 후 자동 종료 시 재시작 처리
  - 컴포넌트 언마운트 시 자동 정리
- `components/InterviewSession.tsx` 수정 — 마이크 버튼 및 STT 연동
  - 답변 입력 영역 우측 하단에 "음성 입력" 버튼 추가
  - 말하는 중 실시간 텍스트 표시 (interim), 확정 시 textarea에 누적 (final)
  - 녹음 중 textarea에 빨간 링 표시 및 readOnly 처리
  - 미지원 브라우저(Safari 등)에서 버튼 자동 숨김

## Test plan

- [x] Chrome에서 면접 진입 → "음성 입력" 버튼 클릭 → 마이크 권한 허용
- [x] 말하는 중 textarea에 실시간 텍스트 표시 확인
- [x] "녹음 중지" 클릭 후 텍스트 편집 가능 확인
- [x] Ctrl+Enter / 제출 버튼으로 정상 제출 확인
- [x] 텍스트 직접 입력 폴백 정상 동작 확인

Closes #106

🤖 Generated with [Claude Code](https://claude.com/claude-code)