### PR TITLE
feat: DART 직원 현황(empSttus) 수집 및 면접 컨텍스트 주입

### DIFF
--- a/app/api/interview/debate/route.ts
+++ b/app/api/interview/debate/route.ts
@@ -216,7 +216,7 @@ export async function POST(request: NextRequest) {
 
     const { data: companyInfo } = await supabase
       .from("company_info")
-      .select("company_cache(foundedYear, listingStatus, industrySector, financialSummary, recentDisclosures)")
+      .select("company_cache(foundedYear, listingStatus, industrySector, financialSummary, recentDisclosures, employeeSummary)")
       .eq("jobPostingId", jobPosting.id)
       .maybeSingle();
 
@@ -226,6 +226,7 @@ export async function POST(request: NextRequest) {
       industrySector: string | null;
       financialSummary: string | null;
       recentDisclosures: string | null;
+      employeeSummary: string | null;
     } | null;
 
     const profileContext: ProfileContext = {
@@ -250,6 +251,7 @@ export async function POST(request: NextRequest) {
       industrySector: cache?.industrySector ?? undefined,
       financialSummary: cache?.financialSummary ?? undefined,
       recentDisclosures: cache?.recentDisclosures ?? undefined,
+      employeeSummary: cache?.employeeSummary ?? undefined,
     };
 
     const sessionId = crypto.randomUUID();

--- a/app/api/interview/follow-up/route.ts
+++ b/app/api/interview/follow-up/route.ts
@@ -69,7 +69,7 @@ export async function POST(request: NextRequest) {
 
     const { data: companyInfo } = await supabase
       .from("company_info")
-      .select("company_cache(foundedYear, listingStatus, industrySector, financialSummary, recentDisclosures)")
+      .select("company_cache(foundedYear, listingStatus, industrySector, financialSummary, recentDisclosures, employeeSummary)")
       .eq("jobPostingId", jobPosting.id)
       .maybeSingle();
 
@@ -79,6 +79,7 @@ export async function POST(request: NextRequest) {
       industrySector: string | null;
       financialSummary: string | null;
       recentDisclosures: string | null;
+      employeeSummary: string | null;
     } | null;
 
     const profileContext = {
@@ -124,6 +125,7 @@ export async function POST(request: NextRequest) {
       industrySector: cache?.industrySector ?? undefined,
       financialSummary: cache?.financialSummary ?? undefined,
       recentDisclosures: cache?.recentDisclosures ?? undefined,
+      employeeSummary: cache?.employeeSummary ?? undefined,
     };
 
     const { thought, selectedAgentId } = await findFollowUpAgent(

--- a/app/api/interview/question/route.ts
+++ b/app/api/interview/question/route.ts
@@ -68,7 +68,7 @@ export async function POST(request: NextRequest) {
 
     const { data: companyInfo } = await supabase
       .from("company_info")
-      .select("company_cache(foundedYear, listingStatus, industrySector, financialSummary, recentDisclosures)")
+      .select("company_cache(foundedYear, listingStatus, industrySector, financialSummary, recentDisclosures, employeeSummary)")
       .eq("jobPostingId", jobPosting.id)
       .maybeSingle();
 
@@ -78,6 +78,7 @@ export async function POST(request: NextRequest) {
       industrySector: string | null;
       financialSummary: string | null;
       recentDisclosures: string | null;
+      employeeSummary: string | null;
     } | null;
 
     const profileContext = {
@@ -126,6 +127,7 @@ export async function POST(request: NextRequest) {
       industrySector: cache?.industrySector ?? undefined,
       financialSummary: cache?.financialSummary ?? undefined,
       recentDisclosures: cache?.recentDisclosures ?? undefined,
+      employeeSummary: cache?.employeeSummary ?? undefined,
     };
 
     const result = await generateAgentBaseQuestion(

--- a/app/dart-test/page.tsx
+++ b/app/dart-test/page.tsx
@@ -13,6 +13,7 @@ interface DartResult {
   industrySector?: string | null;
   financialSummary?: string | null;
   recentDisclosures?: string | null;
+  employeeSummary?: string | null;
 }
 
 export default function DartTestPage() {
@@ -48,7 +49,7 @@ export default function DartTestPage() {
             기업 정보 수집 미리보기
           </h1>
           <p className="text-sm text-gray-500 dark:text-slate-400">
-            회사명을 입력하면 DART에서 설립연도·상장 여부·업종·재무 요약·최근 공시를 수집합니다.
+            회사명을 입력하면 DART에서 설립연도·상장 여부·업종·재무 요약·직원 현황·최근 공시를 수집합니다.
           </p>
         </div>
 
@@ -95,6 +96,13 @@ export default function DartTestPage() {
               <div className="bg-white dark:bg-slate-900 rounded-xl border border-gray-200 dark:border-slate-700 p-5">
                 <div className="text-xs font-semibold text-gray-400 dark:text-slate-500 mb-2">재무 요약</div>
                 <pre className="text-sm text-gray-700 dark:text-slate-300 whitespace-pre-wrap">{result.financialSummary}</pre>
+              </div>
+            )}
+
+            {result.employeeSummary && (
+              <div className="bg-white dark:bg-slate-900 rounded-xl border border-gray-200 dark:border-slate-700 p-5">
+                <div className="text-xs font-semibold text-gray-400 dark:text-slate-500 mb-2">직원 현황</div>
+                <p className="text-sm text-gray-700 dark:text-slate-300">{result.employeeSummary}</p>
               </div>
             )}
 

--- a/lib/agents.ts
+++ b/lib/agents.ts
@@ -95,6 +95,7 @@ function buildContextBlock(profile: ProfileContext, jobPosting: JobPostingContex
     jobPosting.industrySector ? `업종: ${jobPosting.industrySector}` : "",
     jobPosting.financialSummary ? `재무 현황:\n${jobPosting.financialSummary}` : "",
     jobPosting.recentDisclosures ? `최근 주요 공시:\n${jobPosting.recentDisclosures}` : "",
+    jobPosting.employeeSummary ? `직원 현황: ${jobPosting.employeeSummary}` : "",
     jobPosting.responsibilities ? `담당 업무: ${jobPosting.responsibilities}` : "",
     jobPosting.requirements ? `자격 요건: ${jobPosting.requirements}` : "",
     jobPosting.preferredQuals ? `우대 사항: ${jobPosting.preferredQuals}` : "",

--- a/lib/company-info-collector.ts
+++ b/lib/company-info-collector.ts
@@ -152,6 +152,108 @@ async function fetchFinancial3Years(corpCode: string): Promise<string> {
   return lines.join("\n");
 }
 
+interface EmpSttusItem {
+  fo_bbm: string;
+  sexdstn: string;
+  sm: string;
+  fyer_salary_totamt: string;
+  jan_salary_am: string;
+  avrg_cnwk_sdytrn: string;
+}
+
+function parseNum(s: string): number {
+  return parseInt(s?.replace(/,/g, "") ?? "0") || 0;
+}
+
+function parseTenure(raw: string): number | null {
+  const s = raw?.trim();
+  if (!s || s === "-") return null;
+  const ym = s.match(/(\d+)년\s*(\d+)개월/);
+  if (ym) return parseInt(ym[1]) + parseInt(ym[2]) / 12;
+  const yu = s.match(/^([\d.]+)년/);
+  if (yu) return parseFloat(yu[1]);
+  if (/^[\d.]+$/.test(s)) return parseFloat(s);
+  return null;
+}
+
+function formatHeadcount(n: number): string {
+  const unit = n >= 10_000 ? 1_000 : 100;
+  return (Math.round(n / unit) * unit).toLocaleString("ko-KR");
+}
+
+function formatSalaryWon(won: number): string {
+  const rounded = Math.round(won / 1_000_000) * 1_000_000;
+  const eok = Math.floor(rounded / 100_000_000);
+  const man = Math.round((rounded % 100_000_000) / 10_000);
+  if (eok > 0 && man > 0) return `${eok}억 ${man.toLocaleString("ko-KR")}만원`;
+  if (eok > 0) return `${eok}억원`;
+  return `${man.toLocaleString("ko-KR")}만원`;
+}
+
+function buildEmployeeSummary(list: EmpSttusItem[]): string | null {
+  const PRIORITY_DIVS = ["전사", "성별합계"];
+  let rows = list.filter(r => PRIORITY_DIVS.includes(r.fo_bbm));
+  if (rows.length === 0) rows = list;
+
+  let totalEmp = 0;
+  let tenureWeightedSum = 0;
+  let tenureWeightTotal = 0;
+
+  for (const r of rows) {
+    const emp = parseNum(r.sm);
+    totalEmp += emp;
+    const tenure = parseTenure(r.avrg_cnwk_sdytrn);
+    if (tenure !== null && emp > 0) {
+      tenureWeightedSum += tenure * emp;
+      tenureWeightTotal += emp;
+    }
+  }
+
+  if (totalEmp === 0) return null;
+
+  const parts: string[] = [`임직원 약 ${formatHeadcount(totalEmp)}명`];
+
+  if (tenureWeightTotal > 0) {
+    const avg = Math.round((tenureWeightedSum / tenureWeightTotal) * 10) / 10;
+    parts.push(`평균 근속 ${avg}년`);
+  }
+
+  const fyerSalaries = rows.map(r => parseNum(r.fyer_salary_totamt));
+  if (fyerSalaries.every(s => s > 0)) {
+    const avg = Math.round(fyerSalaries.reduce((a, b) => a + b, 0) / totalEmp);
+    parts.push(`평균 연봉 ${formatSalaryWon(avg)}`);
+  } else {
+    const janSalaries = rows.map(r => parseNum(r.jan_salary_am)).filter(s => s > 0);
+    if (janSalaries.length > 0) {
+      const avg = Math.round(janSalaries.reduce((a, b) => a + b, 0) / janSalaries.length);
+      parts.push(`평균 연봉 ${formatSalaryWon(avg)}`);
+    }
+  }
+
+  return parts.join(", ");
+}
+
+async function fetchEmployeeSummary(corpCode: string): Promise<string | null> {
+  const currentYear = new Date().getFullYear();
+  for (const year of [currentYear - 1, currentYear - 2]) {
+    const url = new URL(`${DART_BASE}/empSttus.json`);
+    url.searchParams.set("crtfc_key", API_KEY);
+    url.searchParams.set("corp_code", corpCode);
+    url.searchParams.set("bsns_year", String(year));
+    url.searchParams.set("reprt_code", "11011");
+
+    const res = await fetch(url.toString(), { signal: AbortSignal.timeout(10_000) }).catch(() => null);
+    if (!res?.ok) continue;
+
+    const data = await res.json() as { status: string; list?: EmpSttusItem[] };
+    if (data.status !== "000" || !data.list?.length) continue;
+
+    const summary = buildEmployeeSummary(data.list);
+    if (summary) return summary;
+  }
+  return null;
+}
+
 async function fetchRecentDisclosures(corpCode: string): Promise<string> {
   const bgn_de = new Date(Date.now() - 180 * 24 * 60 * 60 * 1000)
     .toISOString().slice(0, 10).replace(/-/g, "");
@@ -242,6 +344,7 @@ export interface DartCompanyInfo {
   industrySector: string | null;
   financialSummary: string | null;
   recentDisclosures: string | null;
+  employeeSummary: string | null;
 }
 
 export async function fetchDartCompanyInfo(companyName: string): Promise<DartCompanyInfo | null> {
@@ -251,10 +354,11 @@ export async function fetchDartCompanyInfo(companyName: string): Promise<DartCom
   if (!corp) return null;
 
   const isListed = !!corp.stock_code?.trim();
-  const [detail, financial, disclosures] = await Promise.all([
+  const [detail, financial, disclosures, employees] = await Promise.all([
     fetchCompanyDetail(corp.corp_code),
     fetchFinancial3Years(corp.corp_code),
     fetchRecentDisclosures(corp.corp_code),
+    fetchEmployeeSummary(corp.corp_code),
   ]);
 
   return {
@@ -265,6 +369,7 @@ export async function fetchDartCompanyInfo(companyName: string): Promise<DartCom
     industrySector: detail?.induty_code ? formatIndutyCls(detail.induty_code) || null : null,
     financialSummary: financial || null,
     recentDisclosures: disclosures || null,
+    employeeSummary: employees || null,
   };
 }
 
@@ -294,12 +399,14 @@ export async function collectCompanyInfo(jobPostingId: string, companyName: stri
       let industrySector: string | null = null;
       let financialSummary: string | null = null;
       let recentDisclosures: string | null = null;
+      let employeeSummary: string | null = null;
 
       if (corp) {
-        const [detail, financial, disclosures] = await Promise.all([
+        const [detail, financial, disclosures, employees] = await Promise.all([
           fetchCompanyDetail(corp.corp_code),
           fetchFinancial3Years(corp.corp_code),
           fetchRecentDisclosures(corp.corp_code),
+          fetchEmployeeSummary(corp.corp_code),
         ]);
 
         if (detail) {
@@ -312,6 +419,7 @@ export async function collectCompanyInfo(jobPostingId: string, companyName: stri
         }
         if (financial) financialSummary = financial;
         if (disclosures) recentDisclosures = disclosures;
+        if (employees) employeeSummary = employees;
       }
 
       const { data: upserted, error } = await supabase
@@ -325,6 +433,7 @@ export async function collectCompanyInfo(jobPostingId: string, companyName: stri
             industrySector,
             financialSummary,
             recentDisclosures,
+            employeeSummary,
             isListed,
             collectedAt: new Date().toISOString(),
           },

--- a/lib/interview.ts
+++ b/lib/interview.ts
@@ -87,6 +87,7 @@ export interface JobPostingContext {
   industrySector?: string;
   financialSummary?: string;
   recentDisclosures?: string;
+  employeeSummary?: string;
 }
 
 export function buildProfileSummary(profile: ProfileContext): string {

--- a/types/supabase.ts
+++ b/types/supabase.ts
@@ -124,6 +124,7 @@ export type Database = {
           ceoName: string | null
           collectedAt: string
           companyName: string
+          employeeSummary: string | null
           financialSummary: string | null
           foundedYear: string | null
           id: string
@@ -136,6 +137,7 @@ export type Database = {
           ceoName?: string | null
           collectedAt?: string
           companyName: string
+          employeeSummary?: string | null
           financialSummary?: string | null
           foundedYear?: string | null
           id?: string
@@ -148,6 +150,7 @@ export type Database = {
           ceoName?: string | null
           collectedAt?: string
           companyName?: string
+          employeeSummary?: string | null
           financialSummary?: string | null
           foundedYear?: string | null
           id?: string


### PR DESCRIPTION
## Summary

- DART `empSttus` API로 임직원 수·평균 근속·평균 연봉 수집, `company_cache.employeeSummary`에 저장
- 면접 question·follow-up·debate 라우트의 `JobPostingContext`에 `직원 현황` 라인 주입
- 사업부문별 분리 기업(삼성전자 DX/DS 등)은 `전사`·`성별합계` 행 우선 집계해 중복 합산 방지
- DART 2025년 데이터의 `avrg_cnwk_sdytrn` 앞뒤 공백 버그 대응 (`trim` 처리)
- `dart-test` 페이지에 직원 현황 블록 추가

## Test plan

- [ ] dart-test 페이지에서 삼성전자·NAVER·카카오·컬리 입력 후 직원 현황 표시 확인
- [ ] 사업보고서 미제출 기업 입력 시 직원 현황 없이 정상 렌더링 확인
- [ ] 면접 진행 시 에이전트 컨텍스트에 직원 현황 포함 여부 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)