### PR TITLE
feat: 면접 진행 상태 복구 및 기록 삭제 기능 추가

### DIFF
--- a/app/api/interview/sessions/[id]/route.ts
+++ b/app/api/interview/sessions/[id]/route.ts
@@ -1,0 +1,28 @@
+import { NextRequest, NextResponse } from "next/server";
+import { supabaseAdmin as supabase } from "@/lib/supabase-admin";
+import { getAuthUser } from "@/lib/auth";
+
+export async function DELETE(
+  _request: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  try {
+    const userId = await getAuthUser();
+    if (!userId) return NextResponse.json({ error: "로그인이 필요합니다" }, { status: 401 });
+
+    const { id } = await params;
+
+    const { error } = await supabase
+      .from("interview_sessions")
+      .delete()
+      .eq("id", id)
+      .eq("userId", userId);
+
+    if (error) throw error;
+
+    return NextResponse.json({ ok: true });
+  } catch (error) {
+    console.error("Session delete error:", error);
+    return NextResponse.json({ error: "세션을 삭제할 수 없습니다" }, { status: 500 });
+  }
+}

--- a/components/InterviewSession.tsx
+++ b/components/InterviewSession.tsx
@@ -21,6 +21,44 @@ const ANSWER_TIME_LIMIT = 80;
 
 type Phase = "selecting" | "interviewing" | "finished" | "debating" | "done";
 
+type ResumeSnapshot = {
+  phase: "interviewing" | "finished";
+  difficulty: Difficulty;
+  messages: Message[];
+  agentIndex: number;
+  followUpRound: number;
+  avatarSeeds: Record<AgentId, string>;
+  inProgressSessionId: string | null;
+};
+
+const STORAGE_KEY = "zoom-interview:in-progress";
+
+function loadSnapshot(): ResumeSnapshot | null {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    return raw ? (JSON.parse(raw) as ResumeSnapshot) : null;
+  } catch {
+    return null;
+  }
+}
+
+function saveSnapshot(snap: ResumeSnapshot) {
+  try {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(snap));
+  } catch {}
+}
+
+function clearSnapshot() {
+  try {
+    localStorage.removeItem(STORAGE_KEY);
+  } catch {}
+}
+
+function updateStoredSessionId(sid: string) {
+  const snap = loadSnapshot();
+  if (snap) saveSnapshot({ ...snap, inProgressSessionId: sid });
+}
+
 async function fetchQuestion(
   messages: Message[],
   agentId: AgentId,
@@ -449,6 +487,9 @@ export default function InterviewSession({ name }: { name: string }) {
   const [currentThought, setCurrentThought] = useState<AgentThoughtResult | null>(null);
   const [questionReady, setQuestionReady] = useState(true);
 
+  const [restored, setRestored] = useState(false);
+  const [pendingContinue, setPendingContinue] = useState(false);
+
   const [sessionId, setSessionId] = useState<string | null>(null);
   const [debateResult, setDebateResult] = useState<DebateResultData | null>(null);
   const [debateError, setDebateError] = useState("");
@@ -538,6 +579,60 @@ export default function InterviewSession({ name }: { name: string }) {
     return () => clearTimeout(timer);
   }, [timeLeft, isLoading, isThinkingPhase, phase]);
 
+  // 새로고침/이탈 후 복귀 시 진행 중이던 면접 복구
+  useEffect(() => {
+    const snap = loadSnapshot();
+    if (snap && (snap.phase === "interviewing" || snap.phase === "finished")) {
+      setDifficulty(snap.difficulty);
+      setMessages(snap.messages);
+      setAgentIndex(snap.agentIndex);
+      setFollowUpRound(snap.followUpRound);
+      setAvatarSeeds(snap.avatarSeeds);
+      inProgressSessionIdRef.current = snap.inProgressSessionId;
+
+      if (snap.phase === "finished") {
+        setFinishedMessages(snap.messages);
+        setPhase("finished");
+        history.pushState({ interviewPhase: "finished" }, "");
+      } else {
+        setPhase("interviewing");
+        history.pushState({ interviewPhase: "interviewing" }, "");
+        // 마지막 메시지가 답변이면 다음 질문 생성 중에 이탈한 것 → 이어서 생성
+        if (snap.messages[snap.messages.length - 1]?.role === "candidate") {
+          setPendingContinue(true);
+        }
+      }
+    }
+    setRestored(true);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  // 복구 시 중단된 질문 생성 이어가기 (복원된 state가 적용된 다음 렌더에서 실행)
+  useEffect(() => {
+    if (!pendingContinue) return;
+    setPendingContinue(false);
+    proceedAfterAnswer(messages);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [pendingContinue]);
+
+  // 진행 상태를 localStorage에 저장 (복구 완료 이후에만)
+  useEffect(() => {
+    if (!restored) return;
+    if (phase === "interviewing" || phase === "finished") {
+      saveSnapshot({
+        phase,
+        difficulty,
+        messages,
+        agentIndex,
+        followUpRound,
+        avatarSeeds,
+        inProgressSessionId: inProgressSessionIdRef.current,
+      });
+    } else {
+      clearSnapshot();
+    }
+  }, [restored, phase, difficulty, messages, agentIndex, followUpRound, avatarSeeds]);
+
   async function handleSubmit() {
     if (isRecording) {
       stop();
@@ -546,13 +641,16 @@ export default function InterviewSession({ name }: { name: string }) {
     const trimmed = answer.trim();
     if (!trimmed || isLoading || isThinkingPhase) return;
 
-    const currentAgentId = AGENT_ORDER[agentIndex];
     const updatedMessages: Message[] = [
       ...messages,
       { role: "candidate", content: trimmed },
     ];
     setMessages(updatedMessages);
     setAnswer("");
+    await proceedAfterAnswer(updatedMessages);
+  }
+
+  async function proceedAfterAnswer(updatedMessages: Message[]) {
     setIsLoading(true);
     setError("");
     setCurrentThought(null);
@@ -566,6 +664,7 @@ export default function InterviewSession({ name }: { name: string }) {
         createSession(updatedMessages, difficulty)
           .then((sid) => {
             inProgressSessionIdRef.current = sid;
+            updateStoredSessionId(sid);
           })
           .catch(() => {})
           .finally(() => { sessionCreatingRef.current = false; });
@@ -579,6 +678,7 @@ export default function InterviewSession({ name }: { name: string }) {
       const canFollowUp = difficulty !== "tutorial" && followUpRound < MAX_FOLLOWUP_ROUNDS[difficulty];
 
       if (canFollowUp) {
+        const currentAgentId = AGENT_ORDER[agentIndex];
         setIsLoading(false);
         setIsThinkingPhase(true);
 
@@ -668,6 +768,19 @@ export default function InterviewSession({ name }: { name: string }) {
     setDebateResult(null);
     setDebateError("");
     setFinishedMessages([]);
+  }
+
+  // 복구 확인 전 잠깐 로딩 (저장된 진행 상태가 있으면 복원)
+  if (!restored) {
+    return (
+      <div className="card flex items-center justify-center py-20">
+        <div className="flex gap-1.5">
+          <span className="w-2 h-2 bg-blue-500 rounded-full animate-bounce [animation-delay:0ms]" />
+          <span className="w-2 h-2 bg-blue-500 rounded-full animate-bounce [animation-delay:150ms]" />
+          <span className="w-2 h-2 bg-blue-500 rounded-full animate-bounce [animation-delay:300ms]" />
+        </div>
+      </div>
+    );
   }
 
   // 난이도 선택

--- a/components/SessionHistoryCard.tsx
+++ b/components/SessionHistoryCard.tsx
@@ -1,4 +1,8 @@
+"use client";
+
 import Link from "next/link";
+import { useRouter } from "next/navigation";
+import { useState } from "react";
 
 const DIFFICULTY_LABEL: Record<string, string> = {
   easy: "입문",
@@ -70,10 +74,28 @@ export default function SessionHistoryCard({
   const badge = statusBadge(status);
   const isDone = status === "done";
 
+  const router = useRouter();
+  const [deleting, setDeleting] = useState(false);
+
+  async function handleDelete() {
+    if (deleting) return;
+    if (!window.confirm("이 면접 기록을 삭제할까요? 삭제하면 복구할 수 없습니다.")) return;
+    setDeleting(true);
+    try {
+      const res = await fetch(`/api/interview/sessions/${id}`, { method: "DELETE" });
+      if (!res.ok) throw new Error();
+      router.refresh();
+    } catch {
+      setDeleting(false);
+      window.alert("삭제에 실패했습니다. 잠시 후 다시 시도해주세요.");
+    }
+  }
+
   return (
+    <div className="relative">
     <Link
       href={`/sessions/${id}`}
-      className="card p-5 block hover:border-blue-200 dark:hover:border-blue-700 transition-colors"
+      className={`card p-5 block hover:border-blue-200 dark:hover:border-blue-700 transition-colors ${deleting ? "opacity-50 pointer-events-none" : ""}`}
     >
       <div className="flex items-start justify-between gap-3">
         <div className="min-w-0 flex-1 space-y-1">
@@ -117,5 +139,20 @@ export default function SessionHistoryCard({
         </div>
       </div>
     </Link>
+      <button
+        type="button"
+        onClick={handleDelete}
+        disabled={deleting}
+        aria-label="기록 삭제"
+        className="absolute bottom-3 right-3 z-10 p-1.5 rounded-lg text-gray-300 dark:text-slate-600 hover:text-red-500 hover:bg-red-50 dark:hover:bg-red-900/30 transition-colors disabled:opacity-50"
+      >
+        <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+          <polyline points="3 6 5 6 21 6" />
+          <path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6m3 0V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2" />
+          <line x1="10" y1="11" x2="10" y2="17" />
+          <line x1="14" y1="11" x2="14" y2="17" />
+        </svg>
+      </button>
+    </div>
   );
 }


### PR DESCRIPTION
## Summary
- 면접 진행 중 새로고침/이탈 후 복귀 시 진행 상태(messages, 현재 면접관, 꼬리질문 횟수, 아바타, 세션ID)를 localStorage로 복구. 기존엔 난이도 선택 화면으로 초기화되던 문제 해결
- 질문 생성 도중 이탈한 경우 복원 후 생성을 이어감
- 면접 기록 카드에 삭제 버튼 추가, 본인 세션만 삭제하는 `DELETE /api/interview/sessions/[id]` 라우트 신규 (하드 삭제)

## Test plan
- [ ] 면접 첫 질문에서 새로고침 → 난이도 선택이 아니라 해당 질문 화면으로 복원
- [ ] 답변 제출 직후(질문 생성 중) 새로고침 → 복원 후 다음 질문 생성 이어감
- [ ] 면접 완료 화면에서 새로고침 → 완료 화면 복원
- [ ] 평가/토론 시작 후 새로고침 → 복구 안 함(의도된 동작), 결과는 히스토리에서 확인
- [ ] 히스토리 카드 삭제 → 목록에서 사라지고 통계 대시보드에서도 제외
- [ ] 타인 세션 삭제 시도 차단(userId 불일치)

🤖 Generated with [Claude Code](https://claude.com/claude-code)