### PR TITLE
feat: Ollama API → vLLM(OpenAI 호환) 마이그레이션 (#104)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,7 @@
-# Ollama 자체 호스팅 LLM (필수)
-OLLAMA_BASE_URL="http://localhost:11434"
-OLLAMA_MODEL="[모델명]"
+# LLM 서버 (vLLM OpenAI 호환, 필수)
+# 로컬: http://localhost:11434 / RunPod: https://<pod-id>-8000.proxy.runpod.net
+LLM_BASE_URL="http://localhost:11434"
+LLM_MODEL="[모델명 예: exaone3.5:7.8b]"
 
 # Supabase JS 클라이언트 (필수)
 SUPABASE_URL="https://<project-ref>.supabase.co"

--- a/app/api/job-posting/analyze/route.ts
+++ b/app/api/job-posting/analyze/route.ts
@@ -2,8 +2,8 @@ import { NextResponse } from "next/server";
 import { supabaseAdmin as supabase } from "@/lib/supabase-admin";
 import { getAuthUser } from "@/lib/auth";
 
-const OLLAMA_BASE_URL = process.env.OLLAMA_BASE_URL ?? "http://localhost:11434";
-const OLLAMA_MODEL = process.env.OLLAMA_MODEL ?? "exaone3.5:2.4b";
+const LLM_BASE_URL = process.env.LLM_BASE_URL ?? "http://localhost:11434";
+const LLM_MODEL = process.env.LLM_MODEL ?? "exaone3.5:2.4b";
 
 async function fetchPageText(url: string): Promise<string> {
   const res = await fetch(`https://r.jina.ai/${url}`, {
@@ -42,17 +42,20 @@ async function extractJobInfo(text: string): Promise<{
 채용공고:
 ${text}`;
 
-  const response = await fetch(`${OLLAMA_BASE_URL}/api/generate`, {
+  const response = await fetch(`${LLM_BASE_URL}/v1/chat/completions`, {
     method: "POST",
-    headers: { "Content-Type": "application/json", "ngrok-skip-browser-warning": "true" },
-    body: JSON.stringify({ model: OLLAMA_MODEL, prompt, stream: false }),
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      model: LLM_MODEL,
+      messages: [{ role: "user", content: prompt }],
+    }),
     signal: AbortSignal.timeout(120_000),
   });
 
-  if (!response.ok) throw new Error(`Ollama 요청 실패 (${response.status})`);
+  if (!response.ok) throw new Error(`LLM 요청 실패 (${response.status})`);
 
   const data = await response.json();
-  const raw: string = data.response ?? "";
+  const raw: string = data.choices?.[0]?.message?.content ?? "";
 
   const start = raw.indexOf("{");
   const end = raw.lastIndexOf("}") + 1;

--- a/lib/agents.ts
+++ b/lib/agents.ts
@@ -1,7 +1,7 @@
 import { AgentId, AGENTS, Message, ProfileContext, JobPostingContext, buildProfileSummary } from "@/lib/interview";
 
-const OLLAMA_BASE_URL = process.env.OLLAMA_BASE_URL ?? "http://localhost:11434";
-const OLLAMA_MODEL = process.env.OLLAMA_MODEL ?? "exaone3.5:2.4b";
+const LLM_BASE_URL = process.env.LLM_BASE_URL ?? "http://localhost:11434";
+const LLM_MODEL = process.env.LLM_MODEL ?? "exaone3.5:2.4b";
 
 export interface AgentEvaluation {
   agentId: AgentId;
@@ -58,13 +58,11 @@ export interface ModeratorResult {
 }
 
 async function callOllama(systemPrompt: string, userContent: string): Promise<string> {
-  const response = await fetch(`${OLLAMA_BASE_URL}/api/chat`, {
+  const response = await fetch(`${LLM_BASE_URL}/v1/chat/completions`, {
     method: "POST",
-    headers: { "Content-Type": "application/json", "ngrok-skip-browser-warning": "true" },
+    headers: { "Content-Type": "application/json" },
     body: JSON.stringify({
-      model: OLLAMA_MODEL,
-      stream: false,
-      format: "json",
+      model: LLM_MODEL,
       messages: [
         { role: "system", content: systemPrompt },
         { role: "user", content: userContent },
@@ -74,11 +72,11 @@ async function callOllama(systemPrompt: string, userContent: string): Promise<st
   });
 
   if (!response.ok) {
-    throw new Error(`Ollama 요청 실패: ${response.status} ${response.statusText}`);
+    throw new Error(`LLM 요청 실패: ${response.status} ${response.statusText}`);
   }
 
   const data = await response.json();
-  return (data.message?.content ?? "").trim();
+  return (data.choices?.[0]?.message?.content ?? "").trim();
 }
 
 function extractJSON<T>(raw: string): T {

--- a/lib/interview.ts
+++ b/lib/interview.ts
@@ -1,5 +1,5 @@
-const OLLAMA_BASE_URL = process.env.OLLAMA_BASE_URL ?? "http://localhost:11434";
-const OLLAMA_MODEL = process.env.OLLAMA_MODEL ?? "exaone3.5:2.4b";
+const LLM_BASE_URL = process.env.LLM_BASE_URL ?? "http://localhost:11434";
+const LLM_MODEL = process.env.LLM_MODEL ?? "exaone3.5:2.4b";
 
 export type AgentId = "organization" | "logic" | "technical";
 export type Difficulty = "tutorial" | "easy" | "normal" | "hard";
@@ -241,30 +241,26 @@ function stripMarkdown(text: string): string {
     .trim();
 }
 
-async function callOllama(systemPrompt: string, userContent: string, json = false): Promise<string> {
-  const body: Record<string, unknown> = {
-    model: OLLAMA_MODEL,
-    stream: false,
-    messages: [
-      { role: "system", content: systemPrompt },
-      { role: "user", content: userContent },
-    ],
-  };
-  if (json) body.format = "json";
-
-  const response = await fetch(`${OLLAMA_BASE_URL}/api/chat`, {
+async function callOllama(systemPrompt: string, userContent: string, _json = false): Promise<string> {
+  const response = await fetch(`${LLM_BASE_URL}/v1/chat/completions`, {
     method: "POST",
-    headers: { "Content-Type": "application/json", "ngrok-skip-browser-warning": "true" },
-    body: JSON.stringify(body),
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      model: LLM_MODEL,
+      messages: [
+        { role: "system", content: systemPrompt },
+        { role: "user", content: userContent },
+      ],
+    }),
     signal: AbortSignal.timeout(180_000),
   });
 
   if (!response.ok) {
-    throw new Error(`Ollama 요청 실패: ${response.status} ${response.statusText}`);
+    throw new Error(`LLM 요청 실패: ${response.status} ${response.statusText}`);
   }
 
   const data = await response.json();
-  const raw: string = (data.message?.content ?? "").trim();
+  const raw: string = (data.choices?.[0]?.message?.content ?? "").trim();
   return raw.replace(/^(면접관|질문|interviewer|question)\s*:\s*/i, "").trim();
 }
 


### PR DESCRIPTION
- OLLAMA_BASE_URL/OLLAMA_MODEL → LLM_BASE_URL/LLM_MODEL 환경변수 이름 변경
- /api/chat, /api/generate → /v1/chat/completions 엔드포인트 변경
- Ollama 전용 옵션 제거: format:"json", stream:false, ngrok 헤더
- 응답 파싱: data.message.content → data.choices[0].message.content
- .env.example RunPod 엔드포인트 예시 추가