### PR TITLE
면접 중 뉴스 컨텍스트 세션당 1회 캐싱 (#177)

### DIFF
--- a/app/api/interview/prepare/route.ts
+++ b/app/api/interview/prepare/route.ts
@@ -1,0 +1,32 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getAuthUser } from "@/lib/auth";
+import { loadJobPostingWithContext } from "@/lib/interview-context";
+import { Difficulty } from "@/lib/interview";
+
+export const maxDuration = 300;
+
+// 난이도 선택 시 클라이언트가 fire-and-forget로 호출한다. loadJobPostingWithContext가
+// 부수효과로 뉴스 캐시를 워밍하므로, 고정 첫 질문(자기소개)에 답하는 동안 수집이 끝나
+// 첫 꼬리질문 생성 지연이 숨겨진다.
+export async function POST(request: NextRequest) {
+  try {
+    const userId = await getAuthUser();
+    if (!userId) {
+      return NextResponse.json({ error: "로그인이 필요합니다" }, { status: 401 });
+    }
+
+    const body = (await request.json().catch(() => ({}))) as { difficulty?: Difficulty };
+    const difficulty = body?.difficulty;
+
+    // 뉴스는 normal/hard에서만 사용 — 그 외 난이도는 워밍할 게 없다.
+    if (difficulty === "normal" || difficulty === "hard") {
+      await loadJobPostingWithContext(userId, { difficulty });
+    }
+
+    return NextResponse.json({ ok: true });
+  } catch (error) {
+    console.error("Interview prepare error:", error);
+    // 워밍 실패는 비치명적 — 읽기 경로에서 라이브 크롤로 폴백한다.
+    return NextResponse.json({ ok: false });
+  }
+}

--- a/components/InterviewSession.tsx
+++ b/components/InterviewSession.tsx
@@ -529,6 +529,14 @@ export default function InterviewSession({ name }: { name: string }) {
 
   function handleDifficultySelect(d: Difficulty) {
     setDifficulty(d);
+    // 고정 첫 질문에 답하는 동안 뉴스 캐시를 백그라운드로 워밍 (normal/hard만 뉴스 사용)
+    if (d === "normal" || d === "hard") {
+      fetch("/api/interview/prepare", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ difficulty: d }),
+      }).catch(() => {});
+    }
     setAvatarSeeds({ organization: randomSeed(), logic: randomSeed(), technical: randomSeed() });
     setMessages([{ role: "interviewer", content: getFirstQuestion(name), agentId: "organization" }]);
     setAgentIndex(0);

--- a/lib/interview-context.ts
+++ b/lib/interview-context.ts
@@ -3,6 +3,10 @@ import { ProfileContext, JobPostingContext, Difficulty } from "@/lib/interview";
 import { detectJobClassification, JobClassification } from "@/lib/job-classifications";
 import { fetchNewsForJobPosting, formatNewsContextForPrompt } from "@/lib/naver-news-crawler";
 
+// 뉴스는 세션 내내 동일하므로 jobPostingId 기준으로 캐시한다. 면접 진행 중 매 요청마다
+// 재크롤링하지 않도록 신선한 캐시가 있으면 재사용하고, 만료 시에만 다시 수집한다.
+const NEWS_CACHE_TTL_MS = 24 * 60 * 60 * 1000; // 24시간
+
 export async function loadProfileContext(userId: string): Promise<ProfileContext | null> {
   const { data: profile } = await supabase
     .from("profiles")
@@ -65,7 +69,7 @@ export async function loadJobPostingWithContext(
 
   const { data: companyInfo } = await supabase
     .from("company_info")
-    .select("company_cache(foundedYear, listingStatus, financialSummary, recentDisclosures, employeeSummary, businessSummary, industrySector, mainServices, visionMission, targetCustomer, competitivePosition)")
+    .select("newsContext, newsCollectedAt, company_cache(foundedYear, listingStatus, financialSummary, recentDisclosures, employeeSummary, businessSummary, industrySector, mainServices, visionMission, targetCustomer, competitivePosition)")
     .eq("jobPostingId", jobPosting.id)
     .maybeSingle();
 
@@ -81,16 +85,45 @@ export async function loadJobPostingWithContext(
 
     const useNews = difficulty === "normal" || difficulty === "hard";
     if (useNews && classification && jobPosting.companyName) {
-      try {
-        const newsResult = await fetchNewsForJobPosting(
-          classification,
-          jobPosting.companyName,
-          jobPosting.responsibilities ?? "",
-          jobPosting.techStack ?? "",
-        );
-        newsContext = formatNewsContextForPrompt(newsResult);
-      } catch (error) {
-        console.warn("뉴스 수집 실패 (무시됨):", error);
+      const cachedNews = companyInfo?.newsContext;
+      const cachedAt = companyInfo?.newsCollectedAt;
+      const newsFresh =
+        !!cachedNews && !!cachedAt &&
+        Date.now() - new Date(cachedAt).getTime() < NEWS_CACHE_TTL_MS;
+
+      if (newsFresh) {
+        newsContext = cachedNews;
+      } else {
+        try {
+          const newsResult = await fetchNewsForJobPosting(
+            classification,
+            jobPosting.companyName,
+            jobPosting.responsibilities ?? "",
+            jobPosting.techStack ?? "",
+          );
+          newsContext = formatNewsContextForPrompt(newsResult);
+
+          // write-through 캐시. companyCacheId 등 기존 값을 덮어쓰지 않도록
+          // 행이 있으면 update, 없으면 insert로 분기한다.
+          const newsCollectedAt = new Date().toISOString();
+          if (companyInfo) {
+            await supabase
+              .from("company_info")
+              .update({ newsContext, newsCollectedAt })
+              .eq("jobPostingId", jobPosting.id);
+          } else {
+            await supabase
+              .from("company_info")
+              .insert({
+                jobPostingId: jobPosting.id,
+                companyName: jobPosting.companyName,
+                newsContext,
+                newsCollectedAt,
+              });
+          }
+        } catch (error) {
+          console.warn("뉴스 수집 실패 (무시됨):", error);
+        }
       }
     }
   }

--- a/types/supabase.ts
+++ b/types/supabase.ts
@@ -186,6 +186,8 @@ export type Database = {
           companyName: string
           id: string
           jobPostingId: string
+          newsCollectedAt: string | null
+          newsContext: string | null
         }
         Insert: {
           collectedAt?: string
@@ -193,6 +195,8 @@ export type Database = {
           companyName: string
           id?: string
           jobPostingId: string
+          newsCollectedAt?: string | null
+          newsContext?: string | null
         }
         Update: {
           collectedAt?: string
@@ -200,6 +204,8 @@ export type Database = {
           companyName?: string
           id?: string
           jobPostingId?: string
+          newsCollectedAt?: string | null
+          newsContext?: string | null
         }
         Relationships: [
           {


### PR DESCRIPTION
## Summary
- normal/hard 면접에서 `loadJobPostingWithContext`가 매 `question`·`follow-up` 요청마다 `fetchNewsForJobPosting`(네이버 API 최대 8회 순차 + LLM 필터링 1회)을 재실행하던 것을, `company_info`에 캐싱(TTL 24h)해 **세션당 1회**로 줄임
- 캐시 미스/만료 시에만 라이브 크롤 + write-through 저장 (`companyCacheId` 보존 위해 update/insert 분기)
- `POST /api/interview/prepare` 워밍 엔드포인트 추가 — 난이도 선택(normal/hard) 시 fire-and-forget 호출로, LLM 없는 고정 첫 질문(자기소개)에 답하는 동안 백그라운드 수집이 끝나도록 해 첫 꼬리질문 지연을 숨김
- `company_info`에 `newsContext`, `newsCollectedAt` 컬럼 추가 (마이그레이션 적용 완료)

## Test plan
- [x] `npx tsc --noEmit` 통과
- [ ] normal 면접 진행 시 뉴스가 1회만 수집(재수집 없음)되는지 확인
- [ ] 같은 공고로 재시작 시 캐시 히트로 즉시 진행되는지 확인
- [ ] 캐시 미스/만료 시 라이브 크롤 폴백 동작 확인
- [ ] easy/tutorial은 뉴스 미사용으로 영향 없는지 확인

Closes #177