### PR TITLE
feat: DART 기업 정보 수집 리팩토링

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,9 @@ yarn-error.log*
 *.tsbuildinfo
 next-env.d.ts
 
+# local notes
+/notes/
+
 # python cache
 server/__pycache__/
 **/*.pyc

--- a/lib/company-info-collector.ts
+++ b/lib/company-info-collector.ts
@@ -1,15 +1,65 @@
 import { supabaseAdmin as supabase } from "@/lib/supabase-admin";
-import { callLLM } from "@/lib/runpod-client";
 
 const DART_BASE = "https://opendart.fss.or.kr/api";
 const API_KEY = process.env.DART_API_KEY ?? "";
 
+const BRAND_MAP: Record<string, string> = {
+  "배달의민족": "우아한형제들",
+  "요기요": "위대한상상",
+  "토스": "비바리퍼블리카",
+  "뱅크샐러드": "레이니스트",
+  "SM엔터테인먼트": "에스엠",
+  "YG엔터테인먼트": "와이지엔터테인먼트",
+  "JYP엔터테인먼트": "JYP Ent.",
+  "올리브영": "씨제이올리브영",
+  "지그재그": "카카오스타일",
+  "오늘의집": "버킷플레이스",
+  "번개장터": "퀵켓",
+  "아이디어스": "백패커",
+  "여기어때": "위드이노베이션",
+  "화해": "버드뷰",
+  "룩핀": "패션플랫폼",
+  "카카오T": "카카오모빌리티",
+  "라인": "라인플러스",
+  "멜론": "카카오엔터테인먼트",
+  "바이브": "엔에이치엔벅스",
+  "산타토익": "뤼이드",
+  "스터디코드": "엘리스",
+  "프로그래머스": "그렙",
+  "영단기": "에스티유니타스",
+  "토익단기": "에스티유니타스",
+  "캐시워크": "넛지헬스케어",
+  "눔": "눔코리아",
+  "블라인드": "팀블라인드",
+  "리멤버": "드라마앤컴퍼니",
+  "아프리카TV": "숲",
+  "펍지": "크래프톤",
+  "PUBG": "크래프톤",
+  "G마켓": "지마켓글로벌",
+  "SSG.com": "에스에스지닷컴",
+  "다이소": "아성다이소",
+  "이마트24": "이마트에브리데이",
+  "스타벅스": "에스씨케이컴퍼니",
+  "맥도날드": "한국맥도날드",
+  "버거킹": "비케이알",
+  "당근마켓": "당근",
+  "네이버": "NAVER",
+};
+
+function normalizeName(name: string): string {
+  const stripped = name
+    .replace(/\s*(주식회사|\(주\)|㈜)$/, "")
+    .replace(/^주식회사\s*/, "")
+    .trim();
+  return BRAND_MAP[stripped] ?? BRAND_MAP[name] ?? stripped;
+}
+
 async function findCorpCode(companyName: string): Promise<{ corp_code: string; stock_code: string | null } | null> {
-  // 완전 일치 → 접두 일치 → 부분 일치 순으로 시도
+  const normalized = normalizeName(companyName);
+  // 각 단계에서 stock_code 있는 행(상장사) 우선 정렬
   const queries = [
-    supabase.from("dart_corps").select("corp_code, stock_code").eq("corp_name", companyName).limit(1).maybeSingle(),
-    supabase.from("dart_corps").select("corp_code, stock_code").ilike("corp_name", `${companyName}%`).limit(1).maybeSingle(),
-    supabase.from("dart_corps").select("corp_code, stock_code").ilike("corp_name", `%${companyName}%`).limit(1).maybeSingle(),
+    supabase.from("dart_corps").select("corp_code, stock_code").eq("corp_name", normalized).order("stock_code", { ascending: false, nullsFirst: false }).limit(1).maybeSingle(),
+    supabase.from("dart_corps").select("corp_code, stock_code").ilike("corp_name", `${normalized}%`).order("stock_code", { ascending: false, nullsFirst: false }).limit(1).maybeSingle(),
   ];
   for (const query of queries) {
     const { data } = await query;
@@ -21,8 +71,8 @@ async function findCorpCode(companyName: string): Promise<{ corp_code: string; s
 async function fetchCompanyDetail(corpCode: string): Promise<{
   ceo_nm: string;
   corp_cls: string;
-  hm_url: string;
   est_dt: string;
+  induty_code: string;
 } | null> {
   const url = new URL(`${DART_BASE}/company.json`);
   url.searchParams.set("crtfc_key", API_KEY);
@@ -37,63 +87,124 @@ async function fetchCompanyDetail(corpCode: string): Promise<{
   return {
     ceo_nm: data.ceo_nm ?? "",
     corp_cls: data.corp_cls ?? "",
-    hm_url: (data.hm_url ?? "").trim(),
     est_dt: data.est_dt ?? "",
+    induty_code: data.induty_code ?? "",
   };
 }
 
-async function fetchFinancialSummary(corpCode: string): Promise<string> {
+async function fetchFinancialYear(corpCode: string, year: number): Promise<{ revenue: number; operatingProfit: number } | null> {
   const url = new URL(`${DART_BASE}/fnlttSinglAcnt.json`);
   url.searchParams.set("crtfc_key", API_KEY);
   url.searchParams.set("corp_code", corpCode);
-  url.searchParams.set("bsns_year", String(new Date().getFullYear() - 1));
+  url.searchParams.set("bsns_year", String(year));
   url.searchParams.set("reprt_code", "11011");
 
-  const res = await fetch(url.toString(), { signal: AbortSignal.timeout(10_000) });
-  if (!res.ok) return "";
+  const res = await fetch(url.toString(), { signal: AbortSignal.timeout(10_000) }).catch(() => null);
+  if (!res?.ok) return null;
 
-  const data = await res.json() as { status: string; list?: { account_nm: string; thstrm_amount: string }[] };
-  if (data.status !== "000" || !data.list?.length) return "";
+  const data = await res.json() as { status: string; list?: { account_nm: string; thstrm_amount: string; fs_div: string }[] };
+  if (data.status !== "000" || !data.list?.length) return null;
 
-  const TARGET = ["매출액", "영업이익", "당기순이익"];
-  const lines = data.list
-    .filter(item => TARGET.includes(item.account_nm))
-    .map(item => {
-      const amount = Number(item.thstrm_amount);
-      const formatted = amount >= 1_000_000_000_000
-        ? `약 ${Math.round((amount / 1_000_000_000_000) * 10) / 10}조원`
-        : amount >= 100_000_000
-        ? `약 ${Math.round(amount / 100_000_000)}억원`
-        : `${amount.toLocaleString("ko-KR")}원`;
-      return `${item.account_nm} ${formatted}`;
-    });
-
-  return lines.join(", ");
+  const map: Record<string, number> = {};
+  for (const item of data.list) {
+    if (item.fs_div !== "CFS") continue;
+    if (item.account_nm === "매출액" || item.account_nm === "영업이익") {
+      map[item.account_nm] = Number(item.thstrm_amount.replace(/,/g, ""));
+    }
+  }
+  if (!("매출액" in map)) return null;
+  return { revenue: map["매출액"], operatingProfit: map["영업이익"] ?? 0 };
 }
 
-function normalizeUrl(url: string): string {
-  return url.startsWith("http://") || url.startsWith("https://") ? url : `https://${url}`;
+function formatAmount(amount: number): string {
+  if (amount < 0) return `-${formatAmount(-amount)}`;
+  if (amount >= 1_000_000_000_000) return `${Math.round((amount / 1_000_000_000_000) * 10) / 10}조원`;
+  if (amount >= 100_000_000) return `${Math.round(amount / 100_000_000)}억원`;
+  return `${amount.toLocaleString("ko-KR")}원`;
 }
 
-async function fetchHomepageSummary(hmUrl: string): Promise<string> {
-  const res = await fetch(`https://r.jina.ai/${normalizeUrl(hmUrl)}`, {
-    headers: { Accept: "text/plain" },
-    signal: AbortSignal.timeout(20_000),
-  });
-  if (!res.ok) return "";
+async function fetchFinancial3Years(corpCode: string): Promise<string> {
+  const currentYear = new Date().getFullYear();
+  const years = [currentYear - 1, currentYear - 2, currentYear - 3];
 
-  const text = (await res.text()).slice(0, 5000).trim();
-  if (!text) return "";
+  const results = await Promise.all(years.map(y => fetchFinancialYear(corpCode, y)));
 
-  const summary = await callLLM({
-    messages: [{
-      role: "user",
-      content: `다음은 회사 홈페이지 텍스트입니다. 회사가 무엇을 하는 곳인지 핵심만 2~3문장으로 요약하세요. 텍스트에 없는 내용은 생성하지 마세요.\n\n${text}`,
-    }],
-    max_tokens: 200,
-  });
+  const lines: string[] = [];
+  for (let i = 0; i < years.length; i++) {
+    const data = results[i];
+    if (!data) continue;
 
-  return summary.trim();
+    let line = `${years[i]}년 매출 ${formatAmount(data.revenue)}, 영업이익 ${formatAmount(data.operatingProfit)}`;
+
+    const prev = results[i + 1];
+    if (prev && prev.revenue > 0) {
+      const growth = Math.round(((data.revenue - prev.revenue) / prev.revenue) * 100);
+      line += ` (전년비 ${growth > 0 ? "+" : ""}${growth}%)`;
+    }
+    lines.push(line);
+  }
+
+  return lines.length > 0 ? `[재무]\n${lines.join("\n")}` : "";
+}
+
+async function fetchRecentDisclosures(corpCode: string): Promise<string> {
+  const bgn_de = new Date(Date.now() - 180 * 24 * 60 * 60 * 1000)
+    .toISOString().slice(0, 10).replace(/-/g, "");
+
+  const KEYWORDS = ["인수", "합병", "투자", "신사업"];
+
+  const fetchList = async (pblntf_ty: string): Promise<{ report_nm: string; rcept_dt: string }[]> => {
+    const url = new URL(`${DART_BASE}/list.json`);
+    url.searchParams.set("crtfc_key", API_KEY);
+    url.searchParams.set("corp_code", corpCode);
+    url.searchParams.set("pblntf_ty", pblntf_ty);
+    url.searchParams.set("bgn_de", bgn_de);
+    url.searchParams.set("page_count", "20");
+
+    const res = await fetch(url.toString(), { signal: AbortSignal.timeout(10_000) }).catch(() => null);
+    if (!res?.ok) return [];
+    const data = await res.json() as { status: string; list?: { report_nm: string; rcept_dt: string }[] };
+    return data.status === "000" ? (data.list ?? []) : [];
+  };
+
+  const [listB, listI] = await Promise.all([fetchList("B"), fetchList("I")]);
+  const filtered = [...listB, ...listI]
+    .filter(item => KEYWORDS.some(kw => item.report_nm.includes(kw)))
+    .sort((a, b) => b.rcept_dt.localeCompare(a.rcept_dt))
+    .slice(0, 5);
+
+  if (filtered.length === 0) return "";
+
+  const lines = filtered.map(item =>
+    `${item.rcept_dt.slice(0, 4)}.${item.rcept_dt.slice(4, 6)}.${item.rcept_dt.slice(6, 8)} ${item.report_nm}`
+  );
+  return `[최근 주요 공시]\n${lines.join("\n")}`;
+}
+
+function formatIndutyCls(code: string): string {
+  const n = parseInt(code.slice(0, 2), 10);
+  if (n >= 1 && n <= 3) return "농림어업";
+  if (n >= 5 && n <= 8) return "광업";
+  if (n >= 10 && n <= 12) return "식품·음료 제조업";
+  if (n >= 13 && n <= 15) return "섬유·의복 제조업";
+  if (n === 20) return "화학 제조업";
+  if (n === 21) return "의약품 제조업";
+  if (n >= 25 && n <= 28) return "기계·전자 제조업";
+  if (n === 26) return "전자·반도체 제조업";
+  if (n === 29 || n === 30) return "자동차·운송장비 제조업";
+  if (n >= 10 && n <= 33) return "제조업";
+  if (n === 35) return "전기·가스업";
+  if (n >= 41 && n <= 42) return "건설업";
+  if (n >= 45 && n <= 47) return "도소매업";
+  if (n >= 49 && n <= 52) return "운수·창고업";
+  if (n >= 55 && n <= 56) return "숙박·음식점업";
+  if (n >= 58 && n <= 63) return "정보통신업";
+  if (n >= 64 && n <= 66) return "금융·보험업";
+  if (n === 68) return "부동산업";
+  if (n >= 70 && n <= 73) return "전문·과학기술 서비스업";
+  if (n === 85) return "교육 서비스업";
+  if (n >= 86 && n <= 87) return "보건·의료업";
+  return "";
 }
 
 function formatEstDate(estDt: string): string {
@@ -106,42 +217,48 @@ function formatCorpCls(corpCls: string, stockCode: string | null): string {
   return map[corpCls] ? `${map[corpCls]} 상장` : "상장사";
 }
 
+async function fetchDartInfo(corpCode: string, stockCode: string | null): Promise<string> {
+  const isListed = !!stockCode?.trim();
+
+  const [detail, financial, disclosures] = await Promise.all([
+    fetchCompanyDetail(corpCode),
+    isListed ? fetchFinancial3Years(corpCode) : Promise.resolve(""),
+    isListed ? fetchRecentDisclosures(corpCode) : Promise.resolve(""),
+  ]);
+
+  const parts: string[] = [];
+
+  if (detail) {
+    const basicParts: string[] = [];
+    if (detail.ceo_nm) basicParts.push(`대표이사 ${detail.ceo_nm}`);
+    if (detail.est_dt) basicParts.push(formatEstDate(detail.est_dt));
+    const listingStr = formatCorpCls(detail.corp_cls, stockCode);
+    if (listingStr) basicParts.push(listingStr);
+    const indutyStr = detail.induty_code ? formatIndutyCls(detail.induty_code) : "";
+    if (indutyStr) basicParts.push(`업종 ${indutyStr}`);
+    if (basicParts.length > 0) parts.push(basicParts.join(" | "));
+  }
+
+  if (financial) parts.push(financial);
+  if (disclosures) parts.push(disclosures);
+
+  return parts.join("\n");
+}
+
 export async function collectCompanyInfo(jobPostingId: string, companyName: string): Promise<void> {
   if (!API_KEY || !companyName) return;
 
   try {
     const corp = await findCorpCode(companyName);
     const isListed = corp !== null && !!corp.stock_code?.trim();
-
-    const parts: string[] = [];
-
-    if (corp) {
-      const detail = await fetchCompanyDetail(corp.corp_code);
-
-      if (detail) {
-        const basicParts: string[] = [];
-        if (detail.ceo_nm) basicParts.push(`대표이사 ${detail.ceo_nm}`);
-        if (detail.est_dt) basicParts.push(formatEstDate(detail.est_dt));
-        const listingStr = formatCorpCls(detail.corp_cls, corp.stock_code);
-        if (listingStr) basicParts.push(listingStr);
-        if (basicParts.length > 0) parts.push(basicParts.join(" | "));
-
-        const [financial, homepageSummary] = await Promise.all([
-          isListed ? fetchFinancialSummary(corp.corp_code) : Promise.resolve(""),
-          detail.hm_url ? fetchHomepageSummary(detail.hm_url).catch(() => "") : Promise.resolve(""),
-        ]);
-
-        if (financial) parts.push(`${financial} (${new Date().getFullYear() - 1}년 기준)`);
-        if (homepageSummary) parts.push(homepageSummary);
-      }
-    }
+    const dartSummary = corp ? await fetchDartInfo(corp.corp_code, corp.stock_code) : null;
 
     await supabase.from("company_info").upsert(
       {
         jobPostingId,
         companyName,
         isListed,
-        dartSummary: parts.length > 0 ? parts.join("\n") : null,
+        dartSummary: dartSummary || null,
         collectedAt: new Date().toISOString(),
       },
       { onConflict: "jobPostingId" },


### PR DESCRIPTION
## Summary

- `fetchDartInfo` 신규 구현: 기본정보 + 재무 3년치(상장사) + 최근 주요 공시(상장사) 병렬 호출
- `BRAND_MAP` + `normalizeName` 추가: 브랜드명 → DART 등록 법인명 변환
- `findCorpCode` 폴백 전략 3단계(substring) → 2단계(prefix)로 축소: substring은 무관한 동명 법인이 잡힐 위험이 있어 제거
- `fetchHomepageSummary` 제거: LLM 의존으로 품질이 낮아 제거
- `notes/` 디렉토리 `.gitignore` 추가

## Test plan

- [ ] 삼성전자(상장사) — 기본정보 + 재무 3년치 + 공시 출력 확인
- [ ] DART 등록 비상장사 — 기본정보만 출력 확인
- [ ] `BRAND_MAP` 등록 브랜드(예: 토스, 배달의민족) — 법인명으로 정상 매핑 확인
- [ ] DART 미등록 회사 — dartSummary null로 저장 확인

Closes #135

🤖 Generated with [Claude Code](https://claude.com/claude-code)