### PR TITLE
feat: 채용공고 분석 개선 — LLM 결과 검증 + 이미지 OCR + 텍스트 붙여넣기 (#76)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -14,3 +14,7 @@ NEXT_PUBLIC_SUPABASE_ANON_KEY="<anon-key>"
 
 # Google Cloud TTS API
 GOOGLE_CLOUD_TTS_API_KEY="<your-google-cloud-tts-api-key>"
+
+# Google Cloud Vision API (이미지 포스터 OCR, 선택)
+# GCP Console → Vision API 활성화 후 발급
+GOOGLE_CLOUD_VISION_API_KEY="<your-google-cloud-vision-api-key>"

--- a/app/api/job-posting/analyze/route.ts
+++ b/app/api/job-posting/analyze/route.ts
@@ -1,18 +1,29 @@
-import { NextResponse } from "next/server";
+import { NextRequest, NextResponse } from "next/server";
 import { supabaseAdmin as supabase } from "@/lib/supabase-admin";
 import { getAuthUser } from "@/lib/auth";
+import { extractTextFromImageUrl } from "@/lib/ocr";
 
 const LLM_BASE_URL = process.env.LLM_BASE_URL ?? "http://localhost:11434";
 const LLM_MODEL = process.env.LLM_MODEL ?? "exaone3.5:2.4b";
 
-async function fetchPageText(url: string): Promise<string> {
+async function fetchPageText(url: string): Promise<{ text: string; markdown: string }> {
   const res = await fetch(`https://r.jina.ai/${url}`, {
     headers: { Accept: "text/plain" },
     signal: AbortSignal.timeout(30_000),
   });
   if (!res.ok) throw new Error(`페이지 가져오기 실패 (${res.status})`);
-  const text = await res.text();
-  return text.slice(0, 8000);
+  const markdown = await res.text();
+  return { text: markdown.slice(0, 8000), markdown };
+}
+
+function extractImageUrls(markdown: string): string[] {
+  const pattern = /!\[.*?\]\((https?:\/\/[^)]+)\)/g;
+  const urls: string[] = [];
+  let match: RegExpExecArray | null;
+  while ((match = pattern.exec(markdown)) !== null) {
+    urls.push(match[1]);
+  }
+  return urls;
 }
 
 async function extractJobInfo(text: string): Promise<{
@@ -101,12 +112,19 @@ ${text}`;
   };
 }
 
-export async function POST() {
+function isAllEmpty(extracted: { responsibilities: string; requirements: string; preferredQuals: string }) {
+  return !extracted.responsibilities && !extracted.requirements && !extracted.preferredQuals;
+}
+
+export async function POST(request: NextRequest) {
   try {
     const userId = await getAuthUser();
     if (!userId) {
       return NextResponse.json({ error: "로그인이 필요합니다" }, { status: 401 });
     }
+
+    const body = await request.json().catch(() => ({})) as { pastedText?: string };
+    const pastedText = body?.pastedText?.trim();
 
     const { data: rows } = await supabase
       .from("job_postings")
@@ -119,12 +137,42 @@ export async function POST() {
     if (!posting) {
       return NextResponse.json({ error: "저장된 채용공고가 없습니다" }, { status: 404 });
     }
-    if (!posting.sourceUrl) {
-      return NextResponse.json({ error: "URL이 없습니다" }, { status: 400 });
+
+    let text: string;
+    let markdown = "";
+
+    if (pastedText) {
+      text = pastedText.slice(0, 8000);
+    } else {
+      if (!posting.sourceUrl) {
+        return NextResponse.json({ error: "URL이 없습니다" }, { status: 400 });
+      }
+      const fetched = await fetchPageText(posting.sourceUrl);
+      text = fetched.text;
+      markdown = fetched.markdown;
     }
 
-    const text = await fetchPageText(posting.sourceUrl);
-    const extracted = await extractJobInfo(text);
+    let extracted = await extractJobInfo(text);
+
+    if (isAllEmpty(extracted) && !pastedText) {
+      const imageUrls = extractImageUrls(markdown);
+      for (const imageUrl of imageUrls.slice(0, 3)) {
+        const ocrText = await extractTextFromImageUrl(imageUrl);
+        if (!ocrText) continue;
+        const ocrExtracted = await extractJobInfo(ocrText);
+        if (!isAllEmpty(ocrExtracted)) {
+          extracted = ocrExtracted;
+          break;
+        }
+      }
+    }
+
+    if (isAllEmpty(extracted)) {
+      return NextResponse.json(
+        { error: "공고 내용을 자동으로 읽지 못했습니다.", needsManualInput: true },
+        { status: 422 }
+      );
+    }
 
     const now = new Date().toISOString();
     const { data: updated } = await supabase

--- a/app/api/job-posting/route.ts
+++ b/app/api/job-posting/route.ts
@@ -54,11 +54,13 @@ export async function POST(request: NextRequest) {
     const existing = rows?.[0] ?? null;
 
     let jobPosting;
+    const sourceType = sourceUrl ? "LINK" : "PASTE";
+
     if (existing) {
       const { data } = await supabase
         .from("job_postings")
         .update({
-          sourceType: "LINK",
+          sourceType,
           sourceUrl,
           responsibilities: null,
           requirements: null,
@@ -75,7 +77,7 @@ export async function POST(request: NextRequest) {
         .insert({
           id: crypto.randomUUID(),
           userId,
-          sourceType: "LINK",
+          sourceType,
           sourceUrl,
           updatedAt: now,
         })

--- a/app/job-posting/edit/page.tsx
+++ b/app/job-posting/edit/page.tsx
@@ -20,12 +20,13 @@ async function getJobPosting() {
 export default async function JobPostingEditPage({
   searchParams,
 }: {
-  searchParams: { analyzing?: string };
+  searchParams: { analyzing?: string; mode?: string };
 }) {
   const userId = await getAuthUser();
   if (!userId) redirect("/login");
 
   const isAnalyzing = searchParams.analyzing === "true";
+  const isPasteMode = searchParams.mode === "paste";
   const jobPosting = isAnalyzing ? null : await getJobPosting();
 
   const initialData = {
@@ -49,7 +50,7 @@ export default async function JobPostingEditPage({
             <p className="text-sm text-gray-500 dark:text-slate-400">내용이 맞으면 면접을 시작하세요</p>
           )}
         </div>
-        <JobPostingEditForm initialData={initialData} isAnalyzing={isAnalyzing} />
+        <JobPostingEditForm initialData={initialData} isAnalyzing={isAnalyzing} isPasteMode={isPasteMode} />
       </div>
     </main>
   );

--- a/components/JobPostingEditForm.tsx
+++ b/components/JobPostingEditForm.tsx
@@ -11,6 +11,7 @@ interface Props {
     preferredQuals: string;
   };
   isAnalyzing?: boolean;
+  isPasteMode?: boolean;
 }
 
 const FIELDS = [
@@ -29,7 +30,7 @@ const ANALYZE_STEPS = [
 
 type Mode = "analyzing" | "view" | "editing";
 
-export default function JobPostingEditForm({ initialData, isAnalyzing = false }: Props) {
+export default function JobPostingEditForm({ initialData, isAnalyzing = false, isPasteMode = false }: Props) {
   const router = useRouter();
   const [mode, setMode] = useState<Mode>(isAnalyzing ? "analyzing" : "view");
   const [fields, setFields] = useState(initialData);
@@ -38,6 +39,9 @@ export default function JobPostingEditForm({ initialData, isAnalyzing = false }:
   const [isSaving, setIsSaving] = useState(false);
   const [errorMessage, setErrorMessage] = useState("");
   const [analysisError, setAnalysisError] = useState("");
+  const [pasteInput, setPasteInput] = useState("");
+  const [isPasteAnalyzing, setIsPasteAnalyzing] = useState(false);
+  const [showManualFields, setShowManualFields] = useState(false);
   const analyzeCalledRef = useRef(false);
 
   // 분석 단계 메시지 타이머
@@ -66,19 +70,31 @@ export default function JobPostingEditForm({ initialData, isAnalyzing = false }:
     if (mode !== "analyzing" || analyzeCalledRef.current) return;
     analyzeCalledRef.current = true;
 
-    fetch("/api/job-posting/analyze", { method: "POST" })
+    const pastedText = isPasteMode ? (sessionStorage.getItem("pastedJobText") ?? "") : undefined;
+    if (isPasteMode) sessionStorage.removeItem("pastedJobText");
+
+    const body = pastedText ? { pastedText } : {};
+
+    fetch("/api/job-posting/analyze", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+    })
       .then(async (res) => {
         const data = await res.json();
-        if (!res.ok || !data.jobPosting) {
-          setAnalysisError("URL에서 공고 내용을 자동으로 가져오지 못했어요. 직접 입력해 주세요.");
-          setMode("editing");
-        } else {
+        if (res.ok && data.jobPosting) {
           setFields({
             responsibilities: data.jobPosting.responsibilities ?? "",
             requirements:     data.jobPosting.requirements     ?? "",
             preferredQuals:   data.jobPosting.preferredQuals   ?? "",
           });
           setMode("view");
+        } else if (res.status === 422 && data.needsManualInput) {
+          setAnalysisError("공고 내용을 자동으로 읽지 못했어요. 아래에 공고 텍스트를 붙여넣으면 분석해드릴게요.");
+          setMode("editing");
+        } else {
+          setAnalysisError("URL에서 공고 내용을 자동으로 가져오지 못했어요. 직접 입력해 주세요.");
+          setMode("editing");
         }
         router.replace("/job-posting/edit");
       })
@@ -87,7 +103,37 @@ export default function JobPostingEditForm({ initialData, isAnalyzing = false }:
         setMode("editing");
         router.replace("/job-posting/edit");
       });
-  }, [mode, router]);
+  }, [mode, router, isPasteMode]);
+
+  async function handlePasteAnalyze() {
+    if (!pasteInput.trim()) return;
+    setIsPasteAnalyzing(true);
+    setErrorMessage("");
+
+    try {
+      const res = await fetch("/api/job-posting/analyze", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ pastedText: pasteInput.trim() }),
+      });
+      const data = await res.json();
+      if (res.ok && data.jobPosting) {
+        setFields({
+          responsibilities: data.jobPosting.responsibilities ?? "",
+          requirements:     data.jobPosting.requirements     ?? "",
+          preferredQuals:   data.jobPosting.preferredQuals   ?? "",
+        });
+        setAnalysisError("");
+        setMode("view");
+      } else {
+        setErrorMessage(data.error ?? "텍스트에서 공고 내용을 찾지 못했어요. 직접 입력해 주세요.");
+      }
+    } catch {
+      setErrorMessage("네트워크 오류가 발생했습니다");
+    } finally {
+      setIsPasteAnalyzing(false);
+    }
+  }
 
   async function handleSave() {
     if (!fields.responsibilities.trim() || !fields.requirements.trim()) return;
@@ -127,9 +173,7 @@ export default function JobPostingEditForm({ initialData, isAnalyzing = false }:
   if (mode === "analyzing") {
     return (
       <div className="space-y-3">
-        {/* 로더 + 단계 메시지 */}
         <div className="card px-6 py-8 flex flex-col items-center gap-5">
-          {/* Toss 스타일 원형 로더 */}
           <div
             className="animate-spin"
             style={{ animationDuration: "1.2s", animationTimingFunction: "linear" }}
@@ -143,7 +187,6 @@ export default function JobPostingEditForm({ initialData, isAnalyzing = false }:
             </svg>
           </div>
 
-          {/* 단계 메시지 */}
           <div className="text-center" style={{ minHeight: "48px" }}>
             <p
               className="text-base font-semibold text-gray-900 dark:text-slate-50 transition-opacity duration-300"
@@ -155,7 +198,6 @@ export default function JobPostingEditForm({ initialData, isAnalyzing = false }:
           </div>
         </div>
 
-        {/* 스켈레톤 결과 카드 */}
         <div className="card p-5 space-y-5">
           {[80, 65, 50].map((w, i) => (
             <div key={i} className="space-y-2">
@@ -200,16 +242,10 @@ export default function JobPostingEditForm({ initialData, isAnalyzing = false }:
             ← 다시 입력
           </Link>
           <div className="flex gap-2">
-            <button
-              onClick={() => setMode("editing")}
-              className="btn-secondary"
-            >
+            <button onClick={() => setMode("editing")} className="btn-secondary">
               편집하기
             </button>
-            <Link
-              href="/interview"
-              className="btn-primary"
-            >
+            <Link href="/interview" className="btn-primary">
               면접 시작하기 →
             </Link>
           </div>
@@ -226,28 +262,60 @@ export default function JobPostingEditForm({ initialData, isAnalyzing = false }:
           {analysisError}
         </div>
       )}
-      <div className="card p-5 space-y-4">
-        {FIELDS.map(({ key, label, required, placeholder }) => (
-          <div key={key} className="space-y-1">
-            <label className="text-sm font-medium text-gray-700 dark:text-slate-300">
-              {label}{required && <span className="text-red-500 ml-0.5">*</span>}
-            </label>
-            <textarea
-              value={fields[key]}
-              onChange={(e) => setFields((prev) => ({ ...prev, [key]: e.target.value }))}
-              placeholder={placeholder}
-              rows={8}
-              className="input resize-none"
-            />
-          </div>
-        ))}
 
-        {errorMessage && (
-          <div className="bg-red-50 border border-red-100 text-red-600 text-sm rounded-xl px-4 py-3 dark:bg-red-900/30 dark:border-red-800 dark:text-red-400">
-            {errorMessage}
-          </div>
-        )}
-      </div>
+      {/* 붙여넣기 분석 섹션 (자동 추출 실패 시 표시) */}
+      {analysisError && (
+        <div className="card p-5 space-y-3">
+          <p className="text-sm font-medium text-gray-700 dark:text-slate-300">공고 텍스트 붙여넣기</p>
+          <textarea
+            value={pasteInput}
+            onChange={(e) => setPasteInput(e.target.value)}
+            placeholder={"채용공고 페이지의 내용을 복사해서 붙여 넣어주세요\n(회사명, 사업부/팀명, 담당업무, 자격요건, 우대사항 등)"}
+            rows={14}
+            disabled={isPasteAnalyzing}
+            className="input resize-none disabled:opacity-50"
+          />
+          <button
+            onClick={handlePasteAnalyze}
+            disabled={isPasteAnalyzing || !pasteInput.trim()}
+            className="btn-primary w-full disabled:opacity-50"
+          >
+            {isPasteAnalyzing ? "분석 중..." : "텍스트로 분석하기"}
+          </button>
+          <button
+            type="button"
+            onClick={() => setShowManualFields((v) => !v)}
+            className="w-full text-xs text-gray-400 dark:text-slate-500 hover:text-gray-600 dark:hover:text-slate-300 py-1"
+          >
+            {showManualFields ? "직접 입력 닫기" : "직접 입력할게요"}
+          </button>
+        </div>
+      )}
+
+      {(!analysisError || showManualFields) && (
+        <div className="card p-5 space-y-4">
+          {FIELDS.map(({ key, label, required, placeholder }) => (
+            <div key={key} className="space-y-1">
+              <label className="text-sm font-medium text-gray-700 dark:text-slate-300">
+                {label}{required && <span className="text-red-500 ml-0.5">*</span>}
+              </label>
+              <textarea
+                value={fields[key]}
+                onChange={(e) => setFields((prev) => ({ ...prev, [key]: e.target.value }))}
+                placeholder={placeholder}
+                rows={8}
+                className="input resize-none"
+              />
+            </div>
+          ))}
+
+          {errorMessage && (
+            <div className="bg-red-50 border border-red-100 text-red-600 text-sm rounded-xl px-4 py-3 dark:bg-red-900/30 dark:border-red-800 dark:text-red-400">
+              {errorMessage}
+            </div>
+          )}
+        </div>
+      )}
 
       <div className="flex items-center justify-between gap-3">
         <button onClick={() => setMode("view")} className="btn-secondary">

--- a/components/JobPostingForm.tsx
+++ b/components/JobPostingForm.tsx
@@ -4,17 +4,20 @@ import { useState } from "react";
 import Link from "next/link";
 import { useRouter } from "nextjs-toploader/app";
 
+type InputMode = "url" | "paste";
+
 export default function JobPostingForm() {
   const router = useRouter();
+  const [inputMode, setInputMode] = useState<InputMode>("url");
   const [url, setUrl] = useState("");
+  const [pastedText, setPastedText] = useState("");
   const [status, setStatus] = useState<"idle" | "loading" | "error">("idle");
   const [errorMessage, setErrorMessage] = useState("");
 
   const isLoading = status === "loading";
 
-  async function handleAnalyze() {
+  async function handleUrlAnalyze() {
     if (!url.trim()) return;
-
     setStatus("loading");
     setErrorMessage("");
 
@@ -30,8 +33,32 @@ export default function JobPostingForm() {
         setStatus("error");
         return;
       }
-
       router.push("/job-posting/edit?analyzing=true");
+    } catch {
+      setErrorMessage("네트워크 오류가 발생했습니다");
+      setStatus("error");
+    }
+  }
+
+  async function handlePasteAnalyze() {
+    if (!pastedText.trim()) return;
+    setStatus("loading");
+    setErrorMessage("");
+
+    try {
+      const saveRes = await fetch("/api/job-posting", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ sourceUrl: null }),
+      });
+      const saveData = await saveRes.json();
+      if (!saveRes.ok) {
+        setErrorMessage(saveData.error ?? "저장에 실패했습니다");
+        setStatus("error");
+        return;
+      }
+      sessionStorage.setItem("pastedJobText", pastedText.trim());
+      router.push("/job-posting/edit?analyzing=true&mode=paste");
     } catch {
       setErrorMessage("네트워크 오류가 발생했습니다");
       setStatus("error");
@@ -41,19 +68,51 @@ export default function JobPostingForm() {
   return (
     <div className="space-y-4">
       <div className="card p-5 space-y-4">
-        <div className="space-y-2">
-          <label className="text-sm font-medium text-gray-700 dark:text-slate-300">채용공고 URL</label>
-          <input
-            type="url"
-            value={url}
-            onChange={(e) => setUrl(e.target.value)}
-            onKeyDown={(e) => { if (e.key === "Enter") handleAnalyze(); }}
-            placeholder="https://www.wanted.co.kr/wd/..."
-            disabled={isLoading}
-            className="input disabled:opacity-50"
-          />
-          <p className="text-xs text-gray-400 dark:text-slate-500">지원하고자 하는 회사의 채용공고 링크를 붙여 넣어주세요</p>
+        {/* 탭 */}
+        <div className="flex rounded-lg bg-gray-100 dark:bg-slate-700 p-1 gap-1">
+          {([["url", "URL로 분석"], ["paste", "텍스트 붙여넣기"]] as [InputMode, string][]).map(([mode, label]) => (
+            <button
+              key={mode}
+              onClick={() => { setInputMode(mode); setErrorMessage(""); setStatus("idle"); }}
+              className={`flex-1 text-sm font-medium py-1.5 rounded-md transition-colors ${
+                inputMode === mode
+                  ? "bg-white dark:bg-slate-600 text-gray-900 dark:text-slate-50 shadow-sm"
+                  : "text-gray-500 dark:text-slate-400 hover:text-gray-700 dark:hover:text-slate-300"
+              }`}
+            >
+              {label}
+            </button>
+          ))}
         </div>
+
+        {inputMode === "url" ? (
+          <div className="space-y-2">
+            <label className="text-sm font-medium text-gray-700 dark:text-slate-300">채용공고 URL</label>
+            <input
+              type="url"
+              value={url}
+              onChange={(e) => setUrl(e.target.value)}
+              onKeyDown={(e) => { if (e.key === "Enter") handleUrlAnalyze(); }}
+              placeholder="https://careers.example.com/jobs/..."
+              disabled={isLoading}
+              className="input disabled:opacity-50"
+            />
+            <p className="text-xs text-gray-400 dark:text-slate-500">기업 공식 채용 페이지 URL을 붙여 넣어주세요</p>
+          </div>
+        ) : (
+          <div className="space-y-2">
+            <label className="text-sm font-medium text-gray-700 dark:text-slate-300">채용공고 텍스트</label>
+            <textarea
+              value={pastedText}
+              onChange={(e) => setPastedText(e.target.value)}
+              placeholder={"채용공고 페이지의 내용을 복사해서 붙여 넣어주세요\n(회사명, 사업부/팀명, 담당업무, 자격요건, 우대사항 등)"}
+              disabled={isLoading}
+              rows={14}
+              className="input resize-none disabled:opacity-50"
+            />
+            <p className="text-xs text-gray-400 dark:text-slate-500">사람인·잡코리아 등 구직 플랫폼 URL은 공고 텍스트를 직접 붙여넣어 주셔야 해요</p>
+          </div>
+        )}
 
         {status === "error" && (
           <div className="bg-red-50 border border-red-100 text-red-600 text-sm rounded-xl px-4 py-3 dark:bg-red-900/30 dark:border-red-800 dark:text-red-400">
@@ -67,8 +126,8 @@ export default function JobPostingForm() {
           ← 프로필 수정
         </Link>
         <button
-          onClick={handleAnalyze}
-          disabled={isLoading || !url.trim()}
+          onClick={inputMode === "url" ? handleUrlAnalyze : handlePasteAnalyze}
+          disabled={isLoading || (inputMode === "url" ? !url.trim() : !pastedText.trim())}
           className="btn-primary"
         >
           {isLoading ? (

--- a/lib/ocr.ts
+++ b/lib/ocr.ts
@@ -1,0 +1,27 @@
+const VISION_API_URL = "https://vision.googleapis.com/v1/images:annotate";
+
+export async function extractTextFromImageUrl(imageUrl: string): Promise<string> {
+  const apiKey = process.env.GOOGLE_CLOUD_VISION_API_KEY;
+  if (!apiKey) return "";
+
+  try {
+    const res = await fetch(`${VISION_API_URL}?key=${apiKey}`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        requests: [{
+          image: { source: { imageUri: imageUrl } },
+          features: [{ type: "TEXT_DETECTION" }],
+        }],
+      }),
+      signal: AbortSignal.timeout(15_000),
+    });
+
+    if (!res.ok) return "";
+
+    const data = await res.json();
+    return data.responses?.[0]?.fullTextAnnotation?.text ?? "";
+  } catch {
+    return "";
+  }
+}

--- a/lib/schemas.ts
+++ b/lib/schemas.ts
@@ -47,7 +47,7 @@ export const profileSchema = z.object({
 });
 
 export const jobPostingSchema = z.object({
-  sourceUrl: z.string().url("올바른 URL을 입력해주세요"),
+  sourceUrl: z.string().url("올바른 URL을 입력해주세요").nullable(),
 });
 
 export const jobPostingManualSchema = z.object({


### PR DESCRIPTION
## Summary

- LLM 추출 결과 품질로 실패 판정 (텍스트 길이 기준 제거 — 잡코리아는 12,000자를 반환해도 채용 내용 없음)
- Jina.ai 마크다운 이미지 URL 감지 → Google Cloud Vision OCR 시도 (기업 공식 이미지 포스터 대응)
- 최종 실패 시 422 `needsManualInput` 반환 → 프론트에서 붙여넣기 섹션 표시
- `JobPostingForm`에 URL / 텍스트 붙여넣기 탭 추가 (사람인·잡코리아 등 크롤링 불가 플랫폼 대응)
- 분석 실패 시 편집 화면에서 텍스트 붙여넣기 섹션 표시, "직접 입력할게요" 토글로 항목별 입력 접근

## Test plan

- [ ] URL 탭 → 기업 공식 채용 페이지 URL 입력 → 정상 추출 확인
- [ ] URL 탭 → 사람인/잡코리아 URL 입력 → 자동 실패 후 붙여넣기 섹션 표시 확인
- [ ] 텍스트 붙여넣기 탭 → 공고 텍스트 붙여넣기 → 분석 정상 동작 확인
- [ ] 분석 실패 화면 → "직접 입력할게요" 클릭 → 항목별 입력 칸 펼쳐짐 확인
- [ ] 기존 URL 분석 정상 동작에 영향 없음 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)