### PR TITLE
fix: 채용공고 분석 LLM 타입 미검증 및 sourceType 오염 수정

### DIFF
--- a/app/api/job-posting/analyze/route.ts
+++ b/app/api/job-posting/analyze/route.ts
@@ -84,7 +84,10 @@ ${text}`;
       if (key.includes(keyword)) { matched = canonical; break; }
     }
     const target = matched ?? (key in normalized ? key : null);
-    if (target) normalized[target] = value as string[];
+    if (target) {
+      const arr = Array.isArray(value) ? value as string[] : (value ? [String(value)] : []);
+      normalized[target] = normalized[target].concat(arr);
+    }
   }
 
   const join = (arr: string[]) => arr.join("\n");

--- a/app/api/job-posting/manual/route.ts
+++ b/app/api/job-posting/manual/route.ts
@@ -47,7 +47,7 @@ export async function POST(request: NextRequest) {
         .insert({
           id: crypto.randomUUID(),
           userId,
-          sourceType: "LINK",
+          sourceType: "MANUAL",
           sourceUrl: null,
           responsibilities,
           requirements,


### PR DESCRIPTION
## 변경 내용

### 버그 1 (Critical): LLM 출력 타입 미검증 → 런타임 크래시
**파일:** `app/api/job-posting/analyze/route.ts`

LLM이 배열 대신 문자열이나 `null`을 반환할 경우, `arr.join("\n")` 호출에서 `TypeError`가 발생해 분석 API가 500 에러를 반환했습니다.

```ts
// Before
if (target) normalized[target] = value as string[];

// After
if (target) {
  const arr = Array.isArray(value) ? value as string[] : (value ? [String(value)] : []);
  normalized[target] = normalized[target].concat(arr);
}
```

### 버그 2 (Minor): 동일 타겟 키 중복 시 데이터 덮어쓰기
같은 수정에서 함께 해결. `=` 대신 `concat`으로 누적하도록 변경해 데이터 소실 방지.

### 버그 3 (Data integrity): 수동 입력 시 `sourceType: "LINK"` 오염
**파일:** `app/api/job-posting/manual/route.ts`

URL 없이 직접 입력한 공고도 `sourceType: "LINK"`로 저장되어 데이터 의미가 맞지 않았습니다. `"MANUAL"`로 수정했습니다.

## 검토 포인트
- `sourceType` 컬럼은 `string` 타입으로 DB enum 제약 없음 (확인 완료)
- 기존 `"LINK"` 레코드는 영향 없음 (INSERT 경로만 변경)