### PR TITLE
feat: 과거 세션 결과 다시보기 페이지 추가

### DIFF
--- a/app/sessions/[id]/page.tsx
+++ b/app/sessions/[id]/page.tsx
@@ -1,0 +1,149 @@
+import { notFound, redirect } from "next/navigation";
+import Link from "next/link";
+import { supabaseAdmin as supabase } from "@/lib/supabase-admin";
+import { getAuthUser } from "@/lib/auth";
+import SessionDetailResult from "@/components/SessionDetailResult";
+import type { DebateResultData } from "@/components/DebateLoading";
+import type { AgentEvaluation, AgentFinalOpinion } from "@/lib/agents";
+
+const DIFFICULTY_LABEL: Record<string, string> = {
+  easy: "입문",
+  normal: "기본",
+  hard: "심화",
+};
+
+function formatDate(iso: string | null): string {
+  if (!iso) return "날짜 정보 없음";
+  const d = new Date(iso);
+  return new Intl.DateTimeFormat("ko-KR", {
+    year: "numeric",
+    month: "long",
+    day: "numeric",
+    hour: "numeric",
+    minute: "2-digit",
+  }).format(d);
+}
+
+export default async function SessionDetailPage({
+  params,
+}: {
+  params: Promise<{ id: string }>;
+}) {
+  const userId = await getAuthUser();
+  if (!userId) redirect("/login");
+
+  const { id } = await params;
+
+  const { data: session } = await supabase
+    .from("interview_sessions")
+    .select("*")
+    .eq("id", id)
+    .eq("userId", userId)
+    .neq("difficulty", "tutorial")
+    .maybeSingle();
+
+  if (!session) notFound();
+
+  let companyName: string | null = null;
+  let divisionName: string | null = null;
+  if (session.jobPostingId) {
+    const { data: posting } = await supabase
+      .from("job_postings")
+      .select("companyName, divisionName")
+      .eq("id", session.jobPostingId)
+      .maybeSingle();
+    companyName = posting?.companyName ?? null;
+    divisionName = posting?.divisionName ?? null;
+  }
+
+  return (
+    <main className="min-h-screen py-8 px-4">
+      <div className="max-w-2xl mx-auto space-y-6">
+        {/* 헤더 */}
+        <header className="space-y-2">
+          <div className="flex items-center gap-2 text-xs text-gray-500 dark:text-slate-400">
+            <span>{formatDate(session.createdAt)}</span>
+            <span className="text-gray-300 dark:text-slate-600">·</span>
+            <span>{DIFFICULTY_LABEL[session.difficulty] ?? session.difficulty}</span>
+          </div>
+          <h1 className="text-2xl font-bold text-gray-900 dark:text-slate-50">
+            {companyName ?? "정보 없음"}
+          </h1>
+          <p className="text-sm text-gray-500 dark:text-slate-400">
+            {divisionName ?? "직무 정보 없음"}
+          </p>
+        </header>
+
+        {/* 상태별 본문 */}
+        {session.status === "done" ? (
+          <SessionDetailResult
+            data={{
+              finalScore: session.finalScore ?? 0,
+              agentEvaluations: (session.agentEvaluations ?? []) as unknown as AgentEvaluation[],
+              agentFinalOpinions: (session.agentFinalOpinions ?? []) as unknown as AgentFinalOpinion[],
+              finalFeedback: (session.finalFeedback ?? {
+                strengths: "",
+                weaknesses: "",
+                advice: "",
+              }) as DebateResultData["finalFeedback"],
+              debateSummary: session.debateSummary ?? "",
+              improvementTips: (session.improvementTips ?? []) as unknown as string[],
+            }}
+          />
+        ) : session.status === "error" ? (
+          <StatusCard
+            title="평가 중 오류가 발생했습니다"
+            description={session.errorMessage ?? "알 수 없는 오류"}
+            tone="error"
+          />
+        ) : session.status === "in_progress" ? (
+          <StatusCard
+            title="이전 면접이 중단되었습니다"
+            description="새로고침이나 이탈로 면접이 끝까지 진행되지 않았습니다. 새 면접을 시작해보세요."
+            cta={{ label: "새 면접 시작", href: "/interview" }}
+          />
+        ) : (
+          <StatusCard
+            title="평가가 진행 중입니다"
+            description="잠시 후 다시 확인해주세요."
+          />
+        )}
+
+        <Link
+          href="/history"
+          className="block text-center text-sm text-gray-400 dark:text-slate-500 hover:text-gray-600 dark:hover:text-slate-300"
+        >
+          ← 히스토리로 돌아가기
+        </Link>
+      </div>
+    </main>
+  );
+}
+
+function StatusCard({
+  title,
+  description,
+  cta,
+  tone = "neutral",
+}: {
+  title: string;
+  description: string;
+  cta?: { label: string; href: string };
+  tone?: "neutral" | "error";
+}) {
+  const titleColor =
+    tone === "error"
+      ? "text-red-600 dark:text-red-300"
+      : "text-gray-900 dark:text-slate-50";
+  return (
+    <div className="card p-6 space-y-3 text-center">
+      <h2 className={`text-lg font-bold ${titleColor}`}>{title}</h2>
+      <p className="text-sm text-gray-600 dark:text-slate-300">{description}</p>
+      {cta && (
+        <Link href={cta.href} className="btn-primary inline-block mt-2">
+          {cta.label}
+        </Link>
+      )}
+    </div>
+  );
+}

--- a/components/DebateResult.tsx
+++ b/components/DebateResult.tsx
@@ -19,8 +19,9 @@ interface Props {
   };
   debateSummary: string;
   improvementTips: string[];
-  onRestart: () => void;
+  onRestart?: () => void;
   onBack: () => void;
+  isHistory?: boolean;
 }
 
 function stripMd(text: string): string {
@@ -111,6 +112,7 @@ export default function DebateResult({
   improvementTips,
   onRestart,
   onBack,
+  isHistory = false,
 }: Props) {
   const displayEvaluations: (AgentEvaluation | AgentFinalOpinion)[] =
     (agentFinalOpinions && agentFinalOpinions.length > 0 ? agentFinalOpinions : agentEvaluations) ?? [];
@@ -125,7 +127,7 @@ export default function DebateResult({
         onClick={onBack}
         className="flex items-center gap-1.5 text-sm text-gray-400 dark:text-slate-500 hover:text-gray-600 dark:hover:text-slate-300 transition-colors"
       >
-        ← 면접관 토론 돌아보기
+        {isHistory ? "← 히스토리로 돌아가기" : "← 면접관 토론 돌아보기"}
       </button>
 
       {/* 점수 링 + 채용 권고 + 점수 분포 */}
@@ -306,14 +308,18 @@ export default function DebateResult({
       )}
 
       {/* 액션 버튼 */}
-      <div className="flex flex-col gap-3">
-        <a href="/job-posting" className="btn-secondary text-center">
-          채용공고 변경
-        </a>
-        <button onClick={onRestart} className="btn-primary">
-          다시 연습하기
-        </button>
-      </div>
+      {!isHistory && (
+        <div className="flex flex-col gap-3">
+          <a href="/job-posting" className="btn-secondary text-center">
+            채용공고 변경
+          </a>
+          {onRestart && (
+            <button onClick={onRestart} className="btn-primary">
+              다시 연습하기
+            </button>
+          )}
+        </div>
+      )}
     </div>
   );
 }

--- a/components/SessionDetailResult.tsx
+++ b/components/SessionDetailResult.tsx
@@ -1,0 +1,25 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import DebateResult from "@/components/DebateResult";
+import type { DebateResultData } from "@/components/DebateLoading";
+
+interface Props {
+  data: DebateResultData;
+}
+
+export default function SessionDetailResult({ data }: Props) {
+  const router = useRouter();
+  return (
+    <DebateResult
+      finalScore={data.finalScore}
+      agentEvaluations={data.agentEvaluations}
+      agentFinalOpinions={data.agentFinalOpinions}
+      finalFeedback={data.finalFeedback}
+      debateSummary={data.debateSummary}
+      improvementTips={data.improvementTips}
+      onBack={() => router.push("/history")}
+      isHistory
+    />
+  );
+}


### PR DESCRIPTION
## Summary
- `/sessions/[id]` 라우트 추가 — 회사명/직무/면접 날짜 헤더 + 상태별 본문 분기
- `DebateResult`에 `isHistory` prop 추가 → "히스토리로 돌아가기" 라벨, 채용공고 변경 / 다시 연습하기 버튼 숨김
- 상태별 처리:
  - `done` → 결과 표시 (기존 컴포넌트 재사용)
  - `error` → 에러 메시지 + DB에 저장된 errorMessage 표시
  - `in_progress` → "이전 면접이 중단되었습니다" 안내 + 새 면접 시작 CTA (M6 ⓿의 "이어하기 미지원" 정책에 맞춤)
  - `evaluating/debating/finalizing` → "평가 진행 중" 안내 (폴링 없이 새로고침 유도, 단순성 우선)
- 타인 / tutorial 세션은 404 (서버에서 `userId` 일치 + `difficulty != 'tutorial'` 검증)
- 페이지가 서버 컴포넌트라 onBack 핸들러 전달을 위해 `SessionDetailResult` 클라이언트 래퍼 추가

## Test plan
- [ ] 본인 done 세션 접속 시 결과(점수/평가/요약) 정상 표시
- [ ] 타인 세션 ID 접속 시 404
- [ ] 존재하지 않는 ID 접속 시 404
- [ ] tutorial 세션 ID 접속 시 404
- [ ] error 상태 세션은 errorMessage 표시
- [ ] in_progress 상태 세션은 "중단" 안내 + 새 면접 시작 버튼 표시
- [ ] 헤더의 날짜가 한국식 포맷(yyyy년 m월 d일 오전/오후 h:mm)으로 표시
- [ ] 채용공고가 삭제된 세션은 "정보 없음"으로 표시
- [ ] 미로그인 상태 접근 시 `/login`으로 리다이렉트

Closes #163

🤖 Generated with [Claude Code](https://claude.com/claude-code)