### PR TITLE
feat: DART 사업보고서 원문 파싱 및 면접 컨텍스트 주입

### DIFF
--- a/app/api/interview/debate/route.ts
+++ b/app/api/interview/debate/route.ts
@@ -216,7 +216,7 @@ export async function POST(request: NextRequest) {
 
     const { data: companyInfo } = await supabase
       .from("company_info")
-      .select("company_cache(foundedYear, listingStatus, industrySector, financialSummary, recentDisclosures, employeeSummary)")
+      .select("company_cache(foundedYear, listingStatus, industrySector, financialSummary, recentDisclosures, employeeSummary, businessOverview, mainProducts)")
       .eq("jobPostingId", jobPosting.id)
       .maybeSingle();
 
@@ -227,6 +227,8 @@ export async function POST(request: NextRequest) {
       financialSummary: string | null;
       recentDisclosures: string | null;
       employeeSummary: string | null;
+      businessOverview: string | null;
+      mainProducts: string | null;
     } | null;
 
     const profileContext: ProfileContext = {
@@ -252,6 +254,8 @@ export async function POST(request: NextRequest) {
       financialSummary: cache?.financialSummary ?? undefined,
       recentDisclosures: cache?.recentDisclosures ?? undefined,
       employeeSummary: cache?.employeeSummary ?? undefined,
+      businessOverview: cache?.businessOverview ?? undefined,
+      mainProducts: cache?.mainProducts ?? undefined,
     };
 
     const sessionId = crypto.randomUUID();

--- a/app/api/interview/follow-up/route.ts
+++ b/app/api/interview/follow-up/route.ts
@@ -69,7 +69,7 @@ export async function POST(request: NextRequest) {
 
     const { data: companyInfo } = await supabase
       .from("company_info")
-      .select("company_cache(foundedYear, listingStatus, industrySector, financialSummary, recentDisclosures, employeeSummary)")
+      .select("company_cache(foundedYear, listingStatus, industrySector, financialSummary, recentDisclosures, employeeSummary, businessOverview, mainProducts)")
       .eq("jobPostingId", jobPosting.id)
       .maybeSingle();
 
@@ -80,6 +80,8 @@ export async function POST(request: NextRequest) {
       financialSummary: string | null;
       recentDisclosures: string | null;
       employeeSummary: string | null;
+      businessOverview: string | null;
+      mainProducts: string | null;
     } | null;
 
     const profileContext = {
@@ -126,6 +128,8 @@ export async function POST(request: NextRequest) {
       financialSummary: cache?.financialSummary ?? undefined,
       recentDisclosures: cache?.recentDisclosures ?? undefined,
       employeeSummary: cache?.employeeSummary ?? undefined,
+      businessOverview: cache?.businessOverview ?? undefined,
+      mainProducts: cache?.mainProducts ?? undefined,
     };
 
     const { thought, selectedAgentId } = await findFollowUpAgent(

--- a/app/api/interview/question/route.ts
+++ b/app/api/interview/question/route.ts
@@ -68,7 +68,7 @@ export async function POST(request: NextRequest) {
 
     const { data: companyInfo } = await supabase
       .from("company_info")
-      .select("company_cache(foundedYear, listingStatus, industrySector, financialSummary, recentDisclosures, employeeSummary)")
+      .select("company_cache(foundedYear, listingStatus, industrySector, financialSummary, recentDisclosures, employeeSummary, businessOverview, mainProducts)")
       .eq("jobPostingId", jobPosting.id)
       .maybeSingle();
 
@@ -79,6 +79,8 @@ export async function POST(request: NextRequest) {
       financialSummary: string | null;
       recentDisclosures: string | null;
       employeeSummary: string | null;
+      businessOverview: string | null;
+      mainProducts: string | null;
     } | null;
 
     const profileContext = {
@@ -128,6 +130,8 @@ export async function POST(request: NextRequest) {
       financialSummary: cache?.financialSummary ?? undefined,
       recentDisclosures: cache?.recentDisclosures ?? undefined,
       employeeSummary: cache?.employeeSummary ?? undefined,
+      businessOverview: cache?.businessOverview ?? undefined,
+      mainProducts: cache?.mainProducts ?? undefined,
     };
 
     const result = await generateAgentBaseQuestion(

--- a/app/dart-test/page.tsx
+++ b/app/dart-test/page.tsx
@@ -14,6 +14,8 @@ interface DartResult {
   financialSummary?: string | null;
   recentDisclosures?: string | null;
   employeeSummary?: string | null;
+  businessOverview?: string | null;
+  mainProducts?: string | null;
 }
 
 export default function DartTestPage() {
@@ -49,7 +51,7 @@ export default function DartTestPage() {
             기업 정보 수집 미리보기
           </h1>
           <p className="text-sm text-gray-500 dark:text-slate-400">
-            회사명을 입력하면 DART에서 설립연도·상장 여부·업종·재무 요약·직원 현황·최근 공시를 수집합니다.
+            회사명을 입력하면 DART에서 설립연도·상장 여부·업종·재무 요약·직원 현황·최근 공시·사업보고서 원문을 수집합니다.
           </p>
         </div>
 
@@ -115,6 +117,30 @@ export default function DartTestPage() {
               <div className="bg-white dark:bg-slate-900 rounded-xl border border-gray-200 dark:border-slate-700 p-5">
                 <div className="text-xs font-semibold text-gray-400 dark:text-slate-500 mb-1">최근 공시</div>
                 <p className="text-sm text-gray-400 dark:text-slate-500">최근 6개월 내 인수·합병·투자·신사업 공시가 없습니다.</p>
+              </div>
+            )}
+
+            {result.businessOverview ? (
+              <div className="bg-white dark:bg-slate-900 rounded-xl border border-gray-200 dark:border-slate-700 p-5">
+                <div className="text-xs font-semibold text-gray-400 dark:text-slate-500 mb-2">사업의 개요 (사업보고서 원문)</div>
+                <p className="text-sm text-gray-700 dark:text-slate-300 whitespace-pre-wrap leading-relaxed">{result.businessOverview}</p>
+              </div>
+            ) : (
+              <div className="bg-white dark:bg-slate-900 rounded-xl border border-gray-200 dark:border-slate-700 p-5">
+                <div className="text-xs font-semibold text-gray-400 dark:text-slate-500 mb-1">사업의 개요</div>
+                <p className="text-sm text-gray-400 dark:text-slate-500">사업보고서에서 사업 개요를 찾을 수 없습니다.</p>
+              </div>
+            )}
+
+            {result.mainProducts ? (
+              <div className="bg-white dark:bg-slate-900 rounded-xl border border-gray-200 dark:border-slate-700 p-5">
+                <div className="text-xs font-semibold text-gray-400 dark:text-slate-500 mb-2">주요 제품·서비스 (사업보고서 원문)</div>
+                <p className="text-sm text-gray-700 dark:text-slate-300 whitespace-pre-wrap leading-relaxed">{result.mainProducts}</p>
+              </div>
+            ) : (
+              <div className="bg-white dark:bg-slate-900 rounded-xl border border-gray-200 dark:border-slate-700 p-5">
+                <div className="text-xs font-semibold text-gray-400 dark:text-slate-500 mb-1">주요 제품·서비스</div>
+                <p className="text-sm text-gray-400 dark:text-slate-500">사업보고서에서 주요 제품·서비스를 찾을 수 없습니다.</p>
               </div>
             )}
           </div>

--- a/lib/company-info-collector.ts
+++ b/lib/company-info-collector.ts
@@ -254,6 +254,100 @@ async function fetchEmployeeSummary(corpCode: string): Promise<string | null> {
   return null;
 }
 
+async function fetchLatestAnnualReportRcptNo(corpCode: string): Promise<string | null> {
+  const bgn_de = new Date(Date.now() - 2 * 365 * 24 * 60 * 60 * 1000)
+    .toISOString().slice(0, 10).replace(/-/g, "");
+
+  const url = new URL(`${DART_BASE}/list.json`);
+  url.searchParams.set("crtfc_key", API_KEY);
+  url.searchParams.set("corp_code", corpCode);
+  url.searchParams.set("pblntf_detail_ty", "A001");
+  url.searchParams.set("bgn_de", bgn_de);
+  url.searchParams.set("last_reprt_at", "Y");
+  url.searchParams.set("page_count", "1");
+
+  const res = await fetch(url.toString(), { signal: AbortSignal.timeout(10_000) }).catch(() => null);
+  if (!res?.ok) return null;
+  const data = await res.json().catch(() => null) as { status: string; list?: { rcept_no: string }[] };
+  if (data?.status !== "000" || !data.list?.length) return null;
+  return data.list[0].rcept_no;
+}
+
+function htmlToText(html: string): string {
+  return html
+    .replace(/<[^>]+>/g, " ")
+    .replace(/&nbsp;/gi, " ")
+    .replace(/&amp;/gi, "&")
+    .replace(/&lt;/gi, "<")
+    .replace(/&gt;/gi, ">")
+    .replace(/&quot;/gi, '"')
+    .replace(/&#\d+;/g, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+interface DartSectionInfo {
+  dcmNo: string;
+  eleId: string;
+  offset: string;
+  length: string;
+  dtd: string;
+}
+
+function parseSectionInfo(html: string, keyword: string): DartSectionInfo | null {
+  const escaped = keyword.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const re = new RegExp(`\\['text'\\]\\s*=\\s*"[^"]*${escaped}[^"]*"([\\s\\S]{1,400}?)cnt\\+\\+`);
+  const match = html.match(re);
+  if (!match) return null;
+
+  const block = match[0];
+  const dcmNo = block.match(/\['dcmNo'\]\s*=\s*"(\d+)"/)?.[1];
+  const eleId = block.match(/\['eleId'\]\s*=\s*"(\d+)"/)?.[1];
+  const offset = block.match(/\['offset'\]\s*=\s*"(\d+)"/)?.[1];
+  const length = block.match(/\['length'\]\s*=\s*"(\d+)"/)?.[1];
+  const dtd = block.match(/\['dtd'\]\s*=\s*"([^"]+)"/)?.[1];
+
+  if (!dcmNo || !eleId || !offset || !length) return null;
+  return { dcmNo, eleId, offset, length, dtd: dtd ?? "dart4.xsd" };
+}
+
+async function fetchSectionText(rcptNo: string, section: DartSectionInfo): Promise<string | null> {
+  const url = `https://dart.fss.or.kr/report/viewer.do?rcpNo=${rcptNo}&dcmNo=${section.dcmNo}&eleId=${section.eleId}&offset=${section.offset}&length=${section.length}&dtd=${section.dtd}`;
+  const res = await fetch(url, { signal: AbortSignal.timeout(15_000) }).catch(() => null);
+  if (!res?.ok) return null;
+  const html = await res.text().catch(() => null);
+  if (!html) return null;
+  return htmlToText(html) || null;
+}
+
+async function fetchBusinessReportSections(corpCode: string): Promise<{ businessOverview: string | null; mainProducts: string | null }> {
+  const empty = { businessOverview: null, mainProducts: null };
+
+  const rcptNo = await fetchLatestAnnualReportRcptNo(corpCode);
+  if (!rcptNo) return empty;
+
+  const mainRes = await fetch(
+    `https://dart.fss.or.kr/dsaf001/main.do?rcpNo=${rcptNo}`,
+    { signal: AbortSignal.timeout(10_000) },
+  ).catch(() => null);
+  if (!mainRes?.ok) return empty;
+
+  const mainHtml = await mainRes.text().catch(() => null);
+  if (!mainHtml) return empty;
+
+  const overviewInfo = parseSectionInfo(mainHtml, "사업의 개요");
+  const productsInfo =
+    parseSectionInfo(mainHtml, "주요 제품 및 서비스") ??
+    parseSectionInfo(mainHtml, "주요제품 및 서비스");
+
+  const [businessOverview, mainProducts] = await Promise.all([
+    overviewInfo ? fetchSectionText(rcptNo, overviewInfo) : Promise.resolve(null),
+    productsInfo ? fetchSectionText(rcptNo, productsInfo) : Promise.resolve(null),
+  ]);
+
+  return { businessOverview, mainProducts };
+}
+
 async function fetchRecentDisclosures(corpCode: string): Promise<string> {
   const bgn_de = new Date(Date.now() - 180 * 24 * 60 * 60 * 1000)
     .toISOString().slice(0, 10).replace(/-/g, "");
@@ -345,6 +439,8 @@ export interface DartCompanyInfo {
   financialSummary: string | null;
   recentDisclosures: string | null;
   employeeSummary: string | null;
+  businessOverview: string | null;
+  mainProducts: string | null;
 }
 
 export async function fetchDartCompanyInfo(companyName: string): Promise<DartCompanyInfo | null> {
@@ -354,11 +450,12 @@ export async function fetchDartCompanyInfo(companyName: string): Promise<DartCom
   if (!corp) return null;
 
   const isListed = !!corp.stock_code?.trim();
-  const [detail, financial, disclosures, employees] = await Promise.all([
+  const [detail, financial, disclosures, employees, bizReport] = await Promise.all([
     fetchCompanyDetail(corp.corp_code),
     fetchFinancial3Years(corp.corp_code),
     fetchRecentDisclosures(corp.corp_code),
     fetchEmployeeSummary(corp.corp_code),
+    fetchBusinessReportSections(corp.corp_code),
   ]);
 
   return {
@@ -370,6 +467,8 @@ export async function fetchDartCompanyInfo(companyName: string): Promise<DartCom
     financialSummary: financial || null,
     recentDisclosures: disclosures || null,
     employeeSummary: employees || null,
+    businessOverview: bizReport.businessOverview,
+    mainProducts: bizReport.mainProducts,
   };
 }
 
@@ -400,13 +499,16 @@ export async function collectCompanyInfo(jobPostingId: string, companyName: stri
       let financialSummary: string | null = null;
       let recentDisclosures: string | null = null;
       let employeeSummary: string | null = null;
+      let businessOverview: string | null = null;
+      let mainProducts: string | null = null;
 
       if (corp) {
-        const [detail, financial, disclosures, employees] = await Promise.all([
+        const [detail, financial, disclosures, employees, bizReport] = await Promise.all([
           fetchCompanyDetail(corp.corp_code),
           fetchFinancial3Years(corp.corp_code),
           fetchRecentDisclosures(corp.corp_code),
           fetchEmployeeSummary(corp.corp_code),
+          fetchBusinessReportSections(corp.corp_code),
         ]);
 
         if (detail) {
@@ -420,6 +522,8 @@ export async function collectCompanyInfo(jobPostingId: string, companyName: stri
         if (financial) financialSummary = financial;
         if (disclosures) recentDisclosures = disclosures;
         if (employees) employeeSummary = employees;
+        businessOverview = bizReport.businessOverview;
+        mainProducts = bizReport.mainProducts;
       }
 
       const { data: upserted, error } = await supabase
@@ -434,6 +538,8 @@ export async function collectCompanyInfo(jobPostingId: string, companyName: stri
             financialSummary,
             recentDisclosures,
             employeeSummary,
+            businessOverview,
+            mainProducts,
             isListed,
             collectedAt: new Date().toISOString(),
           },

--- a/lib/interview.ts
+++ b/lib/interview.ts
@@ -88,6 +88,8 @@ export interface JobPostingContext {
   financialSummary?: string;
   recentDisclosures?: string;
   employeeSummary?: string;
+  businessOverview?: string;
+  mainProducts?: string;
 }
 
 export function buildProfileSummary(profile: ProfileContext): string {
@@ -239,6 +241,8 @@ function buildAgentSystemPrompt(
       jobPosting.industrySector ? `업종: ${jobPosting.industrySector}` : "",
       jobPosting.companyDescription ? `회사 소개: ${jobPosting.companyDescription}` : "",
       jobPosting.companyCulture ? `조직 문화: ${jobPosting.companyCulture}` : "",
+      jobPosting.businessOverview ? `사업 개요 (사업보고서 원문):\n${jobPosting.businessOverview.slice(0, 3000)}` : "",
+      jobPosting.mainProducts ? `주요 제품·서비스 (사업보고서 원문):\n${jobPosting.mainProducts.slice(0, 3000)}` : "",
       commonJobBlock,
     ].filter(Boolean).join("\n"),
     logic: [

--- a/types/supabase.ts
+++ b/types/supabase.ts
@@ -121,6 +121,7 @@ export type Database = {
       }
       company_cache: {
         Row: {
+          businessOverview: string | null
           ceoName: string | null
           collectedAt: string
           companyName: string
@@ -131,9 +132,11 @@ export type Database = {
           industrySector: string | null
           isListed: boolean
           listingStatus: string | null
+          mainProducts: string | null
           recentDisclosures: string | null
         }
         Insert: {
+          businessOverview?: string | null
           ceoName?: string | null
           collectedAt?: string
           companyName: string
@@ -144,9 +147,11 @@ export type Database = {
           industrySector?: string | null
           isListed?: boolean
           listingStatus?: string | null
+          mainProducts?: string | null
           recentDisclosures?: string | null
         }
         Update: {
+          businessOverview?: string | null
           ceoName?: string | null
           collectedAt?: string
           companyName?: string
@@ -157,6 +162,7 @@ export type Database = {
           industrySector?: string | null
           isListed?: boolean
           listingStatus?: string | null
+          mainProducts?: string | null
           recentDisclosures?: string | null
         }
         Relationships: []


### PR DESCRIPTION
## Summary

- DART `dart.fss.or.kr` viewer.do 방식으로 사업보고서 원문 파싱 구현
- `company_cache` 테이블에 `businessOverview`, `mainProducts` 컬럼 추가 (Supabase migration 적용)
- 면접 HR 에이전트 프롬프트에 사업의 개요·주요 제품 및 서비스 원문 주입 (각 최대 3,000자)

## 구현 방식

DART OpenAPI `document.json`은 권한 문제로 사용 불가. 대신 공개 접근 가능한 DART 웹 뷰어를 활용:
1. `main.do?rcpNo=` HTML에서 목차 JavaScript 변수 파싱 → 섹션별 `dcmNo`, `eleId`, `offset`, `length` 추출
2. `viewer.do`로 해당 섹션 HTML만 직접 fetch → 텍스트 변환

## 주의사항

- Vercel(해외 서버)에서 `dart.fss.or.kr` 접근 가능 여부 배포 후 확인 필요
- 실패 시 `null` 반환으로 기존 기능에 영향 없음 (graceful degradation)
- DB 캐시 TTL 6개월 유지 (사업보고서 연 1회 발행 주기와 일치)

## Test plan

- [ ] `/dart-test` 페이지에서 회사명 입력 후 사업의 개요·주요 제품·서비스 섹션 출력 확인
- [ ] 채용공고 등록 후 `company_cache` DB에 `businessOverview`, `mainProducts` 저장 확인
- [ ] 면접 시작 시 HR 에이전트 프롬프트에 사업보고서 내용 주입 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)