### PR TITLE
feat: 면접 히스토리 목록 페이지 추가

### DIFF
--- a/app/history/page.tsx
+++ b/app/history/page.tsx
@@ -1,0 +1,81 @@
+import { redirect } from "next/navigation";
+import Link from "next/link";
+import { supabaseAdmin as supabase } from "@/lib/supabase-admin";
+import { getAuthUser } from "@/lib/auth";
+import SessionHistoryCard from "@/components/SessionHistoryCard";
+
+const PAGE_SIZE = 20;
+
+export default async function HistoryPage() {
+  const userId = await getAuthUser();
+  if (!userId) redirect("/login");
+
+  const { data: sessions } = await supabase
+    .from("interview_sessions")
+    .select("id, createdAt, status, finalScore, difficulty, jobPostingId, finalFeedback")
+    .eq("userId", userId)
+    .neq("difficulty", "tutorial")
+    .order("createdAt", { ascending: false })
+    .order("id", { ascending: false })
+    .range(0, PAGE_SIZE - 1);
+
+  const items = sessions ?? [];
+
+  const jobPostingIds = Array.from(
+    new Set(items.map((s) => s.jobPostingId).filter((id): id is string => !!id)),
+  );
+
+  const postingMap = new Map<string, { companyName: string | null; divisionName: string | null }>();
+  if (jobPostingIds.length > 0) {
+    const { data: postings } = await supabase
+      .from("job_postings")
+      .select("id, companyName, divisionName")
+      .in("id", jobPostingIds);
+    for (const p of postings ?? []) {
+      postingMap.set(p.id, { companyName: p.companyName, divisionName: p.divisionName });
+    }
+  }
+
+  return (
+    <main className="min-h-screen py-8 px-4">
+      <div className="max-w-2xl mx-auto space-y-6">
+        <header className="space-y-1">
+          <h1 className="text-2xl font-bold text-gray-900 dark:text-slate-50">면접 기록</h1>
+          <p className="text-sm text-gray-500 dark:text-slate-400">
+            지금까지 진행한 면접을 다시 확인할 수 있어요.
+          </p>
+        </header>
+
+        {items.length === 0 ? (
+          <div className="card p-8 text-center space-y-4">
+            <p className="text-gray-600 dark:text-slate-300">아직 면접 기록이 없습니다.</p>
+            <Link href="/interview" className="btn-primary inline-block">
+              면접 시작
+            </Link>
+          </div>
+        ) : (
+          <ul className="space-y-3">
+            {items.map((s) => {
+              const posting = s.jobPostingId ? postingMap.get(s.jobPostingId) : undefined;
+              const feedback = s.finalFeedback as { recommendLevel?: string } | null;
+              return (
+                <li key={s.id}>
+                  <SessionHistoryCard
+                    id={s.id}
+                    companyName={posting?.companyName ?? null}
+                    divisionName={posting?.divisionName ?? null}
+                    createdAt={s.createdAt}
+                    difficulty={s.difficulty}
+                    status={s.status}
+                    finalScore={s.finalScore}
+                    recommendLevel={feedback?.recommendLevel ?? null}
+                  />
+                </li>
+              );
+            })}
+          </ul>
+        )}
+      </div>
+    </main>
+  );
+}

--- a/components/SessionHistoryCard.tsx
+++ b/components/SessionHistoryCard.tsx
@@ -1,0 +1,121 @@
+import Link from "next/link";
+
+const DIFFICULTY_LABEL: Record<string, string> = {
+  easy: "입문",
+  normal: "기본",
+  hard: "심화",
+};
+
+const RECOMMEND_STYLE: Record<string, string> = {
+  "강력 추천": "bg-green-100 text-green-700 dark:bg-green-900/40 dark:text-green-300",
+  "추천": "bg-blue-100 text-blue-700 dark:bg-blue-900/40 dark:text-blue-300",
+  "보류": "bg-orange-100 text-orange-700 dark:bg-orange-900/40 dark:text-orange-300",
+  "비추천": "bg-red-100 text-red-700 dark:bg-red-900/40 dark:text-red-300",
+};
+
+type StatusBadge = { label: string; className: string };
+
+function statusBadge(status: string): StatusBadge | null {
+  if (status === "in_progress") {
+    return {
+      label: "중단됨",
+      className: "bg-gray-100 text-gray-600 dark:bg-slate-700 dark:text-slate-300",
+    };
+  }
+  if (status === "evaluating" || status === "debating" || status === "finalizing") {
+    return {
+      label: "평가 중",
+      className: "bg-blue-100 text-blue-700 dark:bg-blue-900/40 dark:text-blue-300",
+    };
+  }
+  if (status === "error") {
+    return {
+      label: "오류",
+      className: "bg-red-100 text-red-700 dark:bg-red-900/40 dark:text-red-300",
+    };
+  }
+  return null;
+}
+
+function formatDate(iso: string | null): string {
+  if (!iso) return "—";
+  return new Intl.DateTimeFormat("ko-KR", {
+    year: "numeric",
+    month: "long",
+    day: "numeric",
+  }).format(new Date(iso));
+}
+
+interface Props {
+  id: string;
+  companyName: string | null;
+  divisionName: string | null;
+  createdAt: string | null;
+  difficulty: string;
+  status: string;
+  finalScore: number | null;
+  recommendLevel: string | null;
+}
+
+export default function SessionHistoryCard({
+  id,
+  companyName,
+  divisionName,
+  createdAt,
+  difficulty,
+  status,
+  finalScore,
+  recommendLevel,
+}: Props) {
+  const badge = statusBadge(status);
+  const isDone = status === "done";
+
+  return (
+    <Link
+      href={`/sessions/${id}`}
+      className="card p-5 block hover:border-blue-200 dark:hover:border-blue-700 transition-colors"
+    >
+      <div className="flex items-start justify-between gap-3">
+        <div className="min-w-0 flex-1 space-y-1">
+          <h3 className="font-semibold text-gray-900 dark:text-slate-50 truncate">
+            {companyName ?? "정보 없음"}
+          </h3>
+          <p className="text-sm text-gray-500 dark:text-slate-400 truncate">
+            {divisionName ?? "직무 정보 없음"}
+          </p>
+          <div className="flex items-center gap-2 text-xs text-gray-400 dark:text-slate-500 pt-1">
+            <span>{formatDate(createdAt)}</span>
+            <span className="text-gray-300 dark:text-slate-600">·</span>
+            <span>{DIFFICULTY_LABEL[difficulty] ?? difficulty}</span>
+          </div>
+        </div>
+
+        <div className="shrink-0 flex flex-col items-end gap-1.5">
+          {isDone && finalScore != null ? (
+            <>
+              <span className="text-2xl font-bold text-gray-900 dark:text-slate-50 leading-none">
+                {finalScore}
+                <span className="text-xs text-gray-400 dark:text-slate-500 font-medium ml-0.5">
+                  /100
+                </span>
+              </span>
+              {recommendLevel && (
+                <span
+                  className={`text-xs font-semibold px-2 py-0.5 rounded-full ${
+                    RECOMMEND_STYLE[recommendLevel] ?? RECOMMEND_STYLE["보류"]
+                  }`}
+                >
+                  {recommendLevel}
+                </span>
+              )}
+            </>
+          ) : badge ? (
+            <span className={`text-xs font-semibold px-2 py-0.5 rounded-full ${badge.className}`}>
+              {badge.label}
+            </span>
+          ) : null}
+        </div>
+      </div>
+    </Link>
+  );
+}


### PR DESCRIPTION
## Summary
- `/history` 라우트 (서버 컴포넌트) — 최신 20개 세션 카드 리스트
- `SessionHistoryCard` 신규 — 회사명/직무/날짜/난이도 + `done`은 점수·채용 권고 / 그 외 상태(`in_progress`/`evaluating`·`debating`·`finalizing`/`error`)는 배지로 표시
- 카드 전체를 `Link`로 감싸 `/sessions/[id]` 이동
- 빈 상태: 안내 메시지 + "면접 시작" CTA → `/interview`
- tutorial 세션은 쿼리에서 제외 (정책 일관성)
- 페이지네이션은 단순화를 위해 첫 페이지만 (필요 시 더보기 후속 작업)

## Test plan
- [ ] 본인 세션이 최신순으로 표시됨 (createdAt desc)
- [ ] tutorial 세션이 목록에서 제외됨
- [ ] done 세션 카드에 점수 + 채용 권고가 표시됨
- [ ] in_progress / evaluating / error 세션 카드에 상태 배지가 표시됨
- [ ] 카드 클릭 시 `/sessions/[id]`로 이동
- [ ] 세션이 없을 때 빈 상태 메시지 + 면접 시작 버튼 표시
- [ ] 채용공고 삭제된 세션은 "정보 없음"으로 표시
- [ ] 미로그인 상태에서 접근 시 `/login` 리다이렉트

Closes #164

🤖 Generated with [Claude Code](https://claude.com/claude-code)