### PR TITLE
feat: 면접 진행 중 점진적 DB 저장 및 이탈 경고

### DIFF
--- a/app/api/interview/debate/route.ts
+++ b/app/api/interview/debate/route.ts
@@ -183,9 +183,10 @@ export async function POST(request: NextRequest) {
     const userId = await getAuthUser();
     if (!userId) return NextResponse.json({ error: "로그인이 필요합니다" }, { status: 401 });
 
-    const { messages, difficulty } = (await request.json()) as {
+    const { messages, difficulty, sessionId: existingSessionId } = (await request.json()) as {
       messages: Message[];
       difficulty: Difficulty;
+      sessionId?: string;
     };
 
     const profileContext = await loadProfileContext(userId);
@@ -195,18 +196,19 @@ export async function POST(request: NextRequest) {
     if (!jobPostingData) return NextResponse.json({ error: "채용공고가 없습니다" }, { status: 404 });
 
     const { jobPostingId, jobPostingContext } = jobPostingData;
-    const sessionId = crypto.randomUUID();
+    const sessionId = existingSessionId ?? crypto.randomUUID();
+    const now = new Date().toISOString();
 
-    await supabase.from("interview_sessions").insert({
+    await supabase.from("interview_sessions").upsert({
       id: sessionId,
       userId,
       jobPostingId,
       difficulty,
       messages: messages as unknown as Json,
       status: "evaluating",
-      createdAt: new Date().toISOString(),
-      updatedAt: new Date().toISOString(),
-    });
+      createdAt: now,
+      updatedAt: now,
+    }, { onConflict: "id" });
 
     if (process.env.VERCEL) {
       waitUntil(runDebate(sessionId, messages, profileContext, jobPostingContext));

--- a/app/api/interview/sessions/[id]/messages/route.ts
+++ b/app/api/interview/sessions/[id]/messages/route.ts
@@ -1,0 +1,31 @@
+import { NextRequest, NextResponse } from "next/server";
+import { supabaseAdmin as supabase } from "@/lib/supabase-admin";
+import { getAuthUser } from "@/lib/auth";
+import type { Json } from "@/types/supabase";
+import type { Message } from "@/lib/interview";
+
+export async function PATCH(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  try {
+    const userId = await getAuthUser();
+    if (!userId) return NextResponse.json({ error: "로그인이 필요합니다" }, { status: 401 });
+
+    const { id } = await params;
+    const { messages } = (await request.json()) as { messages: Message[] };
+
+    const { error } = await supabase
+      .from("interview_sessions")
+      .update({ messages: messages as unknown as Json, updatedAt: new Date().toISOString() })
+      .eq("id", id)
+      .eq("userId", userId);
+
+    if (error) throw error;
+
+    return NextResponse.json({ ok: true });
+  } catch (error) {
+    console.error("Session messages update error:", error);
+    return NextResponse.json({ error: "메시지를 저장할 수 없습니다" }, { status: 500 });
+  }
+}

--- a/app/api/interview/sessions/route.ts
+++ b/app/api/interview/sessions/route.ts
@@ -1,0 +1,41 @@
+import { NextRequest, NextResponse } from "next/server";
+import { supabaseAdmin as supabase } from "@/lib/supabase-admin";
+import { getAuthUser } from "@/lib/auth";
+import type { Json } from "@/types/supabase";
+import type { Message, Difficulty } from "@/lib/interview";
+import { loadJobPostingWithContext } from "@/lib/interview-context";
+
+export async function POST(request: NextRequest) {
+  try {
+    const userId = await getAuthUser();
+    if (!userId) return NextResponse.json({ error: "로그인이 필요합니다" }, { status: 401 });
+
+    const { messages, difficulty } = (await request.json()) as {
+      messages: Message[];
+      difficulty: Difficulty;
+    };
+
+    const jobPostingData = await loadJobPostingWithContext(userId);
+    if (!jobPostingData) return NextResponse.json({ error: "채용공고가 없습니다" }, { status: 404 });
+
+    const { jobPostingId } = jobPostingData;
+    const sessionId = crypto.randomUUID();
+    const now = new Date().toISOString();
+
+    await supabase.from("interview_sessions").insert({
+      id: sessionId,
+      userId,
+      jobPostingId,
+      difficulty,
+      messages: messages as unknown as Json,
+      status: "in_progress",
+      createdAt: now,
+      updatedAt: now,
+    });
+
+    return NextResponse.json({ sessionId });
+  } catch (error) {
+    console.error("Session create error:", error);
+    return NextResponse.json({ error: "세션을 생성할 수 없습니다" }, { status: 500 });
+  }
+}

--- a/components/InterviewSession.tsx
+++ b/components/InterviewSession.tsx
@@ -52,14 +52,34 @@ async function fetchFollowUp(
   return data;
 }
 
+async function createSession(messages: Message[], difficulty: Difficulty): Promise<string> {
+  const res = await fetch("/api/interview/sessions", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ messages, difficulty }),
+  });
+  const data = await res.json();
+  if (!res.ok) throw new Error(data.error ?? "세션을 생성할 수 없습니다");
+  return data.sessionId as string;
+}
+
+async function syncMessages(sessionId: string, messages: Message[]): Promise<void> {
+  await fetch(`/api/interview/sessions/${sessionId}/messages`, {
+    method: "PATCH",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ messages }),
+  });
+}
+
 async function startDebate(
   messages: Message[],
   difficulty: Difficulty,
+  sessionId: string | null,
 ): Promise<string> {
   const res = await fetch("/api/interview/debate", {
     method: "POST",
     headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({ messages, difficulty }),
+    body: JSON.stringify({ messages, difficulty, sessionId }),
   });
   const data = await res.json();
   if (!res.ok) throw new Error(data.error ?? "토론을 시작할 수 없습니다");
@@ -433,6 +453,8 @@ export default function InterviewSession({ name }: { name: string }) {
   const [debateResult, setDebateResult] = useState<DebateResultData | null>(null);
   const [debateError, setDebateError] = useState("");
   const proceededRef = useRef(false);
+  const inProgressSessionIdRef = useRef<string | null>(null);
+  const sessionCreatingRef = useRef(false);
 
   const [interimTranscript, setInterimTranscript] = useState("");
   const finalTranscriptRef = useRef("");
@@ -483,11 +505,27 @@ export default function InterviewSession({ name }: { name: string }) {
       done: "debating",
     };
     function handlePopState() {
+      if (phase === "interviewing") {
+        const confirmed = window.confirm("면접을 중단하시겠습니까? 진행 중인 답변은 저장되지 않습니다.");
+        if (!confirmed) {
+          history.pushState({ interviewPhase: phase }, "");
+          return;
+        }
+      }
       const prev = PREV[phase];
       if (prev) setPhase(prev);
     }
     window.addEventListener("popstate", handlePopState);
     return () => window.removeEventListener("popstate", handlePopState);
+  }, [phase]);
+
+  useEffect(() => {
+    if (phase !== "interviewing") return;
+    function handleBeforeUnload(e: BeforeUnloadEvent) {
+      e.preventDefault();
+    }
+    window.addEventListener("beforeunload", handleBeforeUnload);
+    return () => window.removeEventListener("beforeunload", handleBeforeUnload);
   }, [phase]);
 
   useEffect(() => {
@@ -519,6 +557,23 @@ export default function InterviewSession({ name }: { name: string }) {
     setError("");
     setCurrentThought(null);
     setQuestionReady(true);
+
+    // 점진적 DB 저장 (tutorial 제외)
+    if (difficulty !== "tutorial") {
+      if (!inProgressSessionIdRef.current && !sessionCreatingRef.current) {
+        // 첫 답변: 세션 생성
+        sessionCreatingRef.current = true;
+        createSession(updatedMessages, difficulty)
+          .then((sid) => {
+            inProgressSessionIdRef.current = sid;
+          })
+          .catch(() => {})
+          .finally(() => { sessionCreatingRef.current = false; });
+      } else if (inProgressSessionIdRef.current) {
+        // 이후 답변: messages 동기화 (생성 완료된 경우에만)
+        syncMessages(inProgressSessionIdRef.current, updatedMessages).catch(() => {});
+      }
+    }
 
     try {
       const canFollowUp = difficulty !== "tutorial" && followUpRound < MAX_FOLLOWUP_ROUNDS[difficulty];
@@ -608,6 +663,8 @@ export default function InterviewSession({ name }: { name: string }) {
     setQuestionReady(true);
     setIsThinkingPhase(false);
     setSessionId(null);
+    inProgressSessionIdRef.current = null;
+    sessionCreatingRef.current = false;
     setDebateResult(null);
     setDebateError("");
     setFinishedMessages([]);
@@ -641,7 +698,7 @@ export default function InterviewSession({ name }: { name: string }) {
           onClick={async () => {
             goToPhase("debating");
             try {
-              const sid = await startDebate(finishedMessages, difficulty);
+              const sid = await startDebate(finishedMessages, difficulty, inProgressSessionIdRef.current);
               setSessionId(sid);
             } catch (e: unknown) {
               setDebateError(e instanceof Error ? e.message : "토론을 시작할 수 없습니다");


### PR DESCRIPTION
## Summary
- 첫 답변 제출 시 `in_progress` 세션 row 생성 (난이도 선택만 하고 이탈한 경우 row 없음, tutorial 제외)
- 이후 각 답변마다 `messages` 컬럼 점진적 업데이트 (sessionId 미생성 중이면 스킵, 다음 PATCH에서 보정)
- 면접 종료 시 `sessionId`를 debate API에 전달해 동일 row를 `in_progress → evaluating` upsert (새 row 생성 방지)
- 신규 API: `POST /api/interview/sessions`, `PATCH /api/interview/sessions/[id]/messages` (userId 조건으로 타인 수정 차단)
- 면접 진행 중 새로고침/탭닫기 `beforeunload` 경고, 뒤로가기 커스텀 confirm 추가

## Test plan
- [ ] 첫 답변 제출 후 DB에 `in_progress` row 생성 확인
- [ ] tutorial 모드에서 답변 제출해도 `in_progress` row 미생성 확인
- [ ] 이후 답변마다 `messages` 컬럼 업데이트 확인
- [ ] 면접 종료 후 평가 시작 클릭 → 기존 row가 `evaluating`으로 변경 (새 row 아님) 확인
- [ ] 면접 진행 중 새로고침 시 브라우저 경고 표시 확인
- [ ] 면접 진행 중 뒤로가기 시 확인창 표시 확인

Closes #161

🤖 Generated with [Claude Code](https://claude.com/claude-code)