### PR TITLE
refactor: LLM dead code 제거 및 중복 프로필 조회 통합

### DIFF
--- a/app/api/interview/follow-up/route.ts
+++ b/app/api/interview/follow-up/route.ts
@@ -1,9 +1,9 @@
 import { NextRequest, NextResponse } from "next/server";
-
-export const maxDuration = 300;
 import { getAuthUser } from "@/lib/auth";
 import { findFollowUpAgent, AgentId, Difficulty, Message } from "@/lib/interview";
 import { loadProfileContext, loadJobPostingWithContext } from "@/lib/interview-context";
+
+export const maxDuration = 300;
 
 export async function POST(request: NextRequest) {
   try {

--- a/app/api/interview/question/route.ts
+++ b/app/api/interview/question/route.ts
@@ -1,9 +1,9 @@
 import { NextRequest, NextResponse } from "next/server";
-
-export const maxDuration = 300;
 import { getAuthUser } from "@/lib/auth";
 import { generateAgentBaseQuestion, AgentId, Difficulty, Message } from "@/lib/interview";
 import { loadProfileContext, loadJobPostingWithContext } from "@/lib/interview-context";
+
+export const maxDuration = 300;
 
 export async function POST(request: NextRequest) {
   try {

--- a/app/profile/detail/page.tsx
+++ b/app/profile/detail/page.tsx
@@ -1,40 +1,10 @@
 import { redirect } from "next/navigation";
-import { supabaseAdmin as supabase } from "@/lib/supabase-admin";
 import { getAuthUser } from "@/lib/auth";
+import { getFullProfile } from "@/lib/profile";
 import ProfileForm from "@/components/ProfileForm";
 
 interface Props {
   searchParams: { name?: string };
-}
-
-async function getProfileData(userId: string) {
-  const { data: profile } = await supabase
-    .from("profiles")
-    .select("*")
-    .eq("userId", userId)
-    .maybeSingle();
-
-  if (!profile) return null;
-
-  const [
-    { data: educations },
-    { data: careers },
-    { data: certifications },
-    { data: activities },
-  ] = await Promise.all([
-    supabase.from("educations").select("*").eq("profileId", profile.id),
-    supabase.from("careers").select("*").eq("profileId", profile.id),
-    supabase.from("certifications").select("*").eq("profileId", profile.id),
-    supabase.from("activities").select("*").eq("profileId", profile.id),
-  ]);
-
-  return {
-    ...profile,
-    educations: educations ?? [],
-    careers: careers ?? [],
-    certifications: certifications ?? [],
-    activities: activities ?? [],
-  };
 }
 
 export default async function ProfileDetailPage({ searchParams }: Props) {
@@ -42,7 +12,7 @@ export default async function ProfileDetailPage({ searchParams }: Props) {
   if (!name) redirect("/profile");
 
   const userId = await getAuthUser();
-  const profile = userId ? await getProfileData(userId) : null;
+  const profile = userId ? await getFullProfile(userId) : null;
 
   return (
     <main className="min-h-screen py-8 px-4">

--- a/app/settings/page.tsx
+++ b/app/settings/page.tsx
@@ -1,41 +1,11 @@
 import { redirect } from "next/navigation";
-import { supabaseAdmin as supabase } from "@/lib/supabase-admin";
 import { getAuthUser } from "@/lib/auth";
+import { getFullProfile } from "@/lib/profile";
 import SettingsForm from "@/components/SettingsForm";
-
-async function getProfileData(userId: string) {
-  const { data: profile } = await supabase
-    .from("profiles")
-    .select("*")
-    .eq("userId", userId)
-    .maybeSingle();
-
-  if (!profile) return null;
-
-  const [
-    { data: educations },
-    { data: careers },
-    { data: certifications },
-    { data: activities },
-  ] = await Promise.all([
-    supabase.from("educations").select("*").eq("profileId", profile.id),
-    supabase.from("careers").select("*").eq("profileId", profile.id),
-    supabase.from("certifications").select("*").eq("profileId", profile.id),
-    supabase.from("activities").select("*").eq("profileId", profile.id),
-  ]);
-
-  return {
-    ...profile,
-    educations: educations ?? [],
-    careers: careers ?? [],
-    certifications: certifications ?? [],
-    activities: activities ?? [],
-  };
-}
 
 export default async function SettingsPage() {
   const userId = await getAuthUser();
-  const profile = userId ? await getProfileData(userId) : null;
+  const profile = userId ? await getFullProfile(userId) : null;
 
   if (!profile) redirect("/profile");
 

--- a/lib/agents.ts
+++ b/lib/agents.ts
@@ -1,9 +1,6 @@
 import { AgentId, AGENTS, Message, ProfileContext, JobPostingContext, buildProfileSummary } from "@/lib/interview";
 import { callLLM } from "@/lib/runpod-client";
 
-const LLM_BASE_URL = process.env.LLM_BASE_URL ?? "http://localhost:11434";
-const LLM_MODEL = process.env.LLM_MODEL ?? "exaone3.5:2.4b";
-
 export interface AgentEvaluation {
   agentId: AgentId;
   agentLabel: string;

--- a/lib/interview.ts
+++ b/lib/interview.ts
@@ -1,7 +1,5 @@
 import { getNewsQuestionGuide } from "./job-classifications";
-
-const LLM_BASE_URL = process.env.LLM_BASE_URL ?? "http://localhost:11434";
-const LLM_MODEL = process.env.LLM_MODEL ?? "exaone3.5:2.4b";
+import { callLLM } from "@/lib/runpod-client";
 
 export type AgentId = "organization" | "logic" | "technical";
 export type Difficulty = "tutorial" | "easy" | "normal" | "hard";
@@ -415,7 +413,6 @@ function stripMarkdown(text: string): string {
 }
 
 async function callOllama(systemPrompt: string, userContent: string, _json = false): Promise<string> {
-  const { callLLM } = await import("@/lib/runpod-client");
   const raw = await callLLM({
     messages: [
       { role: "system", content: systemPrompt },

--- a/lib/profile.ts
+++ b/lib/profile.ts
@@ -1,0 +1,31 @@
+import { supabaseAdmin as supabase } from "@/lib/supabase-admin";
+
+export async function getFullProfile(userId: string) {
+  const { data: profile } = await supabase
+    .from("profiles")
+    .select("*")
+    .eq("userId", userId)
+    .maybeSingle();
+
+  if (!profile) return null;
+
+  const [
+    { data: educations },
+    { data: careers },
+    { data: certifications },
+    { data: activities },
+  ] = await Promise.all([
+    supabase.from("educations").select("*").eq("profileId", profile.id),
+    supabase.from("careers").select("*").eq("profileId", profile.id),
+    supabase.from("certifications").select("*").eq("profileId", profile.id),
+    supabase.from("activities").select("*").eq("profileId", profile.id),
+  ]);
+
+  return {
+    ...profile,
+    educations: educations ?? [],
+    careers: careers ?? [],
+    certifications: certifications ?? [],
+    activities: activities ?? [],
+  };
+}


### PR DESCRIPTION
## Summary

- `lib/agents.ts`, `lib/interview.ts`에 선언만 되고 실제로 사용되지 않던 `LLM_BASE_URL`, `LLM_MODEL` 상수 제거
- `lib/interview.ts`의 `callLLM` dynamic import(`await import(...)`)를 파일 상단 static import로 통일
- `app/settings/page.tsx`와 `app/profile/detail/page.tsx`에 완전히 동일하게 중복된 `getProfileData` 함수를 `lib/profile.ts`로 추출하여 통합
- `app/api/interview/follow-up/route.ts`, `app/api/interview/question/route.ts`의 `maxDuration` export 위치를 import 블록 이후로 정정

## Test plan

- [ ] 설정 페이지(`/settings`) 진입 시 프로필 데이터 정상 로드 확인
- [ ] 프로필 입력 페이지(`/profile/detail`) 진입 시 프로필 데이터 정상 로드 확인
- [ ] 면접 세션 질문 생성 및 꼬리질문 정상 동작 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)