### PR TITLE
refactor: isITCompany 제거 및 에이전트별 컨텍스트 주입 정교화

### DIFF
--- a/app/api/job-posting/analyze/route.ts
+++ b/app/api/job-posting/analyze/route.ts
@@ -58,7 +58,6 @@ async function extractJobInfo(text: string): Promise<{
   companyName: string;
   divisionName: string;
   techStack: string;
-  isITCompany: boolean;
   companyDescription: string;
   companyCulture: string;
 }> {
@@ -72,7 +71,6 @@ async function extractJobInfo(text: string): Promise<{
 - "회사명": 공고를 올린 회사/기관명 (텍스트에 없으면 빈 문자열)
 - "사업부": 지원 팀·사업부·부서명 (텍스트에 없으면 빈 문자열)
 - "기술스택": 공고에 언급된 기술·툴·언어 목록을 쉼표로 연결 (텍스트에 없으면 빈 문자열)
-- "IT기업": 소프트웨어·인터넷·테크 기업이면 true, 아니면 false
 - "회사 소개": 텍스트에 있는 회사 소개·미션·비전 문장을 원문 그대로 발췌 (텍스트에 없으면 빈 문자열)
 - "조직 문화": 텍스트에 명시된 문화·가치관·일하는 방식 키워드만 쉼표로 연결 (텍스트에 없으면 빈 문자열)
 
@@ -86,7 +84,6 @@ async function extractJobInfo(text: string): Promise<{
   "회사명": "",
   "사업부": "",
   "기술스택": "",
-  "IT기업": false,
   "회사 소개": "",
   "조직 문화": ""
 }
@@ -143,7 +140,6 @@ ${text}`;
     companyName:        typeof parsed["회사명"] === "string" ? parsed["회사명"] : "",
     divisionName:       typeof parsed["사업부"] === "string" ? parsed["사업부"] : "",
     techStack:          typeof parsed["기술스택"] === "string" ? parsed["기술스택"] : (Array.isArray(parsed["기술스택"]) ? (parsed["기술스택"] as string[]).join(", ") : ""),
-    isITCompany:        parsed["IT기업"] === true,
     companyDescription: typeof parsed["회사 소개"] === "string" ? parsed["회사 소개"] : "",
     companyCulture:     typeof parsed["조직 문화"] === "string" ? parsed["조직 문화"] : "",
   };
@@ -161,7 +157,6 @@ function mergeExtracted(
     companyName:        longer(a.companyName, b.companyName),
     divisionName:       longer(a.divisionName, b.divisionName),
     techStack:          longer(a.techStack, b.techStack),
-    isITCompany:        a.isITCompany || b.isITCompany,
     companyDescription: longer(a.companyDescription, b.companyDescription),
     companyCulture:     longer(a.companyCulture, b.companyCulture),
   };

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -53,17 +53,16 @@ DART 기업정보 수집                    뉴스 크롤링
 
 추출 필드:
 
-| 필드 | 설명 |
-|------|------|
-| `responsibilities` | 담당업무 |
-| `requirements` | 자격요건 |
-| `preferredQuals` | 우대사항 |
-| `companyName` | 회사명 |
-| `divisionName` | 사업부/팀명 |
-| `techStack` | 기술스택 |
-| `companyDescription` | 회사 소개 |
-| `companyCulture` | 조직 문화 |
-| `isITCompany` | IT 기업 여부 |
+| 필드 | 설명 | 사용처 |
+|------|------|--------|
+| `responsibilities` | 담당업무 | 면접 프롬프트 (전 에이전트), 수동 편집 폼, 직무 분류 |
+| `requirements` | 자격요건 | 면접 프롬프트 (전 에이전트), 수동 편집 폼 |
+| `preferredQuals` | 우대사항 | 면접 프롬프트 (전 에이전트), 수동 편집 폼 |
+| `companyName` | 회사명 | DART 수집 트리거, 면접 프롬프트 (전 에이전트) |
+| `divisionName` | 사업부/팀명 | 면접 Logic 에이전트 프롬프트 |
+| `techStack` | 기술스택 | 면접 Technical 에이전트, 뉴스 키워드 추출 |
+| `companyDescription` | 회사 소개 | 면접 Organization 에이전트 |
+| `companyCulture` | 조직 문화 | 면접 Organization 에이전트 |
 
 분석 완료 후 `collectCompanyInfo(jobPostingId, companyName)`를 비동기로 호출해 DART 수집을 시작합니다.
 
@@ -85,16 +84,16 @@ DART 기업정보 수집                    뉴스 크롤링
 
 **수집 항목** (병렬 호출):
 
-| 필드 | 출처 | 내용 |
-|------|------|------|
-| `foundedYear` | `/company.json` | 설립연도 |
-| `listingStatus` | `/company.json` | 코스피/코스닥/코넥스/비상장 |
-| `industrySector` | `/company.json` | 업종 분류 (22개) |
-| `financialSummary` | `/fnlttSinglAcnt.json` | 3년 매출·영업이익 및 전년비 |
-| `employeeSummary` | `/empSttus.json` | 임직원 수·평균근속·평균연봉 |
-| `recentDisclosures` | `/list.json` | 최근 180일 인수·합병·투자·신사업 공시 (최대 5건) |
-| `businessOverview` | 사업보고서 HTML | 사업의 개요 원문 |
-| `mainProducts` | 사업보고서 HTML | 주요 제품·서비스 원문 |
+| 필드 | 출처 | 내용 | 사용 에이전트 |
+|------|------|------|-------------|
+| `foundedYear` | `/company.json` | 설립연도 | Organization |
+| `listingStatus` | `/company.json` | 코스피/코스닥/코넥스/비상장 | Organization |
+| `industrySector` | `/company.json` | 업종 분류 (22개) | Organization, Technical |
+| `financialSummary` | `/fnlttSinglAcnt.json` | 3년 매출·영업이익 및 전년비 | Organization |
+| `employeeSummary` | `/empSttus.json` | 임직원 수·평균근속·평균연봉 | Organization |
+| `recentDisclosures` | `/list.json` | 최근 180일 인수·합병·투자·신사업 공시 (최대 5건) | Organization, Logic |
+| `businessOverview` | 사업보고서 HTML | 사업의 개요 원문 | Organization |
+| `mainProducts` | 사업보고서 HTML | 주요 제품·서비스 원문 | Organization |
 
 수집 후 `company_cache` upsert → `company_info`로 `job_postings`와 연결합니다.
 
@@ -147,9 +146,9 @@ DART 기업정보 수집                    뉴스 크롤링
 
 | 에이전트 | 역할 | 판단 기준 | 주입 데이터 |
 |--------|------|---------|-----------|
-| **Organization** (HR 담당자) | 지원동기, 조직 적합성, 장기 재직 가능성 | "왜 하필 우리 회사인가?" | 설립·상장·업종·직원현황·공시·사업보고서 |
-| **Logic** (실무 팀장) | 경험 주도성, 행동 구체성, 성과 재현 가능성 | "내 팀에서 실제로 어떻게 일할 사람인가?" | 재무현황·공시 |
-| **Technical** (현업 선임) | 기술 실사용, 선택 근거, 직무 요건 연결 | "이력서에 써놓은 것들, 실제로 아는 건가?" | 기술스택·업종·공시 |
+| **Organization** (HR 담당자) | 지원동기, 조직 적합성, 장기 재직 가능성 | "왜 하필 우리 회사인가?" | 설립·상장·업종·직원현황·재무현황·공시·회사소개·조직문화·사업보고서 |
+| **Logic** (실무 팀장) | 경험 주도성, 행동 구체성, 성과 재현 가능성 | "내 팀에서 실제로 어떻게 일할 사람인가?" | 사업부명·공시 |
+| **Technical** (현업 선임) | 기술 실사용, 선택 근거, 직무 요건 연결 | "이력서에 써놓은 것들, 실제로 아는 건가?" | 기술스택·업종 |
 
 ### 질문 생성
 
@@ -232,4 +231,4 @@ finalScore = baseScore + adjustment (-5 ~ +5)
 뉴스를 "알고 있냐"고 직접 묻지 않고, 지원자의 경험·판단과 연결하도록 LLM에 지시합니다.
 
 **에이전트별 데이터 비대칭**
-각 에이전트의 역할에 맞는 컨텍스트만 주입합니다. HR 담당자에게 재무 수치를, 기술 선임에게 사업보고서를 주입하는 방식은 지양합니다.
+각 에이전트의 역할에 맞는 컨텍스트만 주입합니다. Organization은 "왜 이 회사인가"를 검증해야 하므로 회사 전반 정보(재무·문화·사업보고서 포함)를 받습니다. Logic은 행동 패턴 검증이 목적이므로 사업부명과 최근 공시만 받습니다. Technical은 기술 검증이 목적이므로 기술스택과 업종만 받습니다. 질문 생성·속마음·토론 전 단계에 동일한 분리 원칙을 적용합니다.

--- a/lib/agents.ts
+++ b/lib/agents.ts
@@ -86,20 +86,54 @@ function buildConversationText(messages: Message[]): string {
     .join("\n\n");
 }
 
-function buildContextBlock(profile: ProfileContext, jobPosting: JobPostingContext): string {
+function buildContextBlock(profile: ProfileContext, jobPosting: JobPostingContext, agentId?: AgentId): string {
   const profileSummary = buildProfileSummary(profile);
-  const jobParts = [
-    jobPosting.companyName ? `회사명: ${jobPosting.companyName}` : "",
-    jobPosting.foundedYear ? `설립: ${jobPosting.foundedYear}` : "",
-    jobPosting.listingStatus ? `상장 현황: ${jobPosting.listingStatus}` : "",
-    jobPosting.industrySector ? `업종: ${jobPosting.industrySector}` : "",
-    jobPosting.financialSummary ? `재무 현황:\n${jobPosting.financialSummary}` : "",
-    jobPosting.recentDisclosures ? `최근 주요 공시:\n${jobPosting.recentDisclosures}` : "",
-    jobPosting.employeeSummary ? `직원 현황: ${jobPosting.employeeSummary}` : "",
+  const commonParts = [
     jobPosting.responsibilities ? `담당 업무: ${jobPosting.responsibilities}` : "",
     jobPosting.requirements ? `자격 요건: ${jobPosting.requirements}` : "",
     jobPosting.preferredQuals ? `우대 사항: ${jobPosting.preferredQuals}` : "",
-  ].filter(Boolean);
+  ];
+
+  let agentParts: string[];
+  if (agentId === "organization") {
+    agentParts = [
+      jobPosting.companyName ? `회사명: ${jobPosting.companyName}` : "",
+      jobPosting.foundedYear ? `설립: ${jobPosting.foundedYear}` : "",
+      jobPosting.listingStatus ? `상장 현황: ${jobPosting.listingStatus}` : "",
+      jobPosting.industrySector ? `업종: ${jobPosting.industrySector}` : "",
+      jobPosting.employeeSummary ? `직원 현황: ${jobPosting.employeeSummary}` : "",
+      jobPosting.financialSummary ? `재무 현황:\n${jobPosting.financialSummary}` : "",
+      jobPosting.recentDisclosures ? `최근 주요 공시:\n${jobPosting.recentDisclosures}` : "",
+      jobPosting.companyDescription ? `회사 소개: ${jobPosting.companyDescription}` : "",
+      jobPosting.companyCulture ? `조직 문화: ${jobPosting.companyCulture}` : "",
+      jobPosting.businessOverview ? `사업 개요:\n${jobPosting.businessOverview.slice(0, 3000)}` : "",
+      jobPosting.mainProducts ? `주요 제품·서비스:\n${jobPosting.mainProducts.slice(0, 3000)}` : "",
+    ];
+  } else if (agentId === "logic") {
+    agentParts = [
+      jobPosting.companyName ? `회사명: ${jobPosting.companyName}` : "",
+      jobPosting.divisionName ? `지원 사업부: ${jobPosting.divisionName}` : "",
+      jobPosting.recentDisclosures ? `최근 주요 공시:\n${jobPosting.recentDisclosures}` : "",
+    ];
+  } else if (agentId === "technical") {
+    agentParts = [
+      jobPosting.techStack ? `기술스택: ${jobPosting.techStack}` : "",
+      jobPosting.industrySector ? `업종: ${jobPosting.industrySector}` : "",
+    ];
+  } else {
+    // 중재자: 핵심 회사 정보만
+    agentParts = [
+      jobPosting.companyName ? `회사명: ${jobPosting.companyName}` : "",
+      jobPosting.foundedYear ? `설립: ${jobPosting.foundedYear}` : "",
+      jobPosting.listingStatus ? `상장 현황: ${jobPosting.listingStatus}` : "",
+      jobPosting.industrySector ? `업종: ${jobPosting.industrySector}` : "",
+      jobPosting.financialSummary ? `재무 현황:\n${jobPosting.financialSummary}` : "",
+      jobPosting.recentDisclosures ? `최근 주요 공시:\n${jobPosting.recentDisclosures}` : "",
+      jobPosting.employeeSummary ? `직원 현황: ${jobPosting.employeeSummary}` : "",
+    ];
+  }
+
+  const jobParts = [...agentParts, ...commonParts].filter(Boolean);
   return `[지원자 배경]\n${profileSummary}\n\n[채용 직무]\n${jobParts.join("\n")}\n\n지원자를 이름으로 부를 때는 반드시 "~님" 형식을 사용하세요. "~씨" 사용 금지.`;
 }
 
@@ -162,7 +196,7 @@ export async function generateAgentEvaluation(
 ): Promise<AgentEvaluation> {
   const agent = AGENTS[agentId];
   const conversationText = buildConversationText(messages);
-  const contextBlock = buildContextBlock(profile, jobPosting);
+  const contextBlock = buildContextBlock(profile, jobPosting, agentId);
 
   let jsonSchema: string;
 
@@ -304,7 +338,7 @@ export async function generateAgentReply(
 ): Promise<AgentReply> {
   const agent = AGENTS[agentId];
   const conversationText = buildConversationText(messages);
-  const contextBlock = buildContextBlock(profile, jobPosting);
+  const contextBlock = buildContextBlock(profile, jobPosting, agentId);
 
   const othersText = otherEvaluations
     .map(
@@ -377,7 +411,7 @@ export async function generateAgentRebuttal(
 ): Promise<AgentRebuttal> {
   const agent = AGENTS[agentId];
   const conversationText = buildConversationText(messages);
-  const contextBlock = buildContextBlock(profile, jobPosting);
+  const contextBlock = buildContextBlock(profile, jobPosting, agentId);
 
   const feedbackText = repliesAboutMe
     .map((r) => `[${r.fromAgentLabel}] [${r.stance}]: ${r.comment}`)
@@ -448,7 +482,7 @@ export async function generateAgentFinalOpinion(
 ): Promise<AgentFinalOpinion> {
   const agent = AGENTS[agentId];
   const conversationText = buildConversationText(messages);
-  const contextBlock = buildContextBlock(profile, jobPosting);
+  const contextBlock = buildContextBlock(profile, jobPosting, agentId);
 
   const feedbackText = repliesAboutMe
     .map((r) => `[${r.fromAgentLabel}] [${r.stance}]: ${r.comment}`)

--- a/lib/interview.ts
+++ b/lib/interview.ts
@@ -240,6 +240,7 @@ function buildAgentSystemPrompt(
       jobPosting.listingStatus ? `상장 현황: ${jobPosting.listingStatus}` : "",
       jobPosting.industrySector ? `업종: ${jobPosting.industrySector}` : "",
       jobPosting.employeeSummary ? `직원 현황: ${jobPosting.employeeSummary}` : "",
+      jobPosting.financialSummary ? `재무 현황:\n${jobPosting.financialSummary}` : "",
       jobPosting.recentDisclosures ? `최근 주요 공시:\n${jobPosting.recentDisclosures}` : "",
       jobPosting.companyDescription ? `회사 소개: ${jobPosting.companyDescription}` : "",
       jobPosting.companyCulture ? `조직 문화: ${jobPosting.companyCulture}` : "",
@@ -250,14 +251,12 @@ function buildAgentSystemPrompt(
     logic: [
       jobPosting.companyName ? `회사명: ${jobPosting.companyName}` : "",
       jobPosting.divisionName ? `지원 사업부: ${jobPosting.divisionName}` : "",
-      jobPosting.financialSummary ? `재무 현황:\n${jobPosting.financialSummary}` : "",
       jobPosting.recentDisclosures ? `최근 주요 공시:\n${jobPosting.recentDisclosures}` : "",
       commonJobBlock,
     ].filter(Boolean).join("\n"),
     technical: [
       jobPosting.techStack ? `기술스택: ${jobPosting.techStack}` : "",
       jobPosting.industrySector ? `업종: ${jobPosting.industrySector}` : "",
-      jobPosting.recentDisclosures ? `최근 주요 공시:\n${jobPosting.recentDisclosures}` : "",
       commonJobBlock,
     ].filter(Boolean).join("\n"),
   };
@@ -541,6 +540,7 @@ async function generateSingleAgentThought(
       jobPosting.listingStatus ? `상장 현황: ${jobPosting.listingStatus}` : "",
       jobPosting.industrySector ? `업종: ${jobPosting.industrySector}` : "",
       jobPosting.employeeSummary ? `직원 현황: ${jobPosting.employeeSummary}` : "",
+      jobPosting.financialSummary ? `재무 현황:\n${jobPosting.financialSummary}` : "",
       jobPosting.recentDisclosures ? `최근 주요 공시:\n${jobPosting.recentDisclosures}` : "",
       jobPosting.companyDescription ? `회사 소개: ${jobPosting.companyDescription}` : "",
       jobPosting.companyCulture ? `조직 문화: ${jobPosting.companyCulture}` : "",
@@ -549,14 +549,12 @@ async function generateSingleAgentThought(
     logic: [
       jobPosting.companyName ? `회사명: ${jobPosting.companyName}` : "",
       jobPosting.divisionName ? `지원 사업부: ${jobPosting.divisionName}` : "",
-      jobPosting.financialSummary ? `재무 현황:\n${jobPosting.financialSummary}` : "",
       jobPosting.recentDisclosures ? `최근 주요 공시:\n${jobPosting.recentDisclosures}` : "",
       thoughtCommonJobBlock,
     ].filter(Boolean).join("\n"),
     technical: [
       jobPosting.techStack ? `기술스택: ${jobPosting.techStack}` : "",
       jobPosting.industrySector ? `업종: ${jobPosting.industrySector}` : "",
-      jobPosting.recentDisclosures ? `최근 주요 공시:\n${jobPosting.recentDisclosures}` : "",
       thoughtCommonJobBlock,
     ].filter(Boolean).join("\n"),
   };

--- a/types/supabase.ts
+++ b/types/supabase.ts
@@ -336,7 +336,6 @@ export type Database = {
           createdAt: string
           divisionName: string | null
           id: string
-          isITCompany: boolean
           preferredQuals: string | null
           requirements: string | null
           responsibilities: string | null
@@ -353,7 +352,6 @@ export type Database = {
           createdAt?: string
           divisionName?: string | null
           id: string
-          isITCompany?: boolean
           preferredQuals?: string | null
           requirements?: string | null
           responsibilities?: string | null
@@ -370,7 +368,6 @@ export type Database = {
           createdAt?: string
           divisionName?: string | null
           id?: string
-          isITCompany?: boolean
           preferredQuals?: string | null
           requirements?: string | null
           responsibilities?: string | null


### PR DESCRIPTION
## Summary

- `isITCompany` 필드 제거 — `techStack`으로 대체 가능하고 실제 사용처 없음 (DB 컬럼 드롭 포함)
- `financialSummary` Logic → Organization 이동 — 재무 현황은 "왜 이 회사인가" 검증에 적합
- `recentDisclosures` Technical에서 제거 — 기술 검증 목적과 무관한 비즈니스 공시
- `agents.ts` `buildContextBlock` 에이전트별 분기 추가 — 토론 라운드(0~3)도 질문 생성과 동일한 분리 원칙 적용
- `architecture.md` 필드 사용처 및 에이전트 주입 데이터 업데이트

## Test plan

- [ ] 채용공고 분석 정상 동작 확인 (isITCompany 없이 저장)
- [ ] 면접 진행 시 각 에이전트가 올바른 컨텍스트로 질문 생성하는지 확인
- [ ] 토론 라운드에서 에이전트별 컨텍스트 분리 적용 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)