### PR TITLE
feat: 세션 목록/상세 조회 API 추가

### DIFF
--- a/app/api/sessions/[id]/route.ts
+++ b/app/api/sessions/[id]/route.ts
@@ -1,0 +1,47 @@
+import { NextRequest, NextResponse } from "next/server";
+import { supabaseAdmin as supabase } from "@/lib/supabase-admin";
+import { getAuthUser } from "@/lib/auth";
+
+export async function GET(
+  _request: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  try {
+    const userId = await getAuthUser();
+    if (!userId) return NextResponse.json({ error: "로그인이 필요합니다" }, { status: 401 });
+
+    const { id } = await params;
+
+    const { data: session } = await supabase
+      .from("interview_sessions")
+      .select("*")
+      .eq("id", id)
+      .eq("userId", userId)
+      .neq("difficulty", "tutorial")
+      .maybeSingle();
+
+    if (!session) {
+      return NextResponse.json({ error: "세션을 찾을 수 없습니다" }, { status: 404 });
+    }
+
+    let jobPosting: {
+      id: string;
+      companyName: string | null;
+      divisionName: string | null;
+    } | null = null;
+
+    if (session.jobPostingId) {
+      const { data: posting } = await supabase
+        .from("job_postings")
+        .select("id, companyName, divisionName")
+        .eq("id", session.jobPostingId)
+        .maybeSingle();
+      jobPosting = posting ?? null;
+    }
+
+    return NextResponse.json({ ...session, jobPosting });
+  } catch (error) {
+    console.error("Session detail error:", error);
+    return NextResponse.json({ error: "세션을 불러올 수 없습니다" }, { status: 500 });
+  }
+}

--- a/app/api/sessions/route.ts
+++ b/app/api/sessions/route.ts
@@ -1,0 +1,67 @@
+import { NextRequest, NextResponse } from "next/server";
+import { supabaseAdmin as supabase } from "@/lib/supabase-admin";
+import { getAuthUser } from "@/lib/auth";
+
+const DEFAULT_LIMIT = 20;
+const MAX_LIMIT = 100;
+
+export async function GET(request: NextRequest) {
+  try {
+    const userId = await getAuthUser();
+    if (!userId) return NextResponse.json({ error: "로그인이 필요합니다" }, { status: 401 });
+
+    const url = new URL(request.url);
+    const rawLimit = Number(url.searchParams.get("limit") ?? DEFAULT_LIMIT);
+    const rawOffset = Number(url.searchParams.get("offset") ?? 0);
+    const limit = Math.min(
+      Math.max(Number.isFinite(rawLimit) ? Math.trunc(rawLimit) : DEFAULT_LIMIT, 1),
+      MAX_LIMIT,
+    );
+    const offset = Math.max(Number.isFinite(rawOffset) ? Math.trunc(rawOffset) : 0, 0);
+
+    const { data: sessions, error } = await supabase
+      .from("interview_sessions")
+      .select("id, createdAt, status, finalScore, difficulty, jobPostingId")
+      .eq("userId", userId)
+      .neq("difficulty", "tutorial")
+      .order("createdAt", { ascending: false })
+      .order("id", { ascending: false })
+      .range(offset, offset + limit - 1);
+
+    if (error) throw error;
+
+    const jobPostingIds = Array.from(
+      new Set((sessions ?? []).map((s) => s.jobPostingId).filter((id): id is string => !!id)),
+    );
+
+    const jobPostingMap = new Map<string, { companyName: string | null; divisionName: string | null }>();
+    if (jobPostingIds.length > 0) {
+      const { data: postings } = await supabase
+        .from("job_postings")
+        .select("id, companyName, divisionName")
+        .in("id", jobPostingIds);
+      for (const p of postings ?? []) {
+        jobPostingMap.set(p.id, { companyName: p.companyName, divisionName: p.divisionName });
+      }
+    }
+
+    const items = (sessions ?? []).map((s) => {
+      const posting = s.jobPostingId ? jobPostingMap.get(s.jobPostingId) : undefined;
+      return {
+        id: s.id,
+        createdAt: s.createdAt,
+        status: s.status,
+        finalScore: s.finalScore,
+        difficulty: s.difficulty,
+        jobPostingId: s.jobPostingId,
+        companyName: posting?.companyName ?? null,
+        divisionName: posting?.divisionName ?? null,
+      };
+    });
+
+    return NextResponse.json({ items, limit, offset });
+  } catch (error) {
+    console.error("Sessions list error:", error);
+    return NextResponse.json({ error: "세션 목록을 불러올 수 없습니다" }, { status: 500 });
+  }
+}


### PR DESCRIPTION
## Summary
- `GET /api/sessions` 본인 세션 목록 (createdAt desc, id desc 정렬, 페이지네이션 limit 기본 20·최대 100)
- `GET /api/sessions/[id]` 세션 상세 — job_postings에서 companyName/divisionName 별도 조회 후 `jobPosting` 필드로 합쳐 반환
- 두 라우트 모두 `getAuthUser` 인증, `userId` 일치 검증
- **tutorial(연습 모드) 세션은 양쪽 API에서 완전 제외** — 통계 오염 방지 정책에 따라 목록 미노출, 상세 요청 시 404
- 기존 폴링 라우트(`/api/interview/debate/[sessionId]/status`)는 가벼운 select 유지 목적으로 그대로 공존

## Test plan
- [ ] `GET /api/sessions` 응답이 본인 세션만 반환 (다른 user 세션 미포함)
- [ ] tutorial 세션이 목록에 포함되지 않음
- [ ] `GET /api/sessions/[id]` 타인 세션 → 404
- [ ] `GET /api/sessions/[id]` tutorial 세션 → 404
- [ ] in_progress / error 세션도 목록에 포함됨
- [ ] jobPostingId가 null인 세션은 companyName/divisionName이 null로 반환
- [ ] limit 100 초과 요청 시 100으로 클램프

Closes #162

🤖 Generated with [Claude Code](https://claude.com/claude-code)