### PR TITLE
feat: 채용공고 파싱 확장 — companyName/divisionName/techStack/isITCompany 추출

### DIFF
--- a/app/api/interview/follow-up/route.ts
+++ b/app/api/interview/follow-up/route.ts
@@ -50,7 +50,7 @@ export async function POST(request: NextRequest) {
 
     const { data: jobPosting } = await supabase
       .from("job_postings")
-      .select("responsibilities, requirements, preferredQuals")
+      .select("responsibilities, requirements, preferredQuals, companyName, divisionName, techStack")
       .eq("userId", userId)
       .order("updatedAt", { ascending: false })
       .limit(1)
@@ -75,6 +75,9 @@ export async function POST(request: NextRequest) {
       responsibilities: jobPosting.responsibilities ?? "",
       requirements: jobPosting.requirements ?? "",
       preferredQuals: jobPosting.preferredQuals ?? "",
+      companyName: jobPosting.companyName ?? undefined,
+      divisionName: jobPosting.divisionName ?? undefined,
+      techStack: jobPosting.techStack ?? undefined,
     };
 
     const { thought, selectedAgentId } = await findFollowUpAgent(

--- a/app/api/interview/question/route.ts
+++ b/app/api/interview/question/route.ts
@@ -49,7 +49,7 @@ export async function POST(request: NextRequest) {
 
     const { data: jobPosting } = await supabase
       .from("job_postings")
-      .select("responsibilities, requirements, preferredQuals")
+      .select("responsibilities, requirements, preferredQuals, companyName, divisionName, techStack")
       .eq("userId", userId)
       .order("updatedAt", { ascending: false })
       .limit(1)
@@ -74,6 +74,9 @@ export async function POST(request: NextRequest) {
       responsibilities: jobPosting.responsibilities ?? "",
       requirements: jobPosting.requirements ?? "",
       preferredQuals: jobPosting.preferredQuals ?? "",
+      companyName: jobPosting.companyName ?? undefined,
+      divisionName: jobPosting.divisionName ?? undefined,
+      techStack: jobPosting.techStack ?? undefined,
     };
 
     const result = await generateAgentBaseQuestion(

--- a/app/api/job-posting/analyze/route.ts
+++ b/app/api/job-posting/analyze/route.ts
@@ -30,24 +30,36 @@ async function extractJobInfo(text: string): Promise<{
   responsibilities: string;
   requirements: string;
   preferredQuals: string;
+  companyName: string;
+  divisionName: string;
+  techStack: string;
+  isITCompany: boolean;
 }> {
   const prompt = `아래는 채용공고 텍스트입니다.
-텍스트에서 의미상 아래 세 가지 항목에 해당하는 내용을 찾아 JSON으로 추출해주세요.
+텍스트에서 의미상 아래 항목에 해당하는 내용을 찾아 JSON으로 추출해주세요.
 항목명이 정확히 일치하지 않아도 의미가 같으면 해당 항목으로 분류하세요.
 
 분류 기준:
 - "업무 내용": 담당업무, 하는 일, 주요 역할, 업무 소개, What you'll do, Responsibilities 등
 - "지원 자격": 자격 요건, 필수 조건, 이런 분을 찾아요, Requirements, Qualifications 등
 - "우대 사항": 우대 조건, 이런 분이면 더 좋아요, Preferred, Nice to have 등
+- "회사명": 공고를 올린 회사/기관명 (없으면 빈 문자열)
+- "사업부": 지원 팀·사업부·부서명 (없으면 빈 문자열)
+- "기술스택": 공고에 언급된 기술·툴·언어 목록을 쉼표로 연결 (없으면 빈 문자열)
+- "IT기업": 소프트웨어·인터넷·테크 기업이면 true, 아니면 false
 
 명시적인 항목 구분 없이 문장이 나열된 경우에도 문맥을 파악해서 적절히 분류하세요.
-해당 항목이 없으면 빈 리스트로 반환하세요.
+해당 항목이 없으면 빈 리스트(배열 항목) 또는 빈 문자열로 반환하세요.
 
 출력 형식 (반드시 JSON만 출력, 다른 텍스트 없이):
 {
   "업무 내용": ["...", "..."],
   "지원 자격": ["...", "..."],
-  "우대 사항": ["...", "..."]
+  "우대 사항": ["...", "..."],
+  "회사명": "...",
+  "사업부": "...",
+  "기술스택": "...",
+  "IT기업": true
 }
 
 채용공고:
@@ -109,6 +121,10 @@ ${text}`;
     responsibilities: join(normalized["업무 내용"]),
     requirements:     join(normalized["지원 자격"]),
     preferredQuals:   join(normalized["우대 사항"]),
+    companyName:      typeof parsed["회사명"] === "string" ? parsed["회사명"] : "",
+    divisionName:     typeof parsed["사업부"] === "string" ? parsed["사업부"] : "",
+    techStack:        typeof parsed["기술스택"] === "string" ? parsed["기술스택"] : (Array.isArray(parsed["기술스택"]) ? (parsed["기술스택"] as string[]).join(", ") : ""),
+    isITCompany:      parsed["IT기업"] === true,
   };
 }
 

--- a/lib/interview.ts
+++ b/lib/interview.ts
@@ -74,6 +74,9 @@ export interface JobPostingContext {
   responsibilities: string;
   requirements: string;
   preferredQuals: string;
+  companyName?: string;
+  divisionName?: string;
+  techStack?: string;
 }
 
 export function buildProfileSummary(profile: ProfileContext): string {
@@ -219,9 +222,9 @@ function buildAgentSystemPrompt(
 ${DIFFICULTY_QUESTION_HINT[difficulty]}
 
 [채용공고]
-담당 업무: ${jobPosting.responsibilities || "N/A"}
+${jobPosting.companyName ? `회사명: ${jobPosting.companyName}\n` : ""}${jobPosting.divisionName ? `지원 사업부: ${jobPosting.divisionName}\n` : ""}담당 업무: ${jobPosting.responsibilities || "N/A"}
 자격 요건: ${jobPosting.requirements || "N/A"}
-우대 사항: ${jobPosting.preferredQuals || "N/A"}
+우대 사항: ${jobPosting.preferredQuals || "N/A"}${jobPosting.techStack ? `\n기술스택: ${jobPosting.techStack}` : ""}
 
 [지원자 프로필]
 ${profileSummary}
@@ -470,9 +473,9 @@ async function generateSingleAgentThought(
   const systemPrompt = `${AGENT_THOUGHT_PERSONA[agentId]}
 
 [채용공고]
-담당 업무: ${jobPosting.responsibilities || "N/A"}
+${jobPosting.companyName ? `회사명: ${jobPosting.companyName}\n` : ""}${jobPosting.divisionName ? `지원 사업부: ${jobPosting.divisionName}\n` : ""}담당 업무: ${jobPosting.responsibilities || "N/A"}
 자격 요건: ${jobPosting.requirements || "N/A"}
-우대 사항: ${jobPosting.preferredQuals || "N/A"}
+우대 사항: ${jobPosting.preferredQuals || "N/A"}${jobPosting.techStack ? `\n기술스택: ${jobPosting.techStack}` : ""}
 
 [지원자 프로필]
 ${profileSummary}

--- a/types/supabase.ts
+++ b/types/supabase.ts
@@ -222,35 +222,47 @@ export type Database = {
       }
       job_postings: {
         Row: {
+          companyName: string | null
           createdAt: string
+          divisionName: string | null
           id: string
+          isITCompany: boolean
           preferredQuals: string | null
           requirements: string | null
           responsibilities: string | null
           sourceType: string
           sourceUrl: string | null
+          techStack: string | null
           updatedAt: string
           userId: string
         }
         Insert: {
+          companyName?: string | null
           createdAt?: string
+          divisionName?: string | null
           id: string
+          isITCompany?: boolean
           preferredQuals?: string | null
           requirements?: string | null
           responsibilities?: string | null
           sourceType: string
           sourceUrl?: string | null
+          techStack?: string | null
           updatedAt?: string
           userId: string
         }
         Update: {
+          companyName?: string | null
           createdAt?: string
+          divisionName?: string | null
           id?: string
+          isITCompany?: boolean
           preferredQuals?: string | null
           requirements?: string | null
           responsibilities?: string | null
           sourceType?: string
           sourceUrl?: string | null
+          techStack?: string | null
           updatedAt?: string
           userId?: string
         }


### PR DESCRIPTION
## Summary
- `job_postings` 테이블에 `companyName`, `divisionName`, `techStack`, `isITCompany` 4개 컬럼 추가
- `/api/job-posting/analyze` LLM 프롬프트 확장으로 신규 필드 자동 추출
- `JobPostingContext` 인터페이스 및 면접관 시스템 프롬프트에 기업 정보 반영
- `isListed`는 이슈 #119(DART API)에서 처리 예정

## Test plan
- [ ] IT 기업 채용공고 URL 분석 후 DB에 `companyName`, `isITCompany=true`, `techStack` 저장 확인
- [ ] 면접 시작 시 기술전문가 질문이 기술스택 기반으로 생성되는지 확인
- [ ] 기존 3개 필드(responsibilities, requirements, preferredQuals) 동작 이상 없음 확인

Closes #118

🤖 Generated with [Claude Code](https://claude.com/claude-code)