### PR TITLE
refactor: 면접 API 중복 컨텍스트 로딩 헬퍼로 추출

### DIFF
--- a/app/api/interview/debate/route.ts
+++ b/app/api/interview/debate/route.ts
@@ -6,6 +6,7 @@ import { supabaseAdmin as supabase } from "@/lib/supabase-admin";
 import { getAuthUser } from "@/lib/auth";
 import type { Json } from "@/types/supabase";
 import { Message, Difficulty, AGENT_ORDER, ProfileContext, JobPostingContext } from "@/lib/interview";
+import { loadProfileContext, loadJobPostingWithContext } from "@/lib/interview-context";
 import {
   generateAgentEvaluation,
   generateAgentReply,
@@ -187,84 +188,19 @@ export async function POST(request: NextRequest) {
       difficulty: Difficulty;
     };
 
-    const { data: profile } = await supabase
-      .from("profiles")
-      .select("*")
-      .eq("userId", userId)
-      .maybeSingle();
-    if (!profile) return NextResponse.json({ error: "프로필이 없습니다" }, { status: 404 });
+    const profileContext = await loadProfileContext(userId);
+    if (!profileContext) return NextResponse.json({ error: "프로필이 없습니다" }, { status: 404 });
 
-    const [
-      { data: educations },
-      { data: careers },
-      { data: certifications },
-      { data: activities },
-    ] = await Promise.all([
-      supabase.from("educations").select("*").eq("profileId", profile.id),
-      supabase.from("careers").select("*").eq("profileId", profile.id),
-      supabase.from("certifications").select("*").eq("profileId", profile.id),
-      supabase.from("activities").select("*").eq("profileId", profile.id),
-    ]);
+    const jobPostingData = await loadJobPostingWithContext(userId);
+    if (!jobPostingData) return NextResponse.json({ error: "채용공고가 없습니다" }, { status: 404 });
 
-    const { data: jobPosting } = await supabase
-      .from("job_postings")
-      .select("id, responsibilities, requirements, preferredQuals, companyName, divisionName, techStack, companyDescription, companyCulture")
-      .eq("userId", userId)
-      .order("updatedAt", { ascending: false })
-      .limit(1)
-      .maybeSingle();
-    if (!jobPosting) return NextResponse.json({ error: "채용공고가 없습니다" }, { status: 404 });
-
-    const { data: companyInfo } = await supabase
-      .from("company_info")
-      .select("company_cache(foundedYear, listingStatus, industrySector, financialSummary, recentDisclosures, employeeSummary, businessOverview, mainProducts)")
-      .eq("jobPostingId", jobPosting.id)
-      .maybeSingle();
-
-    const cache = companyInfo?.company_cache as {
-      foundedYear: string | null;
-      listingStatus: string | null;
-      industrySector: string | null;
-      financialSummary: string | null;
-      recentDisclosures: string | null;
-      employeeSummary: string | null;
-      businessOverview: string | null;
-      mainProducts: string | null;
-    } | null;
-
-    const profileContext: ProfileContext = {
-      name: profile.name,
-      educations: educations ?? [],
-      careers: careers ?? [],
-      certifications: certifications ?? [],
-      activities: activities ?? [],
-    };
-
-    const jobPostingContext: JobPostingContext = {
-      responsibilities: jobPosting.responsibilities ?? "",
-      requirements: jobPosting.requirements ?? "",
-      preferredQuals: jobPosting.preferredQuals ?? "",
-      companyName: jobPosting.companyName ?? undefined,
-      divisionName: jobPosting.divisionName ?? undefined,
-      techStack: jobPosting.techStack ?? undefined,
-      companyDescription: jobPosting.companyDescription ?? undefined,
-      companyCulture: jobPosting.companyCulture ?? undefined,
-      foundedYear: cache?.foundedYear ?? undefined,
-      listingStatus: cache?.listingStatus ?? undefined,
-      industrySector: cache?.industrySector ?? undefined,
-      financialSummary: cache?.financialSummary ?? undefined,
-      recentDisclosures: cache?.recentDisclosures ?? undefined,
-      employeeSummary: cache?.employeeSummary ?? undefined,
-      businessOverview: cache?.businessOverview ?? undefined,
-      mainProducts: cache?.mainProducts ?? undefined,
-    };
-
+    const { jobPostingId, jobPostingContext } = jobPostingData;
     const sessionId = crypto.randomUUID();
 
     await supabase.from("interview_sessions").insert({
       id: sessionId,
       userId,
-      jobPostingId: jobPosting.id,
+      jobPostingId,
       difficulty,
       messages: messages as unknown as Json,
       status: "evaluating",

--- a/app/api/interview/follow-up/route.ts
+++ b/app/api/interview/follow-up/route.ts
@@ -1,16 +1,9 @@
 import { NextRequest, NextResponse } from "next/server";
 
 export const maxDuration = 300;
-import { supabaseAdmin as supabase } from "@/lib/supabase-admin";
 import { getAuthUser } from "@/lib/auth";
-import {
-  findFollowUpAgent,
-  AgentId,
-  Difficulty,
-  Message,
-} from "@/lib/interview";
-import { detectJobClassification } from "@/lib/job-classifications";
-import { fetchNewsForJobPosting, formatNewsContextForPrompt } from "@/lib/naver-news-crawler";
+import { findFollowUpAgent, AgentId, Difficulty, Message } from "@/lib/interview";
+import { loadProfileContext, loadJobPostingWithContext } from "@/lib/interview-context";
 
 export async function POST(request: NextRequest) {
   try {
@@ -27,114 +20,25 @@ export async function POST(request: NextRequest) {
       followUpRound?: number;
     };
 
-    const { data: profile } = await supabase
-      .from("profiles")
-      .select("*")
-      .eq("userId", userId)
-      .maybeSingle();
-
-    if (!profile) {
+    const profileContext = await loadProfileContext(userId);
+    if (!profileContext) {
       return NextResponse.json(
         { error: "프로필이 없습니다. 프로필을 먼저 입력해주세요." },
         { status: 404 },
       );
     }
 
-    const [
-      { data: educations },
-      { data: careers },
-      { data: certifications },
-      { data: activities },
-    ] = await Promise.all([
-      supabase.from("educations").select("*").eq("profileId", profile.id),
-      supabase.from("careers").select("*").eq("profileId", profile.id),
-      supabase.from("certifications").select("*").eq("profileId", profile.id),
-      supabase.from("activities").select("*").eq("profileId", profile.id),
-    ]);
-
-    const { data: jobPosting } = await supabase
-      .from("job_postings")
-      .select("id, responsibilities, requirements, preferredQuals, companyName, divisionName, techStack, companyDescription, companyCulture")
-      .eq("userId", userId)
-      .order("updatedAt", { ascending: false })
-      .limit(1)
-      .maybeSingle();
-
-    if (!jobPosting) {
+    const jobPostingData = await loadJobPostingWithContext(userId, { difficulty });
+    if (!jobPostingData) {
       return NextResponse.json(
         { error: "채용공고가 없습니다. 채용공고를 먼저 입력해주세요." },
         { status: 404 },
       );
     }
 
-    const { data: companyInfo } = await supabase
-      .from("company_info")
-      .select("company_cache(foundedYear, listingStatus, industrySector, financialSummary, recentDisclosures, employeeSummary, businessOverview, mainProducts)")
-      .eq("jobPostingId", jobPosting.id)
-      .maybeSingle();
-
-    const cache = companyInfo?.company_cache as {
-      foundedYear: string | null;
-      listingStatus: string | null;
-      industrySector: string | null;
-      financialSummary: string | null;
-      recentDisclosures: string | null;
-      employeeSummary: string | null;
-      businessOverview: string | null;
-      mainProducts: string | null;
-    } | null;
-
-    const profileContext = {
-      name: profile.name,
-      educations: educations ?? [],
-      careers: careers ?? [],
-      certifications: certifications ?? [],
-      activities: activities ?? [],
-    };
-
-    // 뉴스 컨텍스트는 기본(normal) · 심화(hard) 난이도에서만 활용
-    const jobText = `${jobPosting.responsibilities ?? ""} ${jobPosting.requirements ?? ""}`;
-    const classification = detectJobClassification(jobText);
-    const useNews = difficulty === "normal" || difficulty === "hard";
-    let newsContext: string | undefined = undefined;
-    if (useNews && classification && jobPosting.companyName) {
-      try {
-        const newsResult = await fetchNewsForJobPosting(
-          classification,
-          jobPosting.companyName,
-          jobPosting.responsibilities ?? "",
-          jobPosting.techStack ?? "",
-        );
-        newsContext = formatNewsContextForPrompt(newsResult);
-      } catch (error) {
-        console.warn("뉴스 수집 실패 (무시됨):", error);
-      }
-    }
-
-    const jobPostingContext = {
-      responsibilities: jobPosting.responsibilities ?? "",
-      requirements: jobPosting.requirements ?? "",
-      preferredQuals: jobPosting.preferredQuals ?? "",
-      companyName: jobPosting.companyName ?? undefined,
-      divisionName: jobPosting.divisionName ?? undefined,
-      techStack: jobPosting.techStack ?? undefined,
-      companyDescription: jobPosting.companyDescription ?? undefined,
-      companyCulture: jobPosting.companyCulture ?? undefined,
-      jobClassification: classification ?? undefined,
-      newsContext,
-      foundedYear: cache?.foundedYear ?? undefined,
-      listingStatus: cache?.listingStatus ?? undefined,
-      industrySector: cache?.industrySector ?? undefined,
-      financialSummary: cache?.financialSummary ?? undefined,
-      recentDisclosures: cache?.recentDisclosures ?? undefined,
-      employeeSummary: cache?.employeeSummary ?? undefined,
-      businessOverview: cache?.businessOverview ?? undefined,
-      mainProducts: cache?.mainProducts ?? undefined,
-    };
-
     const { thought, selectedAgentId } = await findFollowUpAgent(
       profileContext,
-      jobPostingContext,
+      jobPostingData.jobPostingContext,
       messages,
       difficulty,
       currentAgentId,

--- a/app/api/interview/question/route.ts
+++ b/app/api/interview/question/route.ts
@@ -1,16 +1,9 @@
 import { NextRequest, NextResponse } from "next/server";
 
 export const maxDuration = 300;
-import { supabaseAdmin as supabase } from "@/lib/supabase-admin";
 import { getAuthUser } from "@/lib/auth";
-import {
-  generateAgentBaseQuestion,
-  AgentId,
-  Difficulty,
-  Message,
-} from "@/lib/interview";
-import { detectJobClassification } from "@/lib/job-classifications";
-import { fetchNewsForJobPosting, formatNewsContextForPrompt } from "@/lib/naver-news-crawler";
+import { generateAgentBaseQuestion, AgentId, Difficulty, Message } from "@/lib/interview";
+import { loadProfileContext, loadJobPostingWithContext } from "@/lib/interview-context";
 
 export async function POST(request: NextRequest) {
   try {
@@ -26,118 +19,26 @@ export async function POST(request: NextRequest) {
       difficulty: Difficulty;
     };
 
-    const { data: profile } = await supabase
-      .from("profiles")
-      .select("*")
-      .eq("userId", userId)
-      .maybeSingle();
-
-    if (!profile) {
+    const profileContext = await loadProfileContext(userId);
+    if (!profileContext) {
       return NextResponse.json(
         { error: "프로필이 없습니다. 프로필을 먼저 입력해주세요." },
         { status: 404 },
       );
     }
 
-    const [
-      { data: educations },
-      { data: careers },
-      { data: certifications },
-      { data: activities },
-    ] = await Promise.all([
-      supabase.from("educations").select("*").eq("profileId", profile.id),
-      supabase.from("careers").select("*").eq("profileId", profile.id),
-      supabase.from("certifications").select("*").eq("profileId", profile.id),
-      supabase.from("activities").select("*").eq("profileId", profile.id),
-    ]);
-
-    const { data: jobPosting } = await supabase
-      .from("job_postings")
-      .select("id, responsibilities, requirements, preferredQuals, companyName, divisionName, techStack, companyDescription, companyCulture")
-      .eq("userId", userId)
-      .order("updatedAt", { ascending: false })
-      .limit(1)
-      .maybeSingle();
-
-    if (!jobPosting) {
+    const jobPostingData = await loadJobPostingWithContext(userId, { difficulty });
+    if (!jobPostingData) {
       return NextResponse.json(
         { error: "채용공고가 없습니다. 채용공고를 먼저 입력해주세요." },
         { status: 404 },
       );
     }
 
-    const { data: companyInfo } = await supabase
-      .from("company_info")
-      .select("company_cache(foundedYear, listingStatus, industrySector, financialSummary, recentDisclosures, employeeSummary, businessOverview, mainProducts)")
-      .eq("jobPostingId", jobPosting.id)
-      .maybeSingle();
-
-    const cache = companyInfo?.company_cache as {
-      foundedYear: string | null;
-      listingStatus: string | null;
-      industrySector: string | null;
-      financialSummary: string | null;
-      recentDisclosures: string | null;
-      employeeSummary: string | null;
-      businessOverview: string | null;
-      mainProducts: string | null;
-    } | null;
-
-    const profileContext = {
-      name: profile.name,
-      educations: educations ?? [],
-      careers: careers ?? [],
-      certifications: certifications ?? [],
-      activities: activities ?? [],
-    };
-
-    // 채용공고에서 21개 직무 분류 자동 감지
-    const jobText = `${jobPosting.responsibilities ?? ""} ${jobPosting.requirements ?? ""}`;
-    const classification = detectJobClassification(jobText);
-
-    // 직무별 네이버 뉴스 수집은 기본(normal) · 심화(hard) 난이도에서만 활용
-    // 연습(tutorial) · 입문(easy)에서는 채용공고·프로필에만 집중
-    const useNews = difficulty === "normal" || difficulty === "hard";
-    let newsContext: string | undefined = undefined;
-    if (useNews && classification && jobPosting.companyName) {
-      try {
-        const newsResult = await fetchNewsForJobPosting(
-          classification,
-          jobPosting.companyName,
-          jobPosting.responsibilities ?? "",
-          jobPosting.techStack ?? "",
-        );
-        newsContext = formatNewsContextForPrompt(newsResult);
-      } catch (error) {
-        console.warn("뉴스 수집 실패 (무시됨):", error);
-      }
-    }
-
-    const jobPostingContext = {
-      responsibilities: jobPosting.responsibilities ?? "",
-      requirements: jobPosting.requirements ?? "",
-      preferredQuals: jobPosting.preferredQuals ?? "",
-      companyName: jobPosting.companyName ?? undefined,
-      divisionName: jobPosting.divisionName ?? undefined,
-      techStack: jobPosting.techStack ?? undefined,
-      companyDescription: jobPosting.companyDescription ?? undefined,
-      companyCulture: jobPosting.companyCulture ?? undefined,
-      jobClassification: classification ?? undefined,
-      newsContext: newsContext,
-      foundedYear: cache?.foundedYear ?? undefined,
-      listingStatus: cache?.listingStatus ?? undefined,
-      industrySector: cache?.industrySector ?? undefined,
-      financialSummary: cache?.financialSummary ?? undefined,
-      recentDisclosures: cache?.recentDisclosures ?? undefined,
-      employeeSummary: cache?.employeeSummary ?? undefined,
-      businessOverview: cache?.businessOverview ?? undefined,
-      mainProducts: cache?.mainProducts ?? undefined,
-    };
-
     const result = await generateAgentBaseQuestion(
       agentId,
       profileContext,
-      jobPostingContext,
+      jobPostingData.jobPostingContext,
       messages,
       difficulty ?? "normal",
     );

--- a/lib/interview-context.ts
+++ b/lib/interview-context.ts
@@ -1,0 +1,117 @@
+import { supabaseAdmin as supabase } from "@/lib/supabase-admin";
+import { ProfileContext, JobPostingContext, Difficulty } from "@/lib/interview";
+import { detectJobClassification, JobClassification } from "@/lib/job-classifications";
+import { fetchNewsForJobPosting, formatNewsContextForPrompt } from "@/lib/naver-news-crawler";
+
+export async function loadProfileContext(userId: string): Promise<ProfileContext | null> {
+  const { data: profile } = await supabase
+    .from("profiles")
+    .select("*")
+    .eq("userId", userId)
+    .maybeSingle();
+
+  if (!profile) return null;
+
+  const [
+    { data: educations },
+    { data: careers },
+    { data: certifications },
+    { data: activities },
+  ] = await Promise.all([
+    supabase.from("educations").select("*").eq("profileId", profile.id),
+    supabase.from("careers").select("*").eq("profileId", profile.id),
+    supabase.from("certifications").select("*").eq("profileId", profile.id),
+    supabase.from("activities").select("*").eq("profileId", profile.id),
+  ]);
+
+  return {
+    name: profile.name,
+    educations: educations ?? [],
+    careers: careers ?? [],
+    certifications: certifications ?? [],
+    activities: activities ?? [],
+  };
+}
+
+type CompanyCache = {
+  foundedYear: string | null;
+  listingStatus: string | null;
+  industrySector: string | null;
+  financialSummary: string | null;
+  recentDisclosures: string | null;
+  employeeSummary: string | null;
+  businessOverview: string | null;
+  mainProducts: string | null;
+} | null;
+
+// difficulty가 있으면 직무 분류 감지 + normal/hard일 때 뉴스 수집
+// difficulty가 없으면 분류·뉴스 없이 기본 컨텍스트만 반환 (토론용)
+export async function loadJobPostingWithContext(
+  userId: string,
+  options?: { difficulty?: Difficulty },
+): Promise<{ jobPostingId: string; jobPostingContext: JobPostingContext } | null> {
+  const { data: jobPosting } = await supabase
+    .from("job_postings")
+    .select("id, responsibilities, requirements, preferredQuals, companyName, divisionName, techStack, companyDescription, companyCulture")
+    .eq("userId", userId)
+    .order("updatedAt", { ascending: false })
+    .limit(1)
+    .maybeSingle();
+
+  if (!jobPosting) return null;
+
+  const { data: companyInfo } = await supabase
+    .from("company_info")
+    .select("company_cache(foundedYear, listingStatus, industrySector, financialSummary, recentDisclosures, employeeSummary, businessOverview, mainProducts)")
+    .eq("jobPostingId", jobPosting.id)
+    .maybeSingle();
+
+  const cache = companyInfo?.company_cache as CompanyCache;
+
+  const difficulty = options?.difficulty;
+  let classification: JobClassification | undefined;
+  let newsContext: string | undefined;
+
+  if (difficulty) {
+    const jobText = `${jobPosting.responsibilities ?? ""} ${jobPosting.requirements ?? ""}`;
+    classification = detectJobClassification(jobText) ?? undefined;
+
+    const useNews = difficulty === "normal" || difficulty === "hard";
+    if (useNews && classification && jobPosting.companyName) {
+      try {
+        const newsResult = await fetchNewsForJobPosting(
+          classification,
+          jobPosting.companyName,
+          jobPosting.responsibilities ?? "",
+          jobPosting.techStack ?? "",
+        );
+        newsContext = formatNewsContextForPrompt(newsResult);
+      } catch (error) {
+        console.warn("뉴스 수집 실패 (무시됨):", error);
+      }
+    }
+  }
+
+  const jobPostingContext: JobPostingContext = {
+    responsibilities: jobPosting.responsibilities ?? "",
+    requirements: jobPosting.requirements ?? "",
+    preferredQuals: jobPosting.preferredQuals ?? "",
+    companyName: jobPosting.companyName ?? undefined,
+    divisionName: jobPosting.divisionName ?? undefined,
+    techStack: jobPosting.techStack ?? undefined,
+    companyDescription: jobPosting.companyDescription ?? undefined,
+    companyCulture: jobPosting.companyCulture ?? undefined,
+    jobClassification: classification,
+    newsContext,
+    foundedYear: cache?.foundedYear ?? undefined,
+    listingStatus: cache?.listingStatus ?? undefined,
+    industrySector: cache?.industrySector ?? undefined,
+    financialSummary: cache?.financialSummary ?? undefined,
+    recentDisclosures: cache?.recentDisclosures ?? undefined,
+    employeeSummary: cache?.employeeSummary ?? undefined,
+    businessOverview: cache?.businessOverview ?? undefined,
+    mainProducts: cache?.mainProducts ?? undefined,
+  };
+
+  return { jobPostingId: jobPosting.id, jobPostingContext };
+}


### PR DESCRIPTION
## Summary

- 프로필 로드, 채용공고+기업정보 로드, 뉴스 수집 로직이 `question` / `follow-up` / `debate` 3개 라우트에 중복되어 있던 코드를 `lib/interview-context.ts` 헬퍼로 추출
- `loadProfileContext(userId)` — 프로필 + 학력/경력/자격증/활동 조회
- `loadJobPostingWithContext(userId, { difficulty? })` — 채용공고 + DART 기업정보 조회, normal/hard 난이도일 때 뉴스 수집 포함

## 변경 범위

- `lib/interview-context.ts` 신규 생성
- `app/api/interview/question/route.ts` — 100줄 → 45줄
- `app/api/interview/follow-up/route.ts` — 100줄 → 45줄
- `app/api/interview/debate/route.ts` — 중복 60줄 제거

## Test plan

- [ ] 면접 질문 생성 정상 동작 확인
- [ ] 꼬리질문/속마음 정상 동작 확인
- [ ] 토론 세션 시작 및 결과 정상 동작 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)