### PR TITLE
feat: DART API 기업 정보 수집 (#131)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -18,3 +18,7 @@ GOOGLE_CLOUD_TTS_API_KEY="<your-google-cloud-tts-api-key>"
 # Google Cloud Vision API (이미지 포스터 OCR, 선택)
 # GCP Console → Vision API 활성화 후 발급
 GOOGLE_CLOUD_VISION_API_KEY="<your-google-cloud-vision-api-key>"
+
+# DART 공시 API (기업 정보 수집, 선택)
+# opendart.fss.or.kr에서 발급
+DART_API_KEY="<your-dart-api-key>"

--- a/app/api/job-posting/analyze/route.ts
+++ b/app/api/job-posting/analyze/route.ts
@@ -5,6 +5,7 @@ import { supabaseAdmin as supabase } from "@/lib/supabase-admin";
 import { getAuthUser } from "@/lib/auth";
 import { callLLM } from "@/lib/runpod-client";
 import { extractTextFromImageUrl } from "@/lib/ocr";
+import { collectCompanyInfo } from "@/lib/company-info-collector";
 
 async function fetchPageText(url: string): Promise<{ text: string; markdown: string }> {
   const res = await fetch(`https://r.jina.ai/${url}`, {
@@ -216,6 +217,10 @@ export async function POST(request: NextRequest) {
       .eq("id", posting.id)
       .select()
       .single();
+
+    if (extracted.companyName) {
+      collectCompanyInfo(posting.id, extracted.companyName).catch(() => {});
+    }
 
     return NextResponse.json({ jobPosting: updated });
   } catch (error) {

--- a/lib/company-info-collector.ts
+++ b/lib/company-info-collector.ts
@@ -1,0 +1,152 @@
+import { supabaseAdmin as supabase } from "@/lib/supabase-admin";
+import { callLLM } from "@/lib/runpod-client";
+
+const DART_BASE = "https://opendart.fss.or.kr/api";
+const API_KEY = process.env.DART_API_KEY ?? "";
+
+async function findCorpCode(companyName: string): Promise<{ corp_code: string; stock_code: string | null } | null> {
+  // 완전 일치 → 접두 일치 → 부분 일치 순으로 시도
+  const queries = [
+    supabase.from("dart_corps").select("corp_code, stock_code").eq("corp_name", companyName).limit(1).maybeSingle(),
+    supabase.from("dart_corps").select("corp_code, stock_code").ilike("corp_name", `${companyName}%`).limit(1).maybeSingle(),
+    supabase.from("dart_corps").select("corp_code, stock_code").ilike("corp_name", `%${companyName}%`).limit(1).maybeSingle(),
+  ];
+  for (const query of queries) {
+    const { data } = await query;
+    if (data) return data;
+  }
+  return null;
+}
+
+async function fetchCompanyDetail(corpCode: string): Promise<{
+  ceo_nm: string;
+  corp_cls: string;
+  hm_url: string;
+  est_dt: string;
+} | null> {
+  const url = new URL(`${DART_BASE}/company.json`);
+  url.searchParams.set("crtfc_key", API_KEY);
+  url.searchParams.set("corp_code", corpCode);
+
+  const res = await fetch(url.toString(), { signal: AbortSignal.timeout(10_000) });
+  if (!res.ok) return null;
+
+  const data = await res.json() as Record<string, string>;
+  if (data.status !== "000") return null;
+
+  return {
+    ceo_nm: data.ceo_nm ?? "",
+    corp_cls: data.corp_cls ?? "",
+    hm_url: (data.hm_url ?? "").trim(),
+    est_dt: data.est_dt ?? "",
+  };
+}
+
+async function fetchFinancialSummary(corpCode: string): Promise<string> {
+  const url = new URL(`${DART_BASE}/fnlttSinglAcnt.json`);
+  url.searchParams.set("crtfc_key", API_KEY);
+  url.searchParams.set("corp_code", corpCode);
+  url.searchParams.set("bsns_year", String(new Date().getFullYear() - 1));
+  url.searchParams.set("reprt_code", "11011");
+
+  const res = await fetch(url.toString(), { signal: AbortSignal.timeout(10_000) });
+  if (!res.ok) return "";
+
+  const data = await res.json() as { status: string; list?: { account_nm: string; thstrm_amount: string }[] };
+  if (data.status !== "000" || !data.list?.length) return "";
+
+  const TARGET = ["매출액", "영업이익", "당기순이익"];
+  const lines = data.list
+    .filter(item => TARGET.includes(item.account_nm))
+    .map(item => {
+      const amount = Number(item.thstrm_amount);
+      const formatted = amount >= 1_000_000_000_000
+        ? `약 ${Math.round((amount / 1_000_000_000_000) * 10) / 10}조원`
+        : amount >= 100_000_000
+        ? `약 ${Math.round(amount / 100_000_000)}억원`
+        : `${amount.toLocaleString("ko-KR")}원`;
+      return `${item.account_nm} ${formatted}`;
+    });
+
+  return lines.join(", ");
+}
+
+function normalizeUrl(url: string): string {
+  return url.startsWith("http://") || url.startsWith("https://") ? url : `https://${url}`;
+}
+
+async function fetchHomepageSummary(hmUrl: string): Promise<string> {
+  const res = await fetch(`https://r.jina.ai/${normalizeUrl(hmUrl)}`, {
+    headers: { Accept: "text/plain" },
+    signal: AbortSignal.timeout(20_000),
+  });
+  if (!res.ok) return "";
+
+  const text = (await res.text()).slice(0, 5000).trim();
+  if (!text) return "";
+
+  const summary = await callLLM({
+    messages: [{
+      role: "user",
+      content: `다음은 회사 홈페이지 텍스트입니다. 회사가 무엇을 하는 곳인지 핵심만 2~3문장으로 요약하세요. 텍스트에 없는 내용은 생성하지 마세요.\n\n${text}`,
+    }],
+    max_tokens: 200,
+  });
+
+  return summary.trim();
+}
+
+function formatEstDate(estDt: string): string {
+  return estDt.length >= 4 ? `${estDt.slice(0, 4)}년 설립` : "";
+}
+
+function formatCorpCls(corpCls: string, stockCode: string | null): string {
+  if (!stockCode?.trim()) return "";
+  const map: Record<string, string> = { Y: "코스피", K: "코스닥", N: "코넥스" };
+  return map[corpCls] ? `${map[corpCls]} 상장` : "상장사";
+}
+
+export async function collectCompanyInfo(jobPostingId: string, companyName: string): Promise<void> {
+  if (!API_KEY || !companyName) return;
+
+  try {
+    const corp = await findCorpCode(companyName);
+    const isListed = corp !== null && !!corp.stock_code?.trim();
+
+    const parts: string[] = [];
+
+    if (corp) {
+      const detail = await fetchCompanyDetail(corp.corp_code);
+
+      if (detail) {
+        const basicParts: string[] = [];
+        if (detail.ceo_nm) basicParts.push(`대표이사 ${detail.ceo_nm}`);
+        if (detail.est_dt) basicParts.push(formatEstDate(detail.est_dt));
+        const listingStr = formatCorpCls(detail.corp_cls, corp.stock_code);
+        if (listingStr) basicParts.push(listingStr);
+        if (basicParts.length > 0) parts.push(basicParts.join(" | "));
+
+        const [financial, homepageSummary] = await Promise.all([
+          isListed ? fetchFinancialSummary(corp.corp_code) : Promise.resolve(""),
+          detail.hm_url ? fetchHomepageSummary(detail.hm_url).catch(() => "") : Promise.resolve(""),
+        ]);
+
+        if (financial) parts.push(`${financial} (${new Date().getFullYear() - 1}년 기준)`);
+        if (homepageSummary) parts.push(homepageSummary);
+      }
+    }
+
+    await supabase.from("company_info").upsert(
+      {
+        jobPostingId,
+        companyName,
+        isListed,
+        dartSummary: parts.length > 0 ? parts.join("\n") : null,
+        collectedAt: new Date().toISOString(),
+      },
+      { onConflict: "jobPostingId" },
+    );
+  } catch (err) {
+    console.error("company-info-collector error:", err);
+  }
+}

--- a/scripts/seed-dart-corps.mjs
+++ b/scripts/seed-dart-corps.mjs
@@ -1,0 +1,92 @@
+/**
+ * DART 전체 법인 코드 목록을 Supabase dart_corps 테이블에 적재합니다.
+ * 실행: node --env-file=.env scripts/seed-dart-corps.mjs
+ */
+
+import { createClient } from "@supabase/supabase-js";
+import { inflateRaw } from "zlib";
+import { promisify } from "util";
+
+const inflateRawAsync = promisify(inflateRaw);
+
+const supabase = createClient(
+  process.env.SUPABASE_URL,
+  process.env.SUPABASE_SERVICE_ROLE_KEY,
+);
+
+async function downloadAndDecompress() {
+  console.log("DART corpCode.xml 다운로드 중...");
+  const res = await fetch(
+    `https://opendart.fss.or.kr/api/corpCode.xml?crtfc_key=${process.env.DART_API_KEY}`,
+    { redirect: "follow" },
+  );
+  if (!res.ok) throw new Error(`다운로드 실패: ${res.status}`);
+
+  const bytes = Buffer.from(await res.arrayBuffer());
+  console.log(`ZIP 크기: ${(bytes.length / 1024 / 1024).toFixed(1)} MB`);
+
+  // End of Central Directory에서 실제 압축 크기 읽기
+  let eocdOffset = -1;
+  for (let i = bytes.length - 22; i >= 0; i--) {
+    if (bytes[i] === 0x50 && bytes[i + 1] === 0x4b && bytes[i + 2] === 0x05 && bytes[i + 3] === 0x06) {
+      eocdOffset = i;
+      break;
+    }
+  }
+  if (eocdOffset < 0) throw new Error("ZIP EOCD 없음");
+
+  const cdOffset = bytes.readUInt32LE(eocdOffset + 16);
+  const compSize = bytes.readUInt32LE(cdOffset + 20);
+  const localOffset = bytes.readUInt32LE(cdOffset + 42);
+  const fnLen = bytes.readUInt16LE(localOffset + 26);
+  const extraLen = bytes.readUInt16LE(localOffset + 28);
+  const dataStart = localOffset + 30 + fnLen + extraLen;
+
+  console.log("압축 해제 중...");
+  const xml = (await inflateRawAsync(bytes.slice(dataStart, dataStart + compSize))).toString("utf8");
+  console.log(`XML 크기: ${(xml.length / 1024 / 1024).toFixed(1)} MB`);
+  return xml;
+}
+
+function parseXml(xml) {
+  const entries = [];
+  const listRegex = /<list>([\s\S]*?)<\/list>/g;
+  const fieldRegex = (name) => new RegExp(`<${name}>([^<]*)<\/${name}>`);
+
+  let match;
+  while ((match = listRegex.exec(xml)) !== null) {
+    const block = match[1];
+    const get = (name) => {
+      const m = fieldRegex(name).exec(block);
+      return m ? m[1].trim() : "";
+    };
+    const corpCode = get("corp_code");
+    const corpName = get("corp_name");
+    if (!corpCode || !corpName) continue;
+
+    entries.push({
+      corp_code: corpCode,
+      corp_name: corpName,
+      stock_code: get("stock_code") || null,
+      modify_date: get("modify_date") || null,
+    });
+  }
+  return entries;
+}
+
+async function upsertBatches(entries) {
+  const BATCH = 1000;
+  console.log(`총 ${entries.length}개 법인 업로드 시작`);
+
+  for (let i = 0; i < entries.length; i += BATCH) {
+    const batch = entries.slice(i, i + BATCH);
+    const { error } = await supabase.from("dart_corps").upsert(batch, { onConflict: "corp_code" });
+    if (error) throw new Error(`업로드 오류 (${i}~${i + batch.length}): ${error.message}`);
+    process.stdout.write(`\r${i + batch.length} / ${entries.length}`);
+  }
+  console.log("\n완료");
+}
+
+const xml = await downloadAndDecompress();
+const entries = parseXml(xml);
+await upsertBatches(entries);

--- a/types/supabase.ts
+++ b/types/supabase.ts
@@ -119,6 +119,62 @@ export type Database = {
           },
         ]
       }
+      company_info: {
+        Row: {
+          collectedAt: string
+          companyName: string
+          dartSummary: string | null
+          id: string
+          isListed: boolean
+          jobPostingId: string
+        }
+        Insert: {
+          collectedAt?: string
+          companyName: string
+          dartSummary?: string | null
+          id?: string
+          isListed?: boolean
+          jobPostingId: string
+        }
+        Update: {
+          collectedAt?: string
+          companyName?: string
+          dartSummary?: string | null
+          id?: string
+          isListed?: boolean
+          jobPostingId?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "company_info_jobPostingId_fkey"
+            columns: ["jobPostingId"]
+            isOneToOne: true
+            referencedRelation: "job_postings"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      dart_corps: {
+        Row: {
+          corp_code: string
+          corp_name: string
+          modify_date: string | null
+          stock_code: string | null
+        }
+        Insert: {
+          corp_code: string
+          corp_name: string
+          modify_date?: string | null
+          stock_code?: string | null
+        }
+        Update: {
+          corp_code?: string
+          corp_name?: string
+          modify_date?: string | null
+          stock_code?: string | null
+        }
+        Relationships: []
+      }
       educations: {
         Row: {
           degree: string | null


### PR DESCRIPTION
## Summary

- `dart_corps` 테이블: DART 전체 법인 목록 캐시 (~10만 건), `scripts/seed-dart-corps.mjs`로 최초 1회 적재
- `company_info` 테이블: 채용공고별 기업 정보 저장
- 채용공고 분석(`/api/job-posting/analyze`) 완료 후 fire-and-forget으로 기업 정보 수집
- 수집 데이터: 대표이사명, 설립연도, 상장 여부(코스피/코스닥), 재무 요약(매출·영업이익·당기순이익), 홈페이지 요약

## 동작 흐름

1. 채용공고 분석 → LLM이 `companyName` 추출
2. DB 업데이트 후 즉시 응답 반환
3. 백그라운드: `dart_corps`에서 corp_code 조회 → DART API 호출 → `company_info` upsert

## 매칭 전략

완전 일치 → 접두 일치(`name%`) → 부분 일치(`%name%`) 순 우선순위로 오매칭 최소화

## 관련 이슈

- Closes #131
- #132 (프롬프트 주입)에서 `dartSummary` 활용 예정

## Test plan

- [ ] 채용공고 분석 후 `company_info` 테이블에 레코드 생성 확인
- [ ] 상장사 공고: `isListed: true`, `dartSummary`에 재무 정보 포함 확인
- [ ] 비상장사 공고: `isListed: false`, 기본 정보만 포함 확인
- [ ] `dart_corps` 테이블에서 회사명 검색 정상 작동 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)