### PR TITLE
면접관 음성 속도 조정: 모든 면접관 1.2로 통일

### DIFF
--- a/lib/tts.ts
+++ b/lib/tts.ts
@@ -11,19 +11,19 @@ const AGENT_VOICE_CONFIG: Record<
     name: "ko-KR-Neural2-B", // 40대 여성 (차분하고 진중한 톤)
     ssmlGender: "FEMALE",
     pitch: -1.0,
-    speakingRate: 0.92,
+    speakingRate: 1.2,
   },
   logic: {
     name: "ko-KR-Neural2-C", // 50대 남성 (진중하고 어두운 톤)
     ssmlGender: "MALE",
     pitch: -1.8,
-    speakingRate: 0.80,
+    speakingRate: 1.2,
   },
   technical: {
     name: "ko-KR-Standard-C", // 젊은 남성 (밝고 명확한 톤)
     ssmlGender: "MALE",
     pitch: 0.6,
-    speakingRate: 1.15,
+    speakingRate: 1.2,
   },
 };
 


### PR DESCRIPTION
## 📝 설명
모든 면접관의 음성 속도를 1.2로 통일하여 면접 진행 속도를 개선했습니다.

## 🔄 변경 사항
- **organization (40대 여성)**: 0.92 → 1.2
- **logic (50대 남성)**: 0.80 → 1.2
- **technical (젊은 남성)**: 1.15 → 1.2

## ✨ 개선 효과
- 면접 진행이 더 빠르고 자연스러워집니다
- 모든 면접관이 일관된 속도로 진행되어 사용자 경험 향상
- 면접 시간을 더 효율적으로 활용 가능

## 📂 수정된 파일
- `lib/tts.ts`: Google Cloud TTS 음성 설정 업데이트