### PR TITLE
fix: Vercel 서버리스 환경에서 백그라운드 작업 waitUntil로 보호

### DIFF
--- a/app/api/interview/debate/route.ts
+++ b/app/api/interview/debate/route.ts
@@ -1,4 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
+import { waitUntil } from "@vercel/functions";
 
 export const maxDuration = 300;
 import { supabaseAdmin as supabase } from "@/lib/supabase-admin";
@@ -271,8 +272,11 @@ export async function POST(request: NextRequest) {
       updatedAt: new Date().toISOString(),
     });
 
-    // fire-and-forget
-    runDebate(sessionId, messages, profileContext, jobPostingContext).catch(() => {});
+    if (process.env.VERCEL) {
+      waitUntil(runDebate(sessionId, messages, profileContext, jobPostingContext));
+    } else {
+      runDebate(sessionId, messages, profileContext, jobPostingContext).catch(() => {});
+    }
 
     return NextResponse.json({ sessionId });
   } catch (error) {

--- a/app/api/job-posting/analyze/route.ts
+++ b/app/api/job-posting/analyze/route.ts
@@ -1,4 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
+import { waitUntil } from "@vercel/functions";
 
 export const maxDuration = 300;
 import { supabaseAdmin as supabase } from "@/lib/supabase-admin";
@@ -260,7 +261,11 @@ export async function POST(request: NextRequest) {
       .single();
 
     if (extracted.companyName) {
-      collectCompanyInfo(posting.id, extracted.companyName).catch(() => {});
+      if (process.env.VERCEL) {
+        waitUntil(collectCompanyInfo(posting.id, extracted.companyName));
+      } else {
+        collectCompanyInfo(posting.id, extracted.companyName).catch(() => {});
+      }
     }
 
     return NextResponse.json({ jobPosting: updated });

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@supabase/ssr": "^0.10.0",
         "@supabase/supabase-js": "^2.101.1",
+        "@vercel/functions": "^3.6.0",
         "next": "^14.2.0",
         "nextjs-toploader": "^3.9.17",
         "react": "^18.3.0",
@@ -424,6 +425,35 @@
       "license": "MIT",
       "dependencies": {
         "@types/node": "*"
+      }
+    },
+    "node_modules/@vercel/functions": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/@vercel/functions/-/functions-3.6.0.tgz",
+      "integrity": "sha512-Xj68JYqqJwtqFWJN7EWmFN7MOiUjv5whjw48UEKqQbg8r7hRkhuJhncTU0ba3jJCh/wxEuLWckrtsKcrHQraxw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@vercel/oidc": "3.4.1"
+      },
+      "engines": {
+        "node": ">= 20"
+      },
+      "peerDependencies": {
+        "@aws-sdk/credential-provider-web-identity": "*"
+      },
+      "peerDependenciesMeta": {
+        "@aws-sdk/credential-provider-web-identity": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vercel/oidc": {
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/@vercel/oidc/-/oidc-3.4.1.tgz",
+      "integrity": "sha512-H6B+/ig/GoahccL3WZjiHayHw1H5KhvTJNceqYulwfK9kkz5iul2hTmYzcJ7tTCQzyd0dutuL9xYFZCyLUqsog==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">= 20"
       }
     },
     "node_modules/any-promise": {

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   "dependencies": {
     "@supabase/ssr": "^0.10.0",
     "@supabase/supabase-js": "^2.101.1",
+    "@vercel/functions": "^3.6.0",
     "next": "^14.2.0",
     "nextjs-toploader": "^3.9.17",
     "react": "^18.3.0",


### PR DESCRIPTION
## Summary

- `collectCompanyInfo` (채용공고 분석 후 DART 수집), `runDebate` (토론) 두 곳에서 fire-and-forget으로 실행되던 비동기 작업을 Vercel 환경에서 `waitUntil`로 보호
- Vercel 서버리스는 응답 반환 후 함수가 종료될 수 있어 백그라운드 작업이 중간에 잘릴 위험이 있었음
- 로컬 개발 환경(`VERCEL` 환경변수 없음)에서는 기존 방식 유지

## Test plan

- [ ] 로컬에서 채용공고 분석 후 DART 데이터가 정상 수집되는지 확인
- [ ] 로컬에서 토론 세션이 4라운드 완료되는지 확인
- [ ] Vercel 배포 후 동일 동작 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)