### PR TITLE
feat: RunPod Serverless 연동 — LLM 호출 클라이언트 교체

### DIFF
--- a/app/api/job-posting/analyze/route.ts
+++ b/app/api/job-posting/analyze/route.ts
@@ -1,9 +1,7 @@
 import { NextResponse } from "next/server";
 import { supabaseAdmin as supabase } from "@/lib/supabase-admin";
 import { getAuthUser } from "@/lib/auth";
-
-const LLM_BASE_URL = process.env.LLM_BASE_URL ?? "http://localhost:11434";
-const LLM_MODEL = process.env.LLM_MODEL ?? "exaone3.5:2.4b";
+import { callLLM } from "@/lib/runpod-client";
 
 async function fetchPageText(url: string): Promise<string> {
   const res = await fetch(`https://r.jina.ai/${url}`, {
@@ -42,20 +40,10 @@ async function extractJobInfo(text: string): Promise<{
 채용공고:
 ${text}`;
 
-  const response = await fetch(`${LLM_BASE_URL}/v1/chat/completions`, {
-    method: "POST",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({
-      model: LLM_MODEL,
-      messages: [{ role: "user", content: prompt }],
-    }),
-    signal: AbortSignal.timeout(120_000),
+  const raw = await callLLM({
+    messages: [{ role: "user", content: prompt }],
+    max_tokens: 1000,
   });
-
-  if (!response.ok) throw new Error(`LLM 요청 실패 (${response.status})`);
-
-  const data = await response.json();
-  const raw: string = data.choices?.[0]?.message?.content ?? "";
 
   const start = raw.indexOf("{");
   const end = raw.lastIndexOf("}") + 1;

--- a/lib/agents.ts
+++ b/lib/agents.ts
@@ -1,4 +1,5 @@
 import { AgentId, AGENTS, Message, ProfileContext, JobPostingContext, buildProfileSummary } from "@/lib/interview";
+import { callLLM } from "@/lib/runpod-client";
 
 const LLM_BASE_URL = process.env.LLM_BASE_URL ?? "http://localhost:11434";
 const LLM_MODEL = process.env.LLM_MODEL ?? "exaone3.5:2.4b";
@@ -58,25 +59,13 @@ export interface ModeratorResult {
 }
 
 async function callOllama(systemPrompt: string, userContent: string): Promise<string> {
-  const response = await fetch(`${LLM_BASE_URL}/v1/chat/completions`, {
-    method: "POST",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({
-      model: LLM_MODEL,
-      messages: [
-        { role: "system", content: systemPrompt },
-        { role: "user", content: userContent },
-      ],
-    }),
-    signal: AbortSignal.timeout(180_000),
+  return callLLM({
+    messages: [
+      { role: "system", content: systemPrompt },
+      { role: "user", content: userContent },
+    ],
+    max_tokens: 2000,
   });
-
-  if (!response.ok) {
-    throw new Error(`LLM 요청 실패: ${response.status} ${response.statusText}`);
-  }
-
-  const data = await response.json();
-  return (data.choices?.[0]?.message?.content ?? "").trim();
 }
 
 function extractJSON<T>(raw: string): T {

--- a/lib/interview.ts
+++ b/lib/interview.ts
@@ -242,25 +242,14 @@ function stripMarkdown(text: string): string {
 }
 
 async function callOllama(systemPrompt: string, userContent: string, _json = false): Promise<string> {
-  const response = await fetch(`${LLM_BASE_URL}/v1/chat/completions`, {
-    method: "POST",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({
-      model: LLM_MODEL,
-      messages: [
-        { role: "system", content: systemPrompt },
-        { role: "user", content: userContent },
-      ],
-    }),
-    signal: AbortSignal.timeout(180_000),
+  const { callLLM } = await import("@/lib/runpod-client");
+  const raw = await callLLM({
+    messages: [
+      { role: "system", content: systemPrompt },
+      { role: "user", content: userContent },
+    ],
+    max_tokens: 1000,
   });
-
-  if (!response.ok) {
-    throw new Error(`LLM 요청 실패: ${response.status} ${response.statusText}`);
-  }
-
-  const data = await response.json();
-  const raw: string = (data.choices?.[0]?.message?.content ?? "").trim();
   return raw.replace(/^(면접관|질문|interviewer|question)\s*:\s*/i, "").trim();
 }
 

--- a/lib/runpod-client.ts
+++ b/lib/runpod-client.ts
@@ -1,0 +1,50 @@
+const RUNPOD_API_KEY = process.env.RUNPOD_API_KEY ?? "";
+const RUNPOD_ENDPOINT_ID = process.env.RUNPOD_ENDPOINT_ID ?? "";
+const BASE_URL = `https://api.runpod.ai/v2/${RUNPOD_ENDPOINT_ID}`;
+
+interface RunPodInput {
+  messages: { role: string; content: string }[];
+  temperature?: number;
+  max_tokens?: number;
+}
+
+async function submitJob(input: RunPodInput): Promise<string> {
+  const res = await fetch(`${BASE_URL}/run`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      "Authorization": `Bearer ${RUNPOD_API_KEY}`,
+    },
+    body: JSON.stringify({ input }),
+  });
+  if (!res.ok) throw new Error(`RunPod job 제출 실패: ${res.status}`);
+  const data = await res.json();
+  return data.id as string;
+}
+
+async function pollJob(jobId: string, timeoutMs = 180_000): Promise<string> {
+  const start = Date.now();
+  while (Date.now() - start < timeoutMs) {
+    const res = await fetch(`${BASE_URL}/status/${jobId}`, {
+      headers: { "Authorization": `Bearer ${RUNPOD_API_KEY}` },
+    });
+    if (!res.ok) throw new Error(`RunPod 상태 조회 실패: ${res.status}`);
+    const data = await res.json();
+
+    if (data.status === "COMPLETED") {
+      if (data.output?.error) throw new Error(data.output.error);
+      return data.output?.output ?? "";
+    }
+    if (data.status === "FAILED") {
+      throw new Error(`RunPod job 실패: ${JSON.stringify(data.error)}`);
+    }
+    // IN_QUEUE / IN_PROGRESS → 계속 폴링
+    await new Promise((r) => setTimeout(r, 2000));
+  }
+  throw new Error("RunPod job 타임아웃");
+}
+
+export async function callLLM(input: RunPodInput): Promise<string> {
+  const jobId = await submitJob(input);
+  return pollJob(jobId);
+}


### PR DESCRIPTION
## Summary
- RunPod Serverless 엔드포인트 연동을 위한 클라이언트 추가
- 기존 직접 HTTP 호출 방식을 RunPod job 큐 방식으로 교체
- LLM_BASE_URL → RUNPOD_API_KEY + RUNPOD_ENDPOINT_ID 환경변수 변경

## 변경 파일
- `lib/runpod-client.ts` (신규): RunPod Serverless API 클라이언트
- `lib/agents.ts`: callOllama → callLLM 교체
- `lib/interview.ts`: callOllama → callLLM 교체
- `app/api/job-posting/analyze/route.ts`: fetch → callLLM 교체

## 인프라
- RunPod Serverless 엔드포인트: dukxwoe7vjz0qo
- 모델: LGAI-EXAONE/EXAONE-3.5-7.8B-Instruct
- URL 고정으로 Pod 재시작 시 코드 수정 불필요

## Test plan
- [ ] 면접 질문 생성 확인
- [ ] 꼬리질문 확인
- [ ] 토론 평가 확인