### PR TITLE
fix: LLM 호출 안정성 및 채점 일관성 개선

### DIFF
--- a/lib/agents.ts
+++ b/lib/agents.ts
@@ -55,13 +55,14 @@ export interface ModeratorResult {
   debateSummary: string;
 }
 
-async function callOllama(systemPrompt: string, userContent: string): Promise<string> {
+async function chatLLM(systemPrompt: string, userContent: string, temperature?: number): Promise<string> {
   return callLLM({
     messages: [
       { role: "system", content: systemPrompt },
       { role: "user", content: userContent },
     ],
     max_tokens: 2000,
+    ...(temperature !== undefined ? { temperature } : {}),
   });
 }
 
@@ -234,7 +235,7 @@ ${conversationText}
 ${jsonSchema}
 문자열 값 안에 마크다운 서식(**, *, #)을 사용하지 마세요.`;
 
-  const raw = await callOllama(AGENT_SYSTEM_PROMPTS[agentId], userContent);
+  const raw = await chatLLM(AGENT_SYSTEM_PROMPTS[agentId], userContent, 0);
 
   if (agentId === "logic") {
     const parsed = extractJSON<{
@@ -375,7 +376,7 @@ ${replySchema}
 }
 문자열 값 안에 마크다운 서식(**, *, #)을 사용하지 마세요.`;
 
-  const raw = await callOllama(systemPrompt, userContent);
+  const raw = await chatLLM(systemPrompt, userContent);
   const parsedReply = extractJSON<{
     replies: { targetAgentId: string; stance: string; comment: string }[];
   }>(raw);
@@ -447,7 +448,7 @@ ${rebuttalSchema}
 }
 문자열 값 안에 마크다운 서식(**, *, #)을 사용하지 마세요.`;
 
-  const raw = await callOllama(systemPrompt, userContent);
+  const raw = await chatLLM(systemPrompt, userContent);
   const parsed = extractJSON<{
     rebuttals: { fromAgentId: string; comment: string }[];
   }>(raw);
@@ -550,7 +551,7 @@ ${othersRebuttalText}
 ${jsonSchema}
 문자열 값 안에 마크다운 서식(**, *, #)을 사용하지 마세요.`;
 
-  const raw = await callOllama(systemPrompt, userContent);
+  const raw = await chatLLM(systemPrompt, userContent, 0);
 
   if (agentId === "logic") {
     const parsed = extractJSON<{
@@ -691,7 +692,7 @@ ${evaluationsText}
 }
 문자열 값 안에 마크다운 서식(**, *, #)을 사용하지 마세요.`;
 
-  const raw = await callOllama(systemPrompt, userContent);
+  const raw = await chatLLM(systemPrompt, userContent, 0);
   const parsedMod = extractJSON<{
     adjustment: number;
     recommendLevel: string;

--- a/lib/interview.ts
+++ b/lib/interview.ts
@@ -412,7 +412,7 @@ function stripMarkdown(text: string): string {
     .trim();
 }
 
-async function callOllama(systemPrompt: string, userContent: string, _json = false): Promise<string> {
+async function chatLLM(systemPrompt: string, userContent: string): Promise<string> {
   const raw = await callLLM({
     messages: [
       { role: "system", content: systemPrompt },
@@ -526,7 +526,7 @@ STAR, S, T, A, R 같은 영어 약어를 출력에 사용하지 마세요.${news
   "hint": ""${thoughtField}
 }`;
 
-  const raw = await callOllama(systemPrompt, userContent, true);
+  const raw = await chatLLM(systemPrompt, userContent);
   try {
     const match = raw.match(/\{[\s\S]*\}/);
     if (!match) throw new Error("no JSON");
@@ -742,7 +742,7 @@ ${{
 }
 reaction/judgment/curiosity는 반드시 반말 구어체(~습니다/~합니다 절대 금지). question은 반드시 격식체 존댓말. 마크다운 서식(**, *, #) 사용 금지.`;
 
-  const raw = await callOllama(systemPrompt, userContent, true);
+  const raw = await chatLLM(systemPrompt, userContent);
 
   try {
     const match = raw.match(/\{[\s\S]*\}/);

--- a/lib/runpod-client.ts
+++ b/lib/runpod-client.ts
@@ -8,38 +8,69 @@ interface RunPodInput {
   max_tokens?: number;
 }
 
+// 잡이 종료 상태(COMPLETED+error / FAILED)로 끝난 경우 — 폴링 재시도로 회복 불가하므로 즉시 전파
+class TerminalJobError extends Error {}
+
+const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
 async function submitJob(input: RunPodInput): Promise<string> {
-  const res = await fetch(`${BASE_URL}/run`, {
-    method: "POST",
-    headers: {
-      "Content-Type": "application/json",
-      "Authorization": `Bearer ${RUNPOD_API_KEY}`,
-    },
-    body: JSON.stringify({ input }),
-  });
-  if (!res.ok) throw new Error(`RunPod job 제출 실패: ${res.status}`);
-  const data = await res.json();
-  return data.id as string;
+  const backoffs = [500, 1000, 2000];
+  let lastErr: unknown;
+  for (let attempt = 0; attempt <= backoffs.length; attempt++) {
+    try {
+      const res = await fetch(`${BASE_URL}/run`, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "Authorization": `Bearer ${RUNPOD_API_KEY}`,
+        },
+        body: JSON.stringify({ input }),
+        signal: AbortSignal.timeout(15_000),
+      });
+      if (!res.ok) throw new Error(`RunPod job 제출 실패: ${res.status}`);
+      const data = await res.json();
+      return data.id as string;
+    } catch (e) {
+      lastErr = e;
+      if (attempt < backoffs.length) await sleep(backoffs[attempt]);
+    }
+  }
+  throw lastErr instanceof Error ? lastErr : new Error("RunPod job 제출 실패");
 }
 
-async function pollJob(jobId: string, timeoutMs = 540_000): Promise<string> {
+async function pollJob(jobId: string, timeoutMs = 290_000): Promise<string> {
   const start = Date.now();
-  while (Date.now() - start < timeoutMs) {
-    const res = await fetch(`${BASE_URL}/status/${jobId}`, {
-      headers: { "Authorization": `Bearer ${RUNPOD_API_KEY}` },
-    });
-    if (!res.ok) throw new Error(`RunPod 상태 조회 실패: ${res.status}`);
-    const data = await res.json();
+  let consecutiveErrors = 0;
+  const MAX_CONSECUTIVE_ERRORS = 5;
 
-    if (data.status === "COMPLETED") {
-      if (data.output?.error) throw new Error(data.output.error);
-      return data.output?.output ?? "";
+  while (Date.now() - start < timeoutMs) {
+    try {
+      const res = await fetch(`${BASE_URL}/status/${jobId}`, {
+        headers: { "Authorization": `Bearer ${RUNPOD_API_KEY}` },
+        signal: AbortSignal.timeout(10_000),
+      });
+      if (!res.ok) throw new Error(`RunPod 상태 조회 실패: ${res.status}`);
+      const data = await res.json();
+      consecutiveErrors = 0;
+
+      if (data.status === "COMPLETED") {
+        if (data.output?.error) throw new TerminalJobError(data.output.error);
+        return data.output?.output ?? "";
+      }
+      if (data.status === "FAILED") {
+        throw new TerminalJobError(`RunPod job 실패: ${JSON.stringify(data.error)}`);
+      }
+      // IN_QUEUE / IN_PROGRESS → 계속 폴링
+    } catch (e) {
+      if (e instanceof TerminalJobError) throw e;
+      // 일시적 조회 오류(네트워크 blip, 타임아웃, 5xx)는 관용 — 진행 중인 잡을 죽이지 않음
+      if (++consecutiveErrors >= MAX_CONSECUTIVE_ERRORS) {
+        throw new Error(
+          `RunPod 상태 조회 ${MAX_CONSECUTIVE_ERRORS}회 연속 실패: ${e instanceof Error ? e.message : String(e)}`,
+        );
+      }
     }
-    if (data.status === "FAILED") {
-      throw new Error(`RunPod job 실패: ${JSON.stringify(data.error)}`);
-    }
-    // IN_QUEUE / IN_PROGRESS → 계속 폴링
-    await new Promise((r) => setTimeout(r, 2000));
+    await sleep(2000);
   }
   throw new Error("RunPod job 타임아웃");
 }


### PR DESCRIPTION
## Summary
- **RunPod 호출 안정성** (`lib/runpod-client.ts`): submit/poll 요청에 `AbortSignal` 타임아웃(15s/10s) 추가로 무한 행 차단. 폴링 중 일시적 조회 오류는 5회까지 관용하여 진행 중인 잡이 네트워크 blip으로 죽지 않도록 보호. 진짜 잡 실패(`FAILED`, `output.error`)는 `TerminalJobError`로 즉시 전파. submit 실패 시 3회 재시도(0.5/1/2s backoff).
- **타임아웃 정렬**: poll 기본 타임아웃을 540s→290s로 조정. 기존엔 Vercel `maxDuration=300`보다 길어 절대 발동하지 않았음.
- **채점 일관성** (`lib/agents.ts`): 평가(Round 0)·최종 의견(Round 3)·중재자 호출에 `temperature: 0` 고정. 같은 답변에 점수가 흔들리던 문제 해결. 토론 라운드(상호 피드백·재반박)는 자연스러운 구어체 유지를 위해 변동 그대로 둠.
- **Ollama 잔재 정리**: RunPod 마이그레이션 때 이름만 남았던 `callOllama` → `chatLLM`. `interview.ts`의 미사용 `_json` 파라미터·인자 제거.

## Test plan
- [x] `npx tsc --noEmit` 통과
- [x] `grep -ri ollama` 0건 확인
- [ ] 로컬에서 면접→토론 1회 정상 동작 (배선 확인)
- [ ] 같은 면접 2~3회 반복 시 최종 점수 안정성 비교 (temperature 0 효과)
- [ ] (선택) submit/poll 장애 주입으로 재시도·관용 경로 확인

> 참고: 재시도·타임아웃 경로는 정상 실행으론 타지 않아 happy-path 테스트로는 검증되지 않음.

🤖 Generated with [Claude Code](https://claude.com/claude-code)