### PR TITLE
refactor: businessOverview/mainProducts → businessSummary 통합, company_info.isListed 제거

### DIFF
--- a/app/dart-test/page.tsx
+++ b/app/dart-test/page.tsx
@@ -14,8 +14,7 @@ interface DartResult {
   financialSummary?: string | null;
   recentDisclosures?: string | null;
   employeeSummary?: string | null;
-  businessOverview?: string | null;
-  mainProducts?: string | null;
+  businessSummary?: string | null;
 }
 
 export default function DartTestPage() {
@@ -158,27 +157,15 @@ export default function DartTestPage() {
               </div>
             )}
 
-            {result.businessOverview ? (
+            {result.businessSummary ? (
               <div className="bg-white dark:bg-slate-900 rounded-xl border border-gray-200 dark:border-slate-700 p-5">
-                <div className="text-xs font-semibold text-gray-400 dark:text-slate-500 mb-2">사업의 개요 (사업보고서 원문)</div>
-                <p className="text-sm text-gray-700 dark:text-slate-300 whitespace-pre-wrap leading-relaxed">{result.businessOverview}</p>
+                <div className="text-xs font-semibold text-gray-400 dark:text-slate-500 mb-2">사업 요약 (사업보고서 LLM 요약)</div>
+                <p className="text-sm text-gray-700 dark:text-slate-300 whitespace-pre-wrap leading-relaxed">{result.businessSummary}</p>
               </div>
             ) : (
               <div className="bg-white dark:bg-slate-900 rounded-xl border border-gray-200 dark:border-slate-700 p-5">
-                <div className="text-xs font-semibold text-gray-400 dark:text-slate-500 mb-1">사업의 개요</div>
-                <p className="text-sm text-gray-400 dark:text-slate-500">사업보고서에서 사업 개요를 찾을 수 없습니다.</p>
-              </div>
-            )}
-
-            {result.mainProducts ? (
-              <div className="bg-white dark:bg-slate-900 rounded-xl border border-gray-200 dark:border-slate-700 p-5">
-                <div className="text-xs font-semibold text-gray-400 dark:text-slate-500 mb-2">주요 제품·서비스 (사업보고서 원문)</div>
-                <p className="text-sm text-gray-700 dark:text-slate-300 whitespace-pre-wrap leading-relaxed">{result.mainProducts}</p>
-              </div>
-            ) : (
-              <div className="bg-white dark:bg-slate-900 rounded-xl border border-gray-200 dark:border-slate-700 p-5">
-                <div className="text-xs font-semibold text-gray-400 dark:text-slate-500 mb-1">주요 제품·서비스</div>
-                <p className="text-sm text-gray-400 dark:text-slate-500">사업보고서에서 주요 제품·서비스를 찾을 수 없습니다.</p>
+                <div className="text-xs font-semibold text-gray-400 dark:text-slate-500 mb-1">사업 요약</div>
+                <p className="text-sm text-gray-400 dark:text-slate-500">사업보고서에서 사업 정보를 찾을 수 없습니다.</p>
               </div>
             )}
           </div>

--- a/lib/agents.ts
+++ b/lib/agents.ts
@@ -106,8 +106,7 @@ function buildContextBlock(profile: ProfileContext, jobPosting: JobPostingContex
       jobPosting.recentDisclosures ? `최근 주요 공시:\n${jobPosting.recentDisclosures}` : "",
       jobPosting.companyDescription ? `회사 소개: ${jobPosting.companyDescription}` : "",
       jobPosting.companyCulture ? `조직 문화: ${jobPosting.companyCulture}` : "",
-      jobPosting.businessOverview ? `사업 개요:\n${jobPosting.businessOverview}` : "",
-      jobPosting.mainProducts ? `주요 제품·서비스:\n${jobPosting.mainProducts}` : "",
+      jobPosting.businessSummary ? `사업 요약:\n${jobPosting.businessSummary}` : "",
     ];
   } else if (agentId === "logic") {
     agentParts = [

--- a/lib/company-info-collector.ts
+++ b/lib/company-info-collector.ts
@@ -324,13 +324,12 @@ async function fetchSectionText(rcptNo: string, section: DartSectionInfo): Promi
 async function summarizeBusinessReport(
   rawOverview: string | null,
   rawProducts: string | null,
-): Promise<{ businessOverview: string | null; mainProducts: string | null }> {
-  if (!rawOverview && !rawProducts) return { businessOverview: null, mainProducts: null };
+): Promise<string | null> {
+  if (!rawOverview && !rawProducts) return null;
 
   const prompt = `다음은 기업 사업보고서에서 추출한 원문 텍스트입니다.
-면접관이 "왜 이 회사인가?"를 검증하는 데 필요한 핵심 내용만 각각 3문장 이내로 요약하세요.
+면접관이 "왜 이 회사인가?"를 검증하는 데 필요한 핵심 내용을 5문장 이내로 요약하세요.
 수치·지표보다 회사의 사업 방향과 특징 위주로 요약하세요.
-해당 항목이 없으면 null을 반환하세요.
 
 [사업의 개요 원문]
 ${rawOverview ? rawOverview.slice(0, 4000) : "없음"}
@@ -338,44 +337,31 @@ ${rawOverview ? rawOverview.slice(0, 4000) : "없음"}
 [주요 제품·서비스 원문]
 ${rawProducts ? rawProducts.slice(0, 4000) : "없음"}
 
-반드시 아래 JSON 형식만 출력하세요:
-{"businessOverview":"<요약 또는 null>","mainProducts":"<요약 또는 null>"}`;
+요약문만 출력하세요.`;
 
   try {
-    const raw = await callLLM({
+    const result = await callLLM({
       messages: [{ role: "user", content: prompt }],
-      max_tokens: 600,
+      max_tokens: 400,
     });
-    const match = raw.match(/\{[\s\S]*\}/);
-    if (!match) throw new Error("JSON 파싱 실패");
-    const parsed = JSON.parse(match[0]) as { businessOverview: string | null; mainProducts: string | null };
-    return {
-      businessOverview: typeof parsed.businessOverview === "string" && parsed.businessOverview !== "null" ? parsed.businessOverview : null,
-      mainProducts: typeof parsed.mainProducts === "string" && parsed.mainProducts !== "null" ? parsed.mainProducts : null,
-    };
+    return result.trim() || null;
   } catch {
-    // 요약 실패 시 원문 앞부분으로 대체
-    return {
-      businessOverview: rawOverview ? rawOverview.slice(0, 500) : null,
-      mainProducts: rawProducts ? rawProducts.slice(0, 500) : null,
-    };
+    return rawOverview ? rawOverview.slice(0, 500) : null;
   }
 }
 
-async function fetchBusinessReportSections(corpCode: string): Promise<{ businessOverview: string | null; mainProducts: string | null }> {
-  const empty = { businessOverview: null, mainProducts: null };
-
+async function fetchBusinessReportSections(corpCode: string): Promise<string | null> {
   const rcptNo = await fetchLatestAnnualReportRcptNo(corpCode);
-  if (!rcptNo) return empty;
+  if (!rcptNo) return null;
 
   const mainRes = await fetch(
     `https://dart.fss.or.kr/dsaf001/main.do?rcpNo=${rcptNo}`,
     { signal: AbortSignal.timeout(10_000) },
   ).catch(() => null);
-  if (!mainRes?.ok) return empty;
+  if (!mainRes?.ok) return null;
 
   const mainHtml = await mainRes.text().catch(() => null);
-  if (!mainHtml) return empty;
+  if (!mainHtml) return null;
 
   const overviewInfo = parseSectionInfo(mainHtml, "사업의 개요");
   const productsInfo =
@@ -481,8 +467,7 @@ export interface DartCompanyInfo {
   financialSummary: string | null;
   recentDisclosures: string | null;
   employeeSummary: string | null;
-  businessOverview: string | null;
-  mainProducts: string | null;
+  businessSummary: string | null;
 }
 
 export async function fetchDartCompanyInfo(companyName: string): Promise<DartCompanyInfo | null> {
@@ -509,8 +494,7 @@ export async function fetchDartCompanyInfo(companyName: string): Promise<DartCom
     financialSummary: financial || null,
     recentDisclosures: disclosures || null,
     employeeSummary: employees || null,
-    businessOverview: bizReport.businessOverview,
-    mainProducts: bizReport.mainProducts,
+    businessSummary: bizReport,
   };
 }
 
@@ -540,8 +524,7 @@ export async function collectCompanyInfo(jobPostingId: string, companyName: stri
       let financialSummary: string | null = null;
       let recentDisclosures: string | null = null;
       let employeeSummary: string | null = null;
-      let businessOverview: string | null = null;
-      let mainProducts: string | null = null;
+      let businessSummary: string | null = null;
 
       if (corp) {
         const [detail, financial, disclosures, employees, bizReport] = await Promise.all([
@@ -562,8 +545,7 @@ export async function collectCompanyInfo(jobPostingId: string, companyName: stri
         if (financial) financialSummary = financial;
         if (disclosures) recentDisclosures = disclosures;
         if (employees) employeeSummary = employees;
-        businessOverview = bizReport.businessOverview;
-        mainProducts = bizReport.mainProducts;
+        businessSummary = bizReport;
       }
 
       const { data: upserted, error } = await supabase
@@ -577,8 +559,7 @@ export async function collectCompanyInfo(jobPostingId: string, companyName: stri
             financialSummary,
             recentDisclosures,
             employeeSummary,
-            businessOverview,
-            mainProducts,
+            businessSummary,
             isListed,
             collectedAt: new Date().toISOString(),
           },
@@ -595,7 +576,6 @@ export async function collectCompanyInfo(jobPostingId: string, companyName: stri
       {
         jobPostingId,
         companyName,
-        isListed: false, // company_cache에서 실제 값 읽으므로 여기선 placeholder
         companyCacheId,
         collectedAt: new Date().toISOString(),
       },

--- a/lib/interview-context.ts
+++ b/lib/interview-context.ts
@@ -40,8 +40,7 @@ type CompanyCache = {
   financialSummary: string | null;
   recentDisclosures: string | null;
   employeeSummary: string | null;
-  businessOverview: string | null;
-  mainProducts: string | null;
+  businessSummary: string | null;
 } | null;
 
 // difficulty가 있으면 직무 분류 감지 + normal/hard일 때 뉴스 수집
@@ -62,7 +61,7 @@ export async function loadJobPostingWithContext(
 
   const { data: companyInfo } = await supabase
     .from("company_info")
-    .select("company_cache(foundedYear, listingStatus, industrySector, financialSummary, recentDisclosures, employeeSummary, businessOverview, mainProducts)")
+    .select("company_cache(foundedYear, listingStatus, industrySector, financialSummary, recentDisclosures, employeeSummary, businessSummary)")
     .eq("jobPostingId", jobPosting.id)
     .maybeSingle();
 
@@ -109,8 +108,7 @@ export async function loadJobPostingWithContext(
     financialSummary: cache?.financialSummary ?? undefined,
     recentDisclosures: cache?.recentDisclosures ?? undefined,
     employeeSummary: cache?.employeeSummary ?? undefined,
-    businessOverview: cache?.businessOverview ?? undefined,
-    mainProducts: cache?.mainProducts ?? undefined,
+    businessSummary: cache?.businessSummary ?? undefined,
   };
 
   return { jobPostingId: jobPosting.id, jobPostingContext };

--- a/lib/interview.ts
+++ b/lib/interview.ts
@@ -88,8 +88,7 @@ export interface JobPostingContext {
   financialSummary?: string;
   recentDisclosures?: string;
   employeeSummary?: string;
-  businessOverview?: string;
-  mainProducts?: string;
+  businessSummary?: string;
 }
 
 export function buildProfileSummary(profile: ProfileContext): string {
@@ -268,8 +267,7 @@ function buildAgentSystemPrompt(
       jobPosting.recentDisclosures ? `최근 주요 공시:\n${jobPosting.recentDisclosures}` : "",
       jobPosting.companyDescription ? `회사 소개: ${jobPosting.companyDescription}` : "",
       jobPosting.companyCulture ? `조직 문화: ${jobPosting.companyCulture}` : "",
-      jobPosting.businessOverview ? `사업 개요:\n${jobPosting.businessOverview}` : "",
-      jobPosting.mainProducts ? `주요 제품·서비스:\n${jobPosting.mainProducts}` : "",
+      jobPosting.businessSummary ? `사업 요약:\n${jobPosting.businessSummary}` : "",
       commonJobBlock,
     ].filter(Boolean).join("\n"),
     logic: [

--- a/types/supabase.ts
+++ b/types/supabase.ts
@@ -121,7 +121,7 @@ export type Database = {
       }
       company_cache: {
         Row: {
-          businessOverview: string | null
+          businessSummary: string | null
           collectedAt: string
           companyName: string
           employeeSummary: string | null
@@ -131,11 +131,10 @@ export type Database = {
           industrySector: string | null
           isListed: boolean
           listingStatus: string | null
-          mainProducts: string | null
           recentDisclosures: string | null
         }
         Insert: {
-          businessOverview?: string | null
+          businessSummary?: string | null
           collectedAt?: string
           companyName: string
           employeeSummary?: string | null
@@ -145,11 +144,10 @@ export type Database = {
           industrySector?: string | null
           isListed?: boolean
           listingStatus?: string | null
-          mainProducts?: string | null
           recentDisclosures?: string | null
         }
         Update: {
-          businessOverview?: string | null
+          businessSummary?: string | null
           collectedAt?: string
           companyName?: string
           employeeSummary?: string | null
@@ -159,7 +157,6 @@ export type Database = {
           industrySector?: string | null
           isListed?: boolean
           listingStatus?: string | null
-          mainProducts?: string | null
           recentDisclosures?: string | null
         }
         Relationships: []
@@ -170,7 +167,6 @@ export type Database = {
           companyCacheId: string | null
           companyName: string
           id: string
-          isListed: boolean
           jobPostingId: string
         }
         Insert: {
@@ -178,7 +174,6 @@ export type Database = {
           companyCacheId?: string | null
           companyName: string
           id?: string
-          isListed?: boolean
           jobPostingId: string
         }
         Update: {
@@ -186,7 +181,6 @@ export type Database = {
           companyCacheId?: string | null
           companyName?: string
           id?: string
-          isListed?: boolean
           jobPostingId?: string
         }
         Relationships: [


### PR DESCRIPTION
## Summary
- `company_cache`의 `businessOverview`, `mainProducts` 두 컬럼을 `businessSummary` 하나로 통합
- LLM 요약 방식을 JSON 두 필드 반환 → 단일 텍스트 반환으로 단순화 (두 섹션 원문은 그대로 함께 입력)
- `company_info.isListed` 제거 — 항상 `false`로 하드코딩되어 실제로 읽히지 않던 데드 컬럼
- `types/supabase.ts`, 관련 코드 전체(`company-info-collector.ts`, `interview-context.ts`, `agents.ts`, `interview.ts`, `dart-test/page.tsx`) 업데이트

## Test plan
- [ ] DART 테스트 페이지(`/dart-test`)에서 회사명 입력 후 수집 실행 → 사업 요약 정상 출력 확인
- [ ] 면접 세션 시작 시 컨텍스트에 `businessSummary` 정상 주입 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)