### PR TITLE
feat: 에이전트별 비대칭 기업 정보 프롬프트 주입

### DIFF
--- a/app/api/interview/debate/route.ts
+++ b/app/api/interview/debate/route.ts
@@ -207,12 +207,26 @@ export async function POST(request: NextRequest) {
 
     const { data: jobPosting } = await supabase
       .from("job_postings")
-      .select("id, responsibilities, requirements, preferredQuals")
+      .select("id, responsibilities, requirements, preferredQuals, companyName, divisionName, techStack, companyDescription, companyCulture")
       .eq("userId", userId)
       .order("updatedAt", { ascending: false })
       .limit(1)
       .maybeSingle();
     if (!jobPosting) return NextResponse.json({ error: "채용공고가 없습니다" }, { status: 404 });
+
+    const { data: companyInfo } = await supabase
+      .from("company_info")
+      .select("company_cache(foundedYear, listingStatus, industrySector, financialSummary, recentDisclosures)")
+      .eq("jobPostingId", jobPosting.id)
+      .maybeSingle();
+
+    const cache = companyInfo?.company_cache as {
+      foundedYear: string | null;
+      listingStatus: string | null;
+      industrySector: string | null;
+      financialSummary: string | null;
+      recentDisclosures: string | null;
+    } | null;
 
     const profileContext: ProfileContext = {
       name: profile.name,
@@ -226,6 +240,16 @@ export async function POST(request: NextRequest) {
       responsibilities: jobPosting.responsibilities ?? "",
       requirements: jobPosting.requirements ?? "",
       preferredQuals: jobPosting.preferredQuals ?? "",
+      companyName: jobPosting.companyName ?? undefined,
+      divisionName: jobPosting.divisionName ?? undefined,
+      techStack: jobPosting.techStack ?? undefined,
+      companyDescription: jobPosting.companyDescription ?? undefined,
+      companyCulture: jobPosting.companyCulture ?? undefined,
+      foundedYear: cache?.foundedYear ?? undefined,
+      listingStatus: cache?.listingStatus ?? undefined,
+      industrySector: cache?.industrySector ?? undefined,
+      financialSummary: cache?.financialSummary ?? undefined,
+      recentDisclosures: cache?.recentDisclosures ?? undefined,
     };
 
     const sessionId = crypto.randomUUID();

--- a/app/api/interview/follow-up/route.ts
+++ b/app/api/interview/follow-up/route.ts
@@ -52,7 +52,7 @@ export async function POST(request: NextRequest) {
 
     const { data: jobPosting } = await supabase
       .from("job_postings")
-      .select("responsibilities, requirements, preferredQuals, companyName, divisionName, techStack, companyDescription, companyCulture")
+      .select("id, responsibilities, requirements, preferredQuals, companyName, divisionName, techStack, companyDescription, companyCulture")
       .eq("userId", userId)
       .order("updatedAt", { ascending: false })
       .limit(1)
@@ -64,6 +64,20 @@ export async function POST(request: NextRequest) {
         { status: 404 },
       );
     }
+
+    const { data: companyInfo } = await supabase
+      .from("company_info")
+      .select("company_cache(foundedYear, listingStatus, industrySector, financialSummary, recentDisclosures)")
+      .eq("jobPostingId", jobPosting.id)
+      .maybeSingle();
+
+    const cache = companyInfo?.company_cache as {
+      foundedYear: string | null;
+      listingStatus: string | null;
+      industrySector: string | null;
+      financialSummary: string | null;
+      recentDisclosures: string | null;
+    } | null;
 
     const profileContext = {
       name: profile.name,
@@ -82,6 +96,11 @@ export async function POST(request: NextRequest) {
       techStack: jobPosting.techStack ?? undefined,
       companyDescription: jobPosting.companyDescription ?? undefined,
       companyCulture: jobPosting.companyCulture ?? undefined,
+      foundedYear: cache?.foundedYear ?? undefined,
+      listingStatus: cache?.listingStatus ?? undefined,
+      industrySector: cache?.industrySector ?? undefined,
+      financialSummary: cache?.financialSummary ?? undefined,
+      recentDisclosures: cache?.recentDisclosures ?? undefined,
     };
 
     const { thought, selectedAgentId } = await findFollowUpAgent(

--- a/app/api/interview/question/route.ts
+++ b/app/api/interview/question/route.ts
@@ -51,7 +51,7 @@ export async function POST(request: NextRequest) {
 
     const { data: jobPosting } = await supabase
       .from("job_postings")
-      .select("responsibilities, requirements, preferredQuals, companyName, divisionName, techStack, companyDescription, companyCulture")
+      .select("id, responsibilities, requirements, preferredQuals, companyName, divisionName, techStack, companyDescription, companyCulture")
       .eq("userId", userId)
       .order("updatedAt", { ascending: false })
       .limit(1)
@@ -63,6 +63,20 @@ export async function POST(request: NextRequest) {
         { status: 404 },
       );
     }
+
+    const { data: companyInfo } = await supabase
+      .from("company_info")
+      .select("company_cache(foundedYear, listingStatus, industrySector, financialSummary, recentDisclosures)")
+      .eq("jobPostingId", jobPosting.id)
+      .maybeSingle();
+
+    const cache = companyInfo?.company_cache as {
+      foundedYear: string | null;
+      listingStatus: string | null;
+      industrySector: string | null;
+      financialSummary: string | null;
+      recentDisclosures: string | null;
+    } | null;
 
     const profileContext = {
       name: profile.name,
@@ -81,6 +95,11 @@ export async function POST(request: NextRequest) {
       techStack: jobPosting.techStack ?? undefined,
       companyDescription: jobPosting.companyDescription ?? undefined,
       companyCulture: jobPosting.companyCulture ?? undefined,
+      foundedYear: cache?.foundedYear ?? undefined,
+      listingStatus: cache?.listingStatus ?? undefined,
+      industrySector: cache?.industrySector ?? undefined,
+      financialSummary: cache?.financialSummary ?? undefined,
+      recentDisclosures: cache?.recentDisclosures ?? undefined,
     };
 
     const result = await generateAgentBaseQuestion(

--- a/lib/agents.ts
+++ b/lib/agents.ts
@@ -89,6 +89,12 @@ function buildConversationText(messages: Message[]): string {
 function buildContextBlock(profile: ProfileContext, jobPosting: JobPostingContext): string {
   const profileSummary = buildProfileSummary(profile);
   const jobParts = [
+    jobPosting.companyName ? `회사명: ${jobPosting.companyName}` : "",
+    jobPosting.foundedYear ? `설립: ${jobPosting.foundedYear}` : "",
+    jobPosting.listingStatus ? `상장 현황: ${jobPosting.listingStatus}` : "",
+    jobPosting.industrySector ? `업종: ${jobPosting.industrySector}` : "",
+    jobPosting.financialSummary ? `재무 현황:\n${jobPosting.financialSummary}` : "",
+    jobPosting.recentDisclosures ? `최근 주요 공시:\n${jobPosting.recentDisclosures}` : "",
     jobPosting.responsibilities ? `담당 업무: ${jobPosting.responsibilities}` : "",
     jobPosting.requirements ? `자격 요건: ${jobPosting.requirements}` : "",
     jobPosting.preferredQuals ? `우대 사항: ${jobPosting.preferredQuals}` : "",

--- a/lib/interview.ts
+++ b/lib/interview.ts
@@ -79,6 +79,12 @@ export interface JobPostingContext {
   techStack?: string;
   companyDescription?: string;
   companyCulture?: string;
+  // DART 수집 데이터
+  foundedYear?: string;
+  listingStatus?: string;
+  industrySector?: string;
+  financialSummary?: string;
+  recentDisclosures?: string;
 }
 
 export function buildProfileSummary(profile: ProfileContext): string {
@@ -216,15 +222,44 @@ function buildAgentSystemPrompt(
 이력서나 지금까지 답변에 나온 특정 기술·경험을 직접 짚어서 검증하는 질문을 하나 하세요. 채용공고에 없는 요건을 만들지 마세요.`,
   };
 
+  const commonJobBlock = [
+    `담당 업무: ${jobPosting.responsibilities || "N/A"}`,
+    `자격 요건: ${jobPosting.requirements || "N/A"}`,
+    `우대 사항: ${jobPosting.preferredQuals || "N/A"}`,
+  ].join("\n");
+
+  const agentJobBlock: Record<AgentId, string> = {
+    organization: [
+      jobPosting.companyName ? `회사명: ${jobPosting.companyName}` : "",
+      jobPosting.foundedYear ? `설립: ${jobPosting.foundedYear}` : "",
+      jobPosting.listingStatus ? `상장 현황: ${jobPosting.listingStatus}` : "",
+      jobPosting.industrySector ? `업종: ${jobPosting.industrySector}` : "",
+      jobPosting.companyDescription ? `회사 소개: ${jobPosting.companyDescription}` : "",
+      jobPosting.companyCulture ? `조직 문화: ${jobPosting.companyCulture}` : "",
+      commonJobBlock,
+    ].filter(Boolean).join("\n"),
+    logic: [
+      jobPosting.companyName ? `회사명: ${jobPosting.companyName}` : "",
+      jobPosting.divisionName ? `지원 사업부: ${jobPosting.divisionName}` : "",
+      jobPosting.financialSummary ? `재무 현황:\n${jobPosting.financialSummary}` : "",
+      jobPosting.recentDisclosures ? `최근 주요 공시:\n${jobPosting.recentDisclosures}` : "",
+      commonJobBlock,
+    ].filter(Boolean).join("\n"),
+    technical: [
+      jobPosting.techStack ? `기술스택: ${jobPosting.techStack}` : "",
+      jobPosting.industrySector ? `업종: ${jobPosting.industrySector}` : "",
+      jobPosting.recentDisclosures ? `최근 주요 공시:\n${jobPosting.recentDisclosures}` : "",
+      commonJobBlock,
+    ].filter(Boolean).join("\n"),
+  };
+
   return `${agentRole[agentId]}
 
 [면접 난이도]
 ${DIFFICULTY_QUESTION_HINT[difficulty]}
 
 [채용공고]
-${jobPosting.companyName ? `회사명: ${jobPosting.companyName}\n` : ""}${jobPosting.divisionName ? `지원 사업부: ${jobPosting.divisionName}\n` : ""}${jobPosting.companyDescription ? `회사 소개: ${jobPosting.companyDescription}\n` : ""}${jobPosting.companyCulture ? `조직 문화: ${jobPosting.companyCulture}\n` : ""}담당 업무: ${jobPosting.responsibilities || "N/A"}
-자격 요건: ${jobPosting.requirements || "N/A"}
-우대 사항: ${jobPosting.preferredQuals || "N/A"}${jobPosting.techStack ? `\n기술스택: ${jobPosting.techStack}` : ""}
+${agentJobBlock[agentId]}
 
 [지원자 프로필]
 ${profileSummary}
@@ -459,12 +494,41 @@ async function generateSingleAgentThought(
     .map((m) => `${m.role === "interviewer" ? "면접관" : "지원자"}: ${m.content}`)
     .join("\n\n");
 
+  const thoughtCommonJobBlock = [
+    `담당 업무: ${jobPosting.responsibilities || "N/A"}`,
+    `자격 요건: ${jobPosting.requirements || "N/A"}`,
+    `우대 사항: ${jobPosting.preferredQuals || "N/A"}`,
+  ].join("\n");
+
+  const thoughtAgentJobBlock: Record<AgentId, string> = {
+    organization: [
+      jobPosting.companyName ? `회사명: ${jobPosting.companyName}` : "",
+      jobPosting.foundedYear ? `설립: ${jobPosting.foundedYear}` : "",
+      jobPosting.listingStatus ? `상장 현황: ${jobPosting.listingStatus}` : "",
+      jobPosting.industrySector ? `업종: ${jobPosting.industrySector}` : "",
+      jobPosting.companyDescription ? `회사 소개: ${jobPosting.companyDescription}` : "",
+      jobPosting.companyCulture ? `조직 문화: ${jobPosting.companyCulture}` : "",
+      thoughtCommonJobBlock,
+    ].filter(Boolean).join("\n"),
+    logic: [
+      jobPosting.companyName ? `회사명: ${jobPosting.companyName}` : "",
+      jobPosting.divisionName ? `지원 사업부: ${jobPosting.divisionName}` : "",
+      jobPosting.financialSummary ? `재무 현황:\n${jobPosting.financialSummary}` : "",
+      jobPosting.recentDisclosures ? `최근 주요 공시:\n${jobPosting.recentDisclosures}` : "",
+      thoughtCommonJobBlock,
+    ].filter(Boolean).join("\n"),
+    technical: [
+      jobPosting.techStack ? `기술스택: ${jobPosting.techStack}` : "",
+      jobPosting.industrySector ? `업종: ${jobPosting.industrySector}` : "",
+      jobPosting.recentDisclosures ? `최근 주요 공시:\n${jobPosting.recentDisclosures}` : "",
+      thoughtCommonJobBlock,
+    ].filter(Boolean).join("\n"),
+  };
+
   const systemPrompt = `${AGENT_THOUGHT_PERSONA[agentId]}
 
 [채용공고]
-${jobPosting.companyName ? `회사명: ${jobPosting.companyName}\n` : ""}${jobPosting.divisionName ? `지원 사업부: ${jobPosting.divisionName}\n` : ""}${jobPosting.companyDescription ? `회사 소개: ${jobPosting.companyDescription}\n` : ""}${jobPosting.companyCulture ? `조직 문화: ${jobPosting.companyCulture}\n` : ""}담당 업무: ${jobPosting.responsibilities || "N/A"}
-자격 요건: ${jobPosting.requirements || "N/A"}
-우대 사항: ${jobPosting.preferredQuals || "N/A"}${jobPosting.techStack ? `\n기술스택: ${jobPosting.techStack}` : ""}
+${thoughtAgentJobBlock[agentId]}
 
 [지원자 프로필]
 ${profileSummary}


### PR DESCRIPTION
## Summary

- `JobPostingContext`에 DART 필드 추가 (`foundedYear`, `listingStatus`, `industrySector`, `financialSummary`, `recentDisclosures`)
- `buildAgentSystemPrompt` 에이전트별 채용공고 블록 비대칭 구성:

  | 에이전트 | 주입 데이터 |
  |---|---|
  | HR 담당자 | 회사 소개·문화 + 설립·상장·업종 |
  | 실무 팀장 | 회사명·사업부 + 재무 현황·최근 공시 |
  | 현업 선임 | 기술스택 + 업종·최근 공시 |
  | 공통 | 담당 업무·자격 요건·우대 사항 |

- `generateSingleAgentThought`(꼬리질문)도 동일 비대칭 패턴 적용
- `buildContextBlock`(`agents.ts`): DART 필드 전체 추가 (debate 평가용)
- 라우트 3개: `company_info → company_cache` 조인 조회 추가, `debate/route.ts` 누락 필드 보완

## Test plan

- [ ] 면접 진행 시 에이전트별로 다른 회사 정보가 프롬프트에 주입되는지 확인
- [ ] 빌드 통과 확인

Closes #140