### PR TITLE
feat: 사업보고서 원문 LLM 요약 후 저장

### DIFF
--- a/lib/agents.ts
+++ b/lib/agents.ts
@@ -106,8 +106,8 @@ function buildContextBlock(profile: ProfileContext, jobPosting: JobPostingContex
       jobPosting.recentDisclosures ? `최근 주요 공시:\n${jobPosting.recentDisclosures}` : "",
       jobPosting.companyDescription ? `회사 소개: ${jobPosting.companyDescription}` : "",
       jobPosting.companyCulture ? `조직 문화: ${jobPosting.companyCulture}` : "",
-      jobPosting.businessOverview ? `사업 개요:\n${jobPosting.businessOverview.slice(0, 3000)}` : "",
-      jobPosting.mainProducts ? `주요 제품·서비스:\n${jobPosting.mainProducts.slice(0, 3000)}` : "",
+      jobPosting.businessOverview ? `사업 개요:\n${jobPosting.businessOverview}` : "",
+      jobPosting.mainProducts ? `주요 제품·서비스:\n${jobPosting.mainProducts}` : "",
     ];
   } else if (agentId === "logic") {
     agentParts = [

--- a/lib/company-info-collector.ts
+++ b/lib/company-info-collector.ts
@@ -1,4 +1,5 @@
 import { supabaseAdmin as supabase } from "@/lib/supabase-admin";
+import { callLLM } from "@/lib/runpod-client";
 
 const DART_BASE = "https://opendart.fss.or.kr/api";
 const API_KEY = process.env.DART_API_KEY ?? "";
@@ -320,6 +321,47 @@ async function fetchSectionText(rcptNo: string, section: DartSectionInfo): Promi
   return htmlToText(html) || null;
 }
 
+async function summarizeBusinessReport(
+  rawOverview: string | null,
+  rawProducts: string | null,
+): Promise<{ businessOverview: string | null; mainProducts: string | null }> {
+  if (!rawOverview && !rawProducts) return { businessOverview: null, mainProducts: null };
+
+  const prompt = `다음은 기업 사업보고서에서 추출한 원문 텍스트입니다.
+면접관이 "왜 이 회사인가?"를 검증하는 데 필요한 핵심 내용만 각각 3문장 이내로 요약하세요.
+수치·지표보다 회사의 사업 방향과 특징 위주로 요약하세요.
+해당 항목이 없으면 null을 반환하세요.
+
+[사업의 개요 원문]
+${rawOverview ? rawOverview.slice(0, 4000) : "없음"}
+
+[주요 제품·서비스 원문]
+${rawProducts ? rawProducts.slice(0, 4000) : "없음"}
+
+반드시 아래 JSON 형식만 출력하세요:
+{"businessOverview":"<요약 또는 null>","mainProducts":"<요약 또는 null>"}`;
+
+  try {
+    const raw = await callLLM({
+      messages: [{ role: "user", content: prompt }],
+      max_tokens: 600,
+    });
+    const match = raw.match(/\{[\s\S]*\}/);
+    if (!match) throw new Error("JSON 파싱 실패");
+    const parsed = JSON.parse(match[0]) as { businessOverview: string | null; mainProducts: string | null };
+    return {
+      businessOverview: typeof parsed.businessOverview === "string" && parsed.businessOverview !== "null" ? parsed.businessOverview : null,
+      mainProducts: typeof parsed.mainProducts === "string" && parsed.mainProducts !== "null" ? parsed.mainProducts : null,
+    };
+  } catch {
+    // 요약 실패 시 원문 앞부분으로 대체
+    return {
+      businessOverview: rawOverview ? rawOverview.slice(0, 500) : null,
+      mainProducts: rawProducts ? rawProducts.slice(0, 500) : null,
+    };
+  }
+}
+
 async function fetchBusinessReportSections(corpCode: string): Promise<{ businessOverview: string | null; mainProducts: string | null }> {
   const empty = { businessOverview: null, mainProducts: null };
 
@@ -340,12 +382,12 @@ async function fetchBusinessReportSections(corpCode: string): Promise<{ business
     parseSectionInfo(mainHtml, "주요 제품 및 서비스") ??
     parseSectionInfo(mainHtml, "주요제품 및 서비스");
 
-  const [businessOverview, mainProducts] = await Promise.all([
+  const [rawOverview, rawProducts] = await Promise.all([
     overviewInfo ? fetchSectionText(rcptNo, overviewInfo) : Promise.resolve(null),
     productsInfo ? fetchSectionText(rcptNo, productsInfo) : Promise.resolve(null),
   ]);
 
-  return { businessOverview, mainProducts };
+  return summarizeBusinessReport(rawOverview, rawProducts);
 }
 
 async function fetchRecentDisclosures(corpCode: string): Promise<string> {

--- a/lib/interview.ts
+++ b/lib/interview.ts
@@ -244,8 +244,8 @@ function buildAgentSystemPrompt(
       jobPosting.recentDisclosures ? `최근 주요 공시:\n${jobPosting.recentDisclosures}` : "",
       jobPosting.companyDescription ? `회사 소개: ${jobPosting.companyDescription}` : "",
       jobPosting.companyCulture ? `조직 문화: ${jobPosting.companyCulture}` : "",
-      jobPosting.businessOverview ? `사업 개요 (사업보고서 원문):\n${jobPosting.businessOverview.slice(0, 3000)}` : "",
-      jobPosting.mainProducts ? `주요 제품·서비스 (사업보고서 원문):\n${jobPosting.mainProducts.slice(0, 3000)}` : "",
+      jobPosting.businessOverview ? `사업 개요:\n${jobPosting.businessOverview}` : "",
+      jobPosting.mainProducts ? `주요 제품·서비스:\n${jobPosting.mainProducts}` : "",
       commonJobBlock,
     ].filter(Boolean).join("\n"),
     logic: [


### PR DESCRIPTION
## Summary

- DART에서 사업보고서 HTML 수집 시 LLM으로 즉시 요약 후 DB에 저장
- `businessOverview` / `mainProducts` 원문(최대 3000자)을 각 3문장 이내 요약으로 대체 → Organization 에이전트 컨텍스트 약 6000자 → ~600자로 감소
- 요약 실패 시 원문 500자 슬라이스로 폴백

## Changes

- `lib/company-info-collector.ts`: `summarizeBusinessReport()` 함수 추가, `fetchBusinessReportSections` 반환 전 요약 적용
- `lib/interview.ts`: `.slice(0, 3000)` 및 `(사업보고서 원문)` 레이블 제거
- `lib/agents.ts`: `buildContextBlock`에서 동일 슬라이스 제거

## Test plan

- [ ] 신규 기업으로 면접 시작 → company_cache에 요약된 businessOverview/mainProducts 저장 확인
- [ ] 요약 실패 시뮬레이션 → 500자 폴백 동작 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)