### PR TITLE
feat: 사이드바에 히스토리 메뉴 추가

### DIFF
--- a/components/Sidebar.tsx
+++ b/components/Sidebar.tsx
@@ -53,6 +53,17 @@ const NAV_ITEMS: NavItem[] = [
     ),
   },
   {
+    href: "/history",
+    label: "히스토리",
+    icon: (
+      <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+        <path d="M3 12a9 9 0 1 0 3-6.7L3 8" />
+        <polyline points="3 3 3 8 8 8" />
+        <polyline points="12 7 12 12 15 14" />
+      </svg>
+    ),
+  },
+  {
     href: "/news-test",
     label: "뉴스 크롤링 테스트",
     icon: (


### PR DESCRIPTION
## Summary
- `NAV_ITEMS`에 `/history` 진입 메뉴 추가 (시계 아이콘)
- 메뉴 순서: 홈 → 프로필 → 채용공고 → 면접 → **히스토리** → (테스트) → 설정
- 대시보드 메뉴는 `/dashboard` 페이지(#165) 구현 시 함께 추가 예정 — 404 방지를 위해 분리

## Test plan
- [ ] 사이드바에 "히스토리" 메뉴가 면접 다음 위치에 표시됨
- [ ] 클릭 시 `/history` 이동
- [ ] `/history` 또는 `/sessions/[id]`에 있을 때 active 상태가 표시됨 (`startsWith` 매칭은 X — `/history`로만)
- [ ] 사이드바 접힘 상태에서도 아이콘이 정상 표시되고 tooltip이 뜸

Refs #166

🤖 Generated with [Claude Code](https://claude.com/claude-code)