### PR TITLE
feat: M7 약점 기반 타겟형 연습 시스템 추가

### DIFF
--- a/app/api/practice/generate/route.ts
+++ b/app/api/practice/generate/route.ts
@@ -1,0 +1,162 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getAuthUser } from "@/lib/auth";
+import { supabaseAdmin as supabase } from "@/lib/supabase-admin";
+import {
+  generatePracticeQuestion,
+  type PracticeContext,
+} from "@/lib/practice-generator";
+import type { DimensionId } from "@/lib/rubric";
+import type { AgentEvaluation, AgentFinalOpinion } from "@/lib/agents";
+import type { Message } from "@/lib/interview";
+import { buildProfileSummary } from "@/lib/interview";
+import { loadProfileContext } from "@/lib/interview-context";
+import { RUBRIC_DIMENSIONS } from "@/lib/rubric";
+
+export const maxDuration = 300;
+
+const VALID_DIMENSION_IDS: DimensionId[] = [
+  "motivation_specificity",
+  "company_understanding",
+  "org_fit",
+  "ownership",
+  "action_concreteness",
+  "result_reproducibility",
+  "tech_actual_use",
+  "tech_reasoning",
+  "tech_ownership",
+];
+
+/**
+ * 차원 → 해당 차원이 속한 에이전트의 평가에서 약점 인용·verdict 추출.
+ * AgentEvaluation의 자연어 필드(opinion, highlights, verdict)를 활용.
+ */
+function extractWeaknessEvidence(
+  dimensionId: DimensionId,
+  evaluations: (AgentEvaluation | AgentFinalOpinion)[],
+): { answerQuote?: string; verdict?: string } {
+  const dim = RUBRIC_DIMENSIONS.find((d) => d.id === dimensionId);
+  if (!dim) return {};
+
+  // 같은 에이전트의 평가 찾기
+  const evalForAgent = evaluations.find((e) => e.agentId === dim.agentId);
+  if (!evalForAgent) return {};
+
+  // opinion + highlights를 합쳐서 따옴표 안의 직접 인용 찾기 (예: "프로젝트가 성공적이었다")
+  const text = [
+    evalForAgent.opinion ?? "",
+    ...(evalForAgent.highlights ?? []),
+  ].join(" ");
+
+  // 한글/영문 따옴표 모두 잡기
+  const quoteMatches = text.match(/[""'"][^""'"]{8,200}[""'"]/g) ?? [];
+
+  return {
+    answerQuote: quoteMatches[0]?.replace(/^[""'"]|[""'"]$/g, "").trim() || undefined,
+    verdict: evalForAgent.verdict || undefined,
+  };
+}
+
+/**
+ * 메시지에서 면접관이 한 질문만 추출.
+ */
+function extractInterviewerQuestions(messages: Message[]): string[] {
+  return messages
+    .filter((m) => m.role === "interviewer" && m.content?.trim())
+    .map((m) => m.content.trim());
+}
+
+export async function POST(request: NextRequest) {
+  try {
+    const userId = await getAuthUser();
+    if (!userId) {
+      return NextResponse.json({ error: "로그인이 필요합니다" }, { status: 401 });
+    }
+
+    const body = await request.json();
+    const { dimensionId, sessionId } = body as {
+      dimensionId: DimensionId;
+      sessionId?: string;
+    };
+
+    if (!VALID_DIMENSION_IDS.includes(dimensionId)) {
+      return NextResponse.json(
+        { error: "유효하지 않은 차원입니다" },
+        { status: 400 },
+      );
+    }
+
+    const ctx: PracticeContext = { dimensionId };
+
+    // ── 지원자 실제 이력 로드 (환각 방지) ─────────────────────
+    try {
+      const profile = await loadProfileContext(userId);
+      if (profile) {
+        ctx.userProfileSummary = buildProfileSummary(profile);
+      }
+    } catch (e) {
+      console.warn("프로필 로드 실패 (무시됨):", e);
+    }
+
+    if (sessionId) {
+      // ── 세션 + 메시지 + 평가 일괄 로드 ─────────────────────
+      const { data: session } = await supabase
+        .from("interview_sessions")
+        .select(
+          "jobPostingId, userId, messages, agentEvaluations, agentFinalOpinions",
+        )
+        .eq("id", sessionId)
+        .eq("userId", userId)
+        .maybeSingle();
+
+      if (session) {
+        // 면접 이력 — 면접관 질문 목록 (중복 방지용)
+        const messages = (session.messages ?? []) as unknown as Message[];
+        if (Array.isArray(messages)) {
+          ctx.previousQuestions = extractInterviewerQuestions(messages);
+        }
+
+        // 약점 증거 — Round 3 finalOpinions 우선, 없으면 Round 0
+        const evaluations = ((session.agentFinalOpinions ??
+          session.agentEvaluations ??
+          []) as unknown) as (AgentEvaluation | AgentFinalOpinion)[];
+        if (Array.isArray(evaluations) && evaluations.length > 0) {
+          const ev = extractWeaknessEvidence(dimensionId, evaluations);
+          ctx.weaknessAnswerQuote = ev.answerQuote;
+          ctx.weaknessVerdict = ev.verdict;
+        }
+
+        // ── 채용공고 전체 필드 로드 ─────────────────────────
+        if (session.jobPostingId) {
+          const { data: posting } = await supabase
+            .from("job_postings")
+            .select(
+              "companyName, divisionName, responsibilities, requirements, preferredQuals, companyDescription, companyCulture, techStack",
+            )
+            .eq("id", session.jobPostingId)
+            .maybeSingle();
+
+          if (posting) {
+            ctx.companyName = posting.companyName;
+            ctx.divisionName = posting.divisionName;
+            ctx.responsibilities = posting.responsibilities;
+            ctx.requirements = posting.requirements;
+            ctx.preferredQuals = posting.preferredQuals;
+            ctx.companyDescription = posting.companyDescription;
+            ctx.companyCulture = posting.companyCulture;
+            ctx.techStack = posting.techStack;
+          }
+        }
+      }
+    }
+
+    const question = await generatePracticeQuestion(ctx);
+
+    return NextResponse.json(question);
+  } catch (error) {
+    console.error("Practice generate error:", error);
+    return NextResponse.json(
+      { error: "연습 문제 생성 중 오류가 발생했습니다" },
+      { status: 500 },
+    );
+  }
+}

--- a/app/api/practice/score/route.ts
+++ b/app/api/practice/score/route.ts
@@ -1,0 +1,65 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getAuthUser } from "@/lib/auth";
+import { scorePracticeAnswer } from "@/lib/practice-scorer";
+import type { DimensionId } from "@/lib/rubric";
+
+export const maxDuration = 300;
+
+const VALID_DIMENSION_IDS: DimensionId[] = [
+  "motivation_specificity",
+  "company_understanding",
+  "org_fit",
+  "ownership",
+  "action_concreteness",
+  "result_reproducibility",
+  "tech_actual_use",
+  "tech_reasoning",
+  "tech_ownership",
+];
+
+export async function POST(request: NextRequest) {
+  try {
+    const userId = await getAuthUser();
+    if (!userId) {
+      return NextResponse.json({ error: "로그인이 필요합니다" }, { status: 401 });
+    }
+
+    const body = await request.json();
+    const { dimensionId, question, answer } = body as {
+      dimensionId: DimensionId;
+      question: string;
+      answer: string;
+    };
+
+    if (!VALID_DIMENSION_IDS.includes(dimensionId)) {
+      return NextResponse.json(
+        { error: "유효하지 않은 차원입니다" },
+        { status: 400 },
+      );
+    }
+
+    if (!question?.trim() || !answer?.trim()) {
+      return NextResponse.json(
+        { error: "질문과 답변이 모두 필요합니다" },
+        { status: 400 },
+      );
+    }
+
+    if (answer.length > 4000) {
+      return NextResponse.json(
+        { error: "답변이 너무 깁니다 (4000자 이하)" },
+        { status: 400 },
+      );
+    }
+
+    const result = await scorePracticeAnswer(dimensionId, question, answer);
+
+    return NextResponse.json(result);
+  } catch (error) {
+    console.error("Practice score error:", error);
+    return NextResponse.json(
+      { error: "답변 채점 중 오류가 발생했습니다" },
+      { status: 500 },
+    );
+  }
+}

--- a/app/sessions/[id]/page.tsx
+++ b/app/sessions/[id]/page.tsx
@@ -77,6 +77,7 @@ export default async function SessionDetailPage({
         {/* 상태별 본문 */}
         {session.status === "done" ? (
           <SessionDetailResult
+            sessionId={session.id}
             data={{
               finalScore: session.finalScore ?? 0,
               agentEvaluations: (session.agentEvaluations ?? []) as unknown as AgentEvaluation[],

--- a/components/DebateResult.tsx
+++ b/components/DebateResult.tsx
@@ -3,6 +3,9 @@
 import type { AgentEvaluation, AgentFinalOpinion } from "@/lib/agents";
 import type { AgentId } from "@/lib/interview";
 import { AGENT_ORDER } from "@/lib/interview";
+import { diagnoseWeaknesses } from "@/lib/weakness-diagnoser";
+import { buildHattieFeedbackList } from "@/lib/hattie-feedback";
+import WeaknessFeedbackCard from "@/components/WeaknessFeedbackCard";
 
 interface Props {
   finalScore: number;
@@ -22,6 +25,8 @@ interface Props {
   onRestart?: () => void;
   onBack: () => void;
   isHistory?: boolean;
+  /** 약점 기반 연습 문제 생성 시 채용공고 컨텍스트 로드용 */
+  sessionId?: string;
 }
 
 function stripMd(text: string): string {
@@ -113,12 +118,20 @@ export default function DebateResult({
   onRestart,
   onBack,
   isHistory = false,
+  sessionId,
 }: Props) {
   const displayEvaluations: (AgentEvaluation | AgentFinalOpinion)[] =
     (agentFinalOpinions && agentFinalOpinions.length > 0 ? agentFinalOpinions : agentEvaluations) ?? [];
   const isFinalOpinion = agentFinalOpinions && agentFinalOpinions.length > 0;
 
   const hasScores = displayEvaluations.some((e) => e.score != null);
+
+  // 약점 진단 + Hattie 3질문 피드백 패키지 생성 (LLM 호출 없는 순수 변환)
+  const weaknesses = diagnoseWeaknesses(
+    { agentEvaluations, agentFinalOpinions },
+    { limit: 2 },
+  );
+  const hattieFeedback = buildHattieFeedbackList(weaknesses);
 
   return (
     <div className="space-y-6">
@@ -291,6 +304,30 @@ export default function DebateResult({
               </li>
             ))}
           </ul>
+        </div>
+      )}
+
+      {/* 약점 기반 맞춤 피드백 — Hattie & Timperley(2007) 3질문 모델 */}
+      {hattieFeedback.length > 0 && (
+        <div className="space-y-3">
+          <div className="px-1 space-y-1">
+            <h3 className="font-bold text-gray-900 dark:text-slate-50 flex items-center gap-2">
+              <span>🎯</span>
+              <span>약점 기반 맞춤 피드백</span>
+            </h3>
+            <p className="text-xs text-gray-400 dark:text-slate-500">
+              평가에서 식별한 핵심 약점 {hattieFeedback.length}가지를 목표 · 현재 상태 · 다음 행동의 3단계로 안내합니다
+            </p>
+          </div>
+          {hattieFeedback.map((pkg, i) => (
+            <WeaknessFeedbackCard
+              key={pkg.dimensionId}
+              pkg={pkg}
+              agentId={pkg.agentId}
+              index={i + 1}
+              sessionId={sessionId}
+            />
+          ))}
         </div>
       )}
 

--- a/components/SessionDetailResult.tsx
+++ b/components/SessionDetailResult.tsx
@@ -6,9 +6,10 @@ import type { DebateResultData } from "@/components/DebateLoading";
 
 interface Props {
   data: DebateResultData;
+  sessionId?: string;
 }
 
-export default function SessionDetailResult({ data }: Props) {
+export default function SessionDetailResult({ data, sessionId }: Props) {
   const router = useRouter();
   return (
     <DebateResult
@@ -20,6 +21,7 @@ export default function SessionDetailResult({ data }: Props) {
       improvementTips={data.improvementTips}
       onBack={() => router.push("/history")}
       isHistory
+      sessionId={sessionId}
     />
   );
 }

--- a/components/WeaknessFeedbackCard.tsx
+++ b/components/WeaknessFeedbackCard.tsx
@@ -1,0 +1,531 @@
+"use client";
+
+import { useState, useRef } from "react";
+import type { HattieFeedbackPackage } from "@/lib/hattie-feedback";
+import type { AgentId } from "@/lib/interview";
+import type { PracticeQuestion } from "@/lib/practice-generator";
+import type { ScoreResult } from "@/lib/practice-scorer";
+import { useSpeechRecognition } from "@/hooks/useSpeechRecognition";
+
+const AGENT_STYLES: Record<AgentId, {
+  border: string;
+  badge: string;
+  accent: string;
+  dot: string;
+  btn: string;
+  btnHover: string;
+}> = {
+  organization: {
+    border: "border-purple-200 dark:border-purple-900/40",
+    badge: "bg-purple-100 dark:bg-purple-900/40 text-purple-700 dark:text-purple-300",
+    accent: "text-purple-700 dark:text-purple-300",
+    dot: "bg-purple-400",
+    btn: "bg-purple-600 dark:bg-purple-700 text-white",
+    btnHover: "hover:bg-purple-700 dark:hover:bg-purple-600",
+  },
+  logic: {
+    border: "border-blue-200 dark:border-blue-900/40",
+    badge: "bg-blue-100 dark:bg-blue-900/40 text-blue-700 dark:text-blue-300",
+    accent: "text-blue-700 dark:text-blue-300",
+    dot: "bg-blue-400",
+    btn: "bg-blue-600 dark:bg-blue-700 text-white",
+    btnHover: "hover:bg-blue-700 dark:hover:bg-blue-600",
+  },
+  technical: {
+    border: "border-green-200 dark:border-green-900/40",
+    badge: "bg-green-100 dark:bg-green-900/40 text-green-700 dark:text-green-300",
+    accent: "text-green-700 dark:text-green-300",
+    dot: "bg-green-400",
+    btn: "bg-green-600 dark:bg-green-700 text-white",
+    btnHover: "hover:bg-green-700 dark:hover:bg-green-600",
+  },
+};
+
+const SEVERITY_LABEL: Record<HattieFeedbackPackage["severity"], { text: string; tone: string }> = {
+  critical: { text: "집중 보완 필요", tone: "text-red-600 dark:text-red-300" },
+  moderate: { text: "보완 권장", tone: "text-orange-600 dark:text-orange-300" },
+  minor: { text: "참고 사항", tone: "text-gray-500 dark:text-slate-400" },
+};
+
+const ANCHOR_LABEL: Record<"low" | "mid" | "high", { text: string; tone: string; emoji: string }> = {
+  low:  { text: "초기 수준",   tone: "text-red-600 dark:text-red-300",     emoji: "🔴" },
+  mid:  { text: "중간 수준",   tone: "text-orange-600 dark:text-orange-300", emoji: "🟡" },
+  high: { text: "목표 수준 도달", tone: "text-green-600 dark:text-green-300", emoji: "🟢" },
+};
+
+type PracticeState =
+  | { phase: "idle" }
+  | { phase: "generating" }
+  | { phase: "writing"; question: PracticeQuestion; answer: string }
+  | { phase: "scoring"; question: PracticeQuestion; answer: string }
+  | { phase: "done"; question: PracticeQuestion; answer: string; result: ScoreResult }
+  | { phase: "error"; message: string; question?: PracticeQuestion; answer?: string };
+
+interface Props {
+  pkg: HattieFeedbackPackage;
+  agentId: AgentId;
+  index?: number;
+  /** 결과 페이지의 sessionId (있으면 채용공고 컨텍스트가 연습 문제에 반영됨) */
+  sessionId?: string;
+}
+
+export default function WeaknessFeedbackCard({ pkg, agentId, index, sessionId }: Props) {
+  const style = AGENT_STYLES[agentId] ?? AGENT_STYLES.organization;
+  const severity = SEVERITY_LABEL[pkg.severity];
+
+  const [practice, setPractice] = useState<PracticeState>({ phase: "idle" });
+  const [interimTranscript, setInterimTranscript] = useState("");
+  const practiceRef = useRef(practice);
+  practiceRef.current = practice;
+
+  const { isRecording, isSupported, start, stop } = useSpeechRecognition(
+    (interim) => setInterimTranscript(interim),
+    (final) => {
+      // final transcript은 writing 상태일 때만 answer에 append
+      const cur = practiceRef.current;
+      if (cur.phase === "writing") {
+        const next = (cur.answer + (cur.answer && !cur.answer.endsWith(" ") ? " " : "") + final).trimStart();
+        setPractice({ ...cur, answer: next });
+      }
+      setInterimTranscript("");
+    },
+  );
+
+  const toggleMic = () => {
+    if (isRecording) stop();
+    else start();
+  };
+
+  const generate = async () => {
+    setPractice({ phase: "generating" });
+    try {
+      const res = await fetch("/api/practice/generate", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ dimensionId: pkg.dimensionId, sessionId }),
+      });
+      if (!res.ok) {
+        const err = await res.json().catch(() => ({}));
+        throw new Error(err.error ?? `연습 문제 생성 실패 (${res.status})`);
+      }
+      const question = (await res.json()) as PracticeQuestion;
+      setPractice({ phase: "writing", question, answer: "" });
+    } catch (e) {
+      setPractice({
+        phase: "error",
+        message: e instanceof Error ? e.message : "알 수 없는 오류",
+      });
+    }
+  };
+
+  const submit = async () => {
+    if (practice.phase !== "writing") return;
+    if (!practice.answer.trim()) return;
+    if (isRecording) stop();
+    setInterimTranscript("");
+    const { question, answer } = practice;
+    setPractice({ phase: "scoring", question, answer });
+    try {
+      const res = await fetch("/api/practice/score", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          dimensionId: pkg.dimensionId,
+          question: question.question,
+          answer,
+        }),
+      });
+      if (!res.ok) {
+        const err = await res.json().catch(() => ({}));
+        throw new Error(err.error ?? `채점 실패 (${res.status})`);
+      }
+      const result = (await res.json()) as ScoreResult;
+      setPractice({ phase: "done", question, answer, result });
+    } catch (e) {
+      setPractice({
+        phase: "error",
+        message: e instanceof Error ? e.message : "알 수 없는 오류",
+        question,
+        answer,
+      });
+    }
+  };
+
+  const retry = () => {
+    if (practice.phase === "done") {
+      setPractice({ phase: "writing", question: practice.question, answer: "" });
+    } else if (practice.phase === "error" && practice.question) {
+      setPractice({ phase: "writing", question: practice.question, answer: practice.answer ?? "" });
+    } else {
+      setPractice({ phase: "idle" });
+    }
+  };
+
+  const newProblem = () => setPractice({ phase: "idle" });
+
+  return (
+    <div className={`card border-l-4 ${style.border} overflow-hidden`}>
+      {/* 헤더 */}
+      <div className="px-5 pt-5 pb-3 space-y-2">
+        <div className="flex items-center gap-2 flex-wrap">
+          {index != null && (
+            <span className={`w-6 h-6 rounded-full ${style.badge} text-xs font-bold flex items-center justify-center`}>
+              {index}
+            </span>
+          )}
+          <span className={`text-xs font-semibold px-2 py-0.5 rounded-full ${style.badge}`}>
+            {pkg.agentLabel}
+          </span>
+          <span className={`text-sm font-bold ${style.accent}`}>{pkg.dimensionLabel}</span>
+          <span className={`text-xs font-medium ${severity.tone}`}>· {severity.text}</span>
+        </div>
+      </div>
+
+      {/* Q1. Feed Up */}
+      <Section
+        emoji="🎯"
+        title="Where am I going?"
+        subtitle="목표가 무엇인가?"
+      >
+        <p className="text-sm text-gray-700 dark:text-slate-300 leading-relaxed">{pkg.feedUp.goal}</p>
+        <div className="mt-3 bg-gray-50 dark:bg-slate-800/50 rounded-lg p-3">
+          <p className="text-xs text-gray-400 dark:text-slate-500 font-medium mb-1">목표 수준의 답변은</p>
+          <p className="text-xs text-gray-600 dark:text-slate-300 leading-relaxed">{pkg.feedUp.targetBehavior}</p>
+        </div>
+      </Section>
+
+      {/* Q2. Feed Back */}
+      <Section
+        emoji="🔍"
+        title="How am I going?"
+        subtitle="목표를 향해 어떤 진전이 이루어지고 있는가?"
+      >
+        <p className="text-sm text-gray-700 dark:text-slate-300 leading-relaxed">{pkg.feedBack.currentBehavior}</p>
+        {pkg.feedBack.evidenceQuotes.length > 0 && (
+          <div className="mt-3 space-y-1.5">
+            <p className="text-xs text-gray-400 dark:text-slate-500 font-medium">평가에서 발견한 근거</p>
+            <ul className="space-y-1">
+              {pkg.feedBack.evidenceQuotes.map((q, i) => (
+                <li key={i} className="text-xs text-gray-600 dark:text-slate-400 leading-relaxed border-l-2 border-gray-200 dark:border-slate-700 pl-3 italic">
+                  {q}
+                </li>
+              ))}
+            </ul>
+          </div>
+        )}
+        {pkg.feedBack.verdict && (
+          <div className="mt-3 border-l-2 border-gray-300 dark:border-slate-600 pl-3">
+            <p className="text-xs text-gray-400 dark:text-slate-500 mb-0.5">핵심 피드백</p>
+            <p className="text-xs text-gray-700 dark:text-slate-300 italic leading-relaxed">{pkg.feedBack.verdict}</p>
+          </div>
+        )}
+      </Section>
+
+      {/* Q3. Feed Forward */}
+      <Section
+        emoji="🚀"
+        title="Where to next?"
+        subtitle="더 나은 진전을 이루기 위해 어떤 활동을 수행해야 하는가?"
+      >
+        <div className="space-y-2">
+          <div className="flex items-center gap-2">
+            <span className={`w-1.5 h-1.5 rounded-full ${style.dot}`} />
+            <p className="text-xs font-semibold text-gray-700 dark:text-slate-200">{pkg.feedForward.process.title}</p>
+          </div>
+          <p className="text-sm text-gray-700 dark:text-slate-300 leading-relaxed pl-3.5">{pkg.feedForward.process.guide}</p>
+        </div>
+        <div className="space-y-2 mt-4">
+          <div className="flex items-center gap-2">
+            <span className={`w-1.5 h-1.5 rounded-full ${style.dot}`} />
+            <p className="text-xs font-semibold text-gray-700 dark:text-slate-200">{pkg.feedForward.selfRegulation.title}</p>
+          </div>
+          <ul className="space-y-1.5 pl-3.5">
+            {pkg.feedForward.selfRegulation.checklist.map((item, i) => (
+              <li key={i} className="flex gap-2 text-sm text-gray-600 dark:text-slate-300">
+                <span className="text-gray-300 dark:text-slate-600 shrink-0 mt-0.5">☐</span>
+                <span className="leading-relaxed">{item}</span>
+              </li>
+            ))}
+          </ul>
+        </div>
+      </Section>
+
+      {/* 🆕 연습 문제 */}
+      <div className="px-5 py-4 bg-gray-50/50 dark:bg-slate-800/30">
+        <div className="flex items-center gap-2 mb-3">
+          <span className="text-base">📝</span>
+          <h4 className="text-sm font-bold text-gray-900 dark:text-slate-50">연습 문제로 풀어보기</h4>
+          <span className="text-xs text-gray-400 dark:text-slate-500">· 이 차원만 타겟</span>
+        </div>
+
+        {practice.phase === "idle" && (
+          <button
+            onClick={generate}
+            className={`${style.btn} ${style.btnHover} text-sm font-semibold px-4 py-2 rounded-lg transition-colors`}
+          >
+            연습 문제 생성하기
+          </button>
+        )}
+
+        {practice.phase === "generating" && (
+          <div className="text-sm text-gray-500 dark:text-slate-400 flex items-center gap-2">
+            <Spinner /> 연습 문제를 만드는 중... (10~30초)
+          </div>
+        )}
+
+        {(practice.phase === "writing" || practice.phase === "scoring") && (
+          <div className="space-y-3">
+            <div className="bg-white dark:bg-slate-900 rounded-lg p-3 border border-gray-200 dark:border-slate-700">
+              <p className="text-xs text-gray-400 dark:text-slate-500 font-medium mb-1">📌 질문</p>
+              <p className="text-sm text-gray-800 dark:text-slate-100 leading-relaxed font-medium">
+                {practice.question.question}
+              </p>
+              {practice.question.hint && (
+                <p className="text-xs text-gray-500 dark:text-slate-400 mt-2 leading-relaxed">
+                  💡 {practice.question.hint}
+                </p>
+              )}
+            </div>
+
+            <div className="relative">
+              <textarea
+                value={practice.answer}
+                onChange={(e) => {
+                  if (practice.phase === "writing") {
+                    setPractice({ ...practice, answer: e.target.value });
+                  }
+                }}
+                disabled={practice.phase === "scoring"}
+                placeholder="답변을 작성하거나 🎤 버튼으로 음성 입력하세요..."
+                className="w-full min-h-[120px] p-3 rounded-lg border border-gray-200 dark:border-slate-700 bg-white dark:bg-slate-900 text-sm text-gray-800 dark:text-slate-100 focus:outline-none focus:ring-2 focus:ring-blue-300 dark:focus:ring-blue-700 disabled:opacity-60"
+                maxLength={4000}
+              />
+              {/* 음성 인식 중간 결과 — 회색으로 미리보기 */}
+              {isRecording && interimTranscript && (
+                <div className="absolute bottom-2 left-3 right-3 pointer-events-none text-sm text-gray-400 dark:text-slate-500 italic truncate bg-white/80 dark:bg-slate-900/80 px-1">
+                  … {interimTranscript}
+                </div>
+              )}
+            </div>
+
+            <div className="flex items-center justify-between gap-2 flex-wrap">
+              <div className="flex items-center gap-3">
+                <span className="text-xs text-gray-400 dark:text-slate-500">
+                  {practice.answer.length} / 4000자
+                </span>
+                {isRecording && (
+                  <span className="flex items-center gap-1.5 text-xs font-medium text-red-600 dark:text-red-300">
+                    <span className="relative flex h-2 w-2">
+                      <span className="animate-ping absolute inline-flex h-full w-full rounded-full bg-red-400 opacity-75" />
+                      <span className="relative inline-flex rounded-full h-2 w-2 bg-red-500" />
+                    </span>
+                    녹음 중
+                  </span>
+                )}
+              </div>
+              <div className="flex items-center gap-2">
+                {/* 마이크 버튼 (브라우저가 지원할 때만) */}
+                {isSupported && practice.phase === "writing" && (
+                  <button
+                    onClick={toggleMic}
+                    title={isRecording ? "녹음 정지" : "음성 입력 시작"}
+                    aria-label={isRecording ? "녹음 정지" : "음성 입력 시작"}
+                    className={`text-sm font-semibold w-9 h-9 flex items-center justify-center rounded-lg transition-colors ${
+                      isRecording
+                        ? "bg-red-500 text-white hover:bg-red-600"
+                        : "bg-gray-100 dark:bg-slate-700 text-gray-700 dark:text-slate-200 hover:bg-gray-200 dark:hover:bg-slate-600"
+                    }`}
+                  >
+                    {isRecording ? "■" : "🎤"}
+                  </button>
+                )}
+                {practice.phase === "scoring" ? (
+                  <div className="text-sm text-gray-500 dark:text-slate-400 flex items-center gap-2">
+                    <Spinner /> 채점 중...
+                  </div>
+                ) : (
+                  <button
+                    onClick={submit}
+                    disabled={!practice.answer.trim()}
+                    className={`${style.btn} ${style.btnHover} text-sm font-semibold px-4 py-2 rounded-lg transition-colors disabled:opacity-40 disabled:cursor-not-allowed`}
+                  >
+                    채점받기
+                  </button>
+                )}
+              </div>
+            </div>
+          </div>
+        )}
+
+        {practice.phase === "done" && (
+          <PracticeResult
+            question={practice.question}
+            answer={practice.answer}
+            result={practice.result}
+            onRetry={retry}
+            onNewProblem={newProblem}
+            style={style}
+          />
+        )}
+
+        {practice.phase === "error" && (
+          <div className="space-y-2">
+            <p className="text-sm text-red-600 dark:text-red-300">⚠️ {practice.message}</p>
+            <button
+              onClick={retry}
+              className="text-sm text-gray-600 dark:text-slate-300 underline"
+            >
+              다시 시도
+            </button>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function PracticeResult({
+  question,
+  answer,
+  result,
+  onRetry,
+  onNewProblem,
+  style,
+}: {
+  question: PracticeQuestion;
+  answer: string;
+  result: ScoreResult;
+  onRetry: () => void;
+  onNewProblem: () => void;
+  style: (typeof AGENT_STYLES)[AgentId];
+}) {
+  const anchor = ANCHOR_LABEL[result.anchorLevel];
+  const ringColor =
+    result.anchorLevel === "high"
+      ? "#22c55e"
+      : result.anchorLevel === "mid"
+      ? "#f59e0b"
+      : "#ef4444";
+
+  return (
+    <div className="space-y-3">
+      {/* 질문 + 답변 다시 표시 (접힘 가능) */}
+      <details className="bg-white dark:bg-slate-900 rounded-lg border border-gray-200 dark:border-slate-700">
+        <summary className="cursor-pointer p-3 text-xs text-gray-500 dark:text-slate-400 list-none flex items-center justify-between">
+          <span>📌 내가 답한 문제 보기</span>
+          <span className="text-gray-300 dark:text-slate-600">▼</span>
+        </summary>
+        <div className="px-3 pb-3 space-y-2 border-t border-gray-100 dark:border-slate-700/50 pt-2">
+          <p className="text-xs text-gray-700 dark:text-slate-300 font-medium leading-relaxed">{question.question}</p>
+          <p className="text-xs text-gray-500 dark:text-slate-400 leading-relaxed whitespace-pre-wrap">{answer}</p>
+        </div>
+      </details>
+
+      {/* 점수 + 앵커 */}
+      <div className="bg-white dark:bg-slate-900 rounded-lg p-4 border border-gray-200 dark:border-slate-700 flex items-center gap-4">
+        <ScoreCircle score={result.score} maxScore={result.maxScore} color={ringColor} />
+        <div className="flex-1 space-y-1">
+          <div className="flex items-center gap-2">
+            <span className="text-base">{anchor.emoji}</span>
+            <span className={`text-sm font-bold ${anchor.tone}`}>{anchor.text}</span>
+          </div>
+          <p className="text-xs text-gray-500 dark:text-slate-400">
+            {result.dimensionLabel} · {result.scorePercent}% 도달
+          </p>
+        </div>
+      </div>
+
+      {/* 피드백 */}
+      <div className="bg-white dark:bg-slate-900 rounded-lg p-4 border border-gray-200 dark:border-slate-700 space-y-3">
+        <div>
+          <p className="text-xs text-gray-400 dark:text-slate-500 font-medium mb-1">📋 채점 근거</p>
+          <p className="text-sm text-gray-700 dark:text-slate-300 leading-relaxed">{result.feedback}</p>
+        </div>
+        {result.strength && (
+          <div className="border-t border-gray-100 dark:border-slate-700/50 pt-3">
+            <p className="text-xs text-gray-400 dark:text-slate-500 font-medium mb-1">✅ 드러난 강점</p>
+            <p className="text-sm text-gray-700 dark:text-slate-300 leading-relaxed">{result.strength}</p>
+          </div>
+        )}
+        {result.nextStep && (
+          <div className="border-t border-gray-100 dark:border-slate-700/50 pt-3">
+            <p className="text-xs text-gray-400 dark:text-slate-500 font-medium mb-1">🚀 다음 시도에서 추가할 것</p>
+            <p className="text-sm text-gray-700 dark:text-slate-300 leading-relaxed">{result.nextStep}</p>
+          </div>
+        )}
+      </div>
+
+      {/* 액션 */}
+      <div className="flex items-center gap-2">
+        <button
+          onClick={onRetry}
+          className={`${style.btn} ${style.btnHover} text-sm font-semibold px-3 py-1.5 rounded-lg transition-colors`}
+        >
+          같은 문제 다시 풀기
+        </button>
+        <button
+          onClick={onNewProblem}
+          className="text-sm font-semibold px-3 py-1.5 rounded-lg border border-gray-200 dark:border-slate-700 text-gray-700 dark:text-slate-300 hover:bg-gray-50 dark:hover:bg-slate-800 transition-colors"
+        >
+          새 문제 만들기
+        </button>
+      </div>
+    </div>
+  );
+}
+
+function ScoreCircle({ score, maxScore, color }: { score: number; maxScore: number; color: string }) {
+  const radius = 22;
+  const stroke = 4;
+  const circumference = 2 * Math.PI * radius;
+  const ratio = maxScore > 0 ? score / maxScore : 0;
+  const offset = circumference * (1 - ratio);
+
+  return (
+    <div className="relative w-14 h-14 shrink-0">
+      <svg className="w-full h-full -rotate-90" viewBox="0 0 56 56">
+        <circle cx="28" cy="28" r={radius} fill="none" stroke="currentColor" strokeWidth={stroke} className="text-gray-100 dark:text-slate-700" />
+        <circle cx="28" cy="28" r={radius} fill="none" stroke={color} strokeWidth={stroke} strokeLinecap="round" strokeDasharray={circumference} strokeDashoffset={offset} style={{ transition: "stroke-dashoffset 0.8s ease-out" }} />
+      </svg>
+      <div className="absolute inset-0 flex flex-col items-center justify-center leading-none">
+        <span className="text-sm font-bold text-gray-800 dark:text-slate-100">{score}</span>
+        <span className="text-[10px] text-gray-400 dark:text-slate-500">/{maxScore}</span>
+      </div>
+    </div>
+  );
+}
+
+function Spinner() {
+  return (
+    <span className="inline-block w-3.5 h-3.5 border-2 border-gray-300 dark:border-slate-600 border-t-gray-600 dark:border-t-slate-300 rounded-full animate-spin" />
+  );
+}
+
+function Section({
+  emoji,
+  title,
+  subtitle,
+  children,
+}: {
+  emoji: string;
+  title: string;
+  subtitle: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <div className="px-5 py-4 border-b border-gray-100 dark:border-slate-700/50">
+      <div className="mb-3">
+        <div className="flex items-start gap-2">
+          <span className="text-base leading-6">{emoji}</span>
+          <h4 className="text-sm font-bold text-gray-900 dark:text-slate-50 leading-6">
+            {title}
+          </h4>
+        </div>
+        <p className="text-xs text-gray-400 dark:text-slate-500 ml-7 mt-1 leading-relaxed">
+          {subtitle}
+        </p>
+      </div>
+      <div className="pl-7">{children}</div>
+    </div>
+  );
+}

--- a/lib/hattie-feedback.ts
+++ b/lib/hattie-feedback.ts
@@ -1,0 +1,131 @@
+/**
+ * Hattie & Timperley (2007) 피드백 모델 패키저
+ *
+ * 약점 차원 + 평가 데이터를 Hattie의 3 질문 구조로 재포장합니다.
+ *   Q1. "Where am I going?"  (Feed Up)
+ *   Q2. "How am I going?"    (Feed Back)
+ *   Q3. "Where to next?"     (Feed Forward)
+ *
+ * 근거: Hattie & Timperley (2007). The power of feedback.
+ *       Review of Educational Research, 77(1), 81–112, p. 86.
+ *
+ * 본 모듈은 LLM 호출 없이 rubric.ts + weakness-diagnoser 결과로만 동작.
+ */
+
+import {
+  getDimension,
+  scoreToAnchorLevel,
+  type DimensionId,
+} from "@/lib/rubric";
+import type { AgentId } from "@/lib/interview";
+import type { WeaknessDimension } from "@/lib/weakness-diagnoser";
+
+export interface HattieFeedbackPackage {
+  /** 약점 차원 메타 */
+  dimensionId: DimensionId;
+  dimensionLabel: string;
+  agentId: AgentId;
+  agentLabel: string;
+  agentScore: number;
+  /** low/mid/high 추정 (에이전트 점수 기반) */
+  estimatedLevel: "low" | "mid" | "high" | null;
+  severity: WeaknessDimension["severity"];
+
+  /** Q1. Feed Up — "어디로 가야 하는가?" */
+  feedUp: {
+    goal: string;
+    /** high anchor (목표 수준의 행동 묘사) */
+    targetBehavior: string;
+  };
+
+  /** Q2. Feed Back — "지금 어디에 있는가?" */
+  feedBack: {
+    summary: string;
+    /** 평가에서 추출한 직접 인용 (왜 약점인지의 근거) */
+    evidenceQuotes: string[];
+    /** 평가의 핵심 피드백 1문장 */
+    verdict: string;
+    /** 현재 추정 수준에 해당하는 행동 묘사 */
+    currentBehavior: string;
+  };
+
+  /** Q3. Feed Forward — "다음에 무엇을 할 것인가?" */
+  feedForward: {
+    /** Process 수준: 어떻게 개선할 것인가 (가장 효과적) */
+    process: {
+      title: string;
+      guide: string;
+    };
+    /** Self-regulation 수준: 스스로 점검할 체크리스트 */
+    selfRegulation: {
+      title: string;
+      checklist: string[];
+    };
+  };
+}
+
+/**
+ * 약점 차원 1개를 Hattie 3 질문 패키지로 변환.
+ */
+export function buildHattieFeedback(
+  weakness: WeaknessDimension,
+): HattieFeedbackPackage | null {
+  const dim = getDimension(weakness.dimensionId);
+  if (!dim) return null;
+
+  const estimatedLevel = scoreToAnchorLevel(
+    weakness.dimensionId,
+    weakness.agentScore * (dim.maxScore / 100), // 에이전트 점수를 차원 척도로 환산
+  );
+
+  const currentAnchor =
+    estimatedLevel === "high"
+      ? dim.anchors.high
+      : estimatedLevel === "mid"
+      ? dim.anchors.mid
+      : dim.anchors.low;
+
+  return {
+    dimensionId: dim.id,
+    dimensionLabel: dim.label,
+    agentId: dim.agentId,
+    agentLabel: weakness.agentLabel,
+    agentScore: weakness.agentScore,
+    estimatedLevel,
+    severity: weakness.severity,
+
+    feedUp: {
+      goal: dim.feedUp,
+      targetBehavior: dim.anchors.high.description,
+    },
+
+    feedBack: {
+      summary: `${dim.label} 차원에서 보완이 필요합니다 (${weakness.agentLabel} 평가).`,
+      evidenceQuotes: weakness.evidence,
+      verdict: weakness.verdict,
+      currentBehavior: currentAnchor.description,
+    },
+
+    feedForward: {
+      process: {
+        title: "다음 답변에서 이렇게 시도해보세요",
+        guide: dim.processGuide,
+      },
+      selfRegulation: {
+        title: "답변 전·후 스스로 점검해보세요",
+        checklist: dim.selfRegChecklist,
+      },
+    },
+  };
+}
+
+/**
+ * 약점 리스트를 일괄 변환.
+ */
+export function buildHattieFeedbackList(
+  weaknesses: WeaknessDimension[],
+): HattieFeedbackPackage[] {
+  return weaknesses
+    .map(buildHattieFeedback)
+    .filter((p): p is HattieFeedbackPackage => p !== null);
+}

--- a/lib/practice-generator.ts
+++ b/lib/practice-generator.ts
@@ -1,0 +1,257 @@
+/**
+ * 약점 기반 타겟 연습 문제 생성기
+ *
+ * 차원 특성에 따른 질문 유형 자동 선택:
+ *   - motivation_specificity, company_understanding → Situational (회사 맥락 시나리오)
+ *   - org_fit, ownership, action_concreteness, result_reproducibility → 과거 경험 회상 (PBDI)
+ *   - tech_actual_use, tech_reasoning, tech_ownership → 기술 경험 회상
+ *
+ * v2: 면접 이력·약점 증거·채용공고 전체 필드 반영으로 퀄리티 강화.
+ */
+
+import { callLLM } from "@/lib/runpod-client";
+import { getDimension, type DimensionId } from "@/lib/rubric";
+
+export interface PreviousQA {
+  question: string;
+  answer: string;
+}
+
+export interface PracticeContext {
+  dimensionId: DimensionId;
+
+  // ── 채용공고 전체 필드 ──────────────────────────────────────
+  companyName?: string | null;
+  divisionName?: string | null;
+  responsibilities?: string | null;
+  /** 자격요건 — 직무 필수 역량 */
+  requirements?: string | null;
+  /** 우대사항 */
+  preferredQuals?: string | null;
+  /** 회사 소개 (사업·서비스) */
+  companyDescription?: string | null;
+  /** 조직 문화 */
+  companyCulture?: string | null;
+  /** 기술스택 — Technical 차원에서 활용 */
+  techStack?: string | null;
+
+  // ── 이전 면접 이력 (중복 방지 + 약점 컨텍스트) ──────────────
+  /** 이전 면접에서 면접관이 한 질문들 — 같은 질문 반복 금지용 */
+  previousQuestions?: string[];
+  /** 약점이 드러난 사용자의 실제 답변 (해당 차원 기준) */
+  weaknessAnswerQuote?: string;
+  /** 평가에서 도출된 핵심 피드백 1문장 */
+  weaknessVerdict?: string;
+
+  // ── 지원자 실제 이력 (환각 방지) ────────────────────────────
+  /** 지원자의 학력·경력·자격증·활동 요약 — buildProfileSummary 출력 */
+  userProfileSummary?: string;
+}
+
+export interface PracticeQuestion {
+  dimensionId: DimensionId;
+  dimensionLabel: string;
+  question: string;
+  hint: string;
+}
+
+const QUESTION_STYLE: Record<DimensionId, "situational" | "past_behavior" | "tech_recall"> = {
+  motivation_specificity: "situational",
+  company_understanding: "situational",
+  org_fit: "past_behavior",
+  ownership: "past_behavior",
+  action_concreteness: "past_behavior",
+  result_reproducibility: "past_behavior",
+  tech_actual_use: "tech_recall",
+  tech_reasoning: "tech_recall",
+  tech_ownership: "tech_recall",
+};
+
+// ── 채용공고 컨텍스트 빌더 ────────────────────────────────────
+
+function truncate(text: string | null | undefined, max: number): string | null {
+  if (!text) return null;
+  const t = text.trim();
+  if (t.length <= max) return t;
+  return t.slice(0, max) + "...";
+}
+
+function buildJobContext(ctx: PracticeContext): string {
+  const style = QUESTION_STYLE[ctx.dimensionId];
+  const parts: string[] = [];
+
+  if (ctx.companyName) parts.push(`■ 회사: ${ctx.companyName}`);
+  if (ctx.divisionName) parts.push(`■ 사업부/직무: ${ctx.divisionName}`);
+
+  // 차원별로 가장 관련 깊은 정보 우선 노출
+  const isOrgDim = ["motivation_specificity", "company_understanding", "org_fit"]
+    .includes(ctx.dimensionId);
+  const isTechDim = style === "tech_recall";
+
+  // Organization 차원: 회사 소개·문화 우선
+  if (isOrgDim) {
+    const desc = truncate(ctx.companyDescription, 400);
+    const culture = truncate(ctx.companyCulture, 300);
+    if (desc) parts.push(`■ 회사 소개: ${desc}`);
+    if (culture) parts.push(`■ 조직 문화: ${culture}`);
+  }
+
+  // 모든 차원: 담당업무·자격요건
+  const resp = truncate(ctx.responsibilities, 400);
+  const reqs = truncate(ctx.requirements, 300);
+  if (resp) parts.push(`■ 담당업무: ${resp}`);
+  if (reqs) parts.push(`■ 자격요건: ${reqs}`);
+
+  // 우대사항은 모두에게 (직무 차별화 요소)
+  const pref = truncate(ctx.preferredQuals, 200);
+  if (pref) parts.push(`■ 우대사항: ${pref}`);
+
+  // Technical 차원: 기술스택 필수
+  if (isTechDim) {
+    const tech = truncate(ctx.techStack, 250);
+    if (tech) parts.push(`■ 기술스택: ${tech}`);
+  }
+
+  return parts.length > 0 ? parts.join("\n") : "(채용공고 정보 없음)";
+}
+
+// ── 면접 이력 + 약점 증거 빌더 ────────────────────────────────
+
+function buildHistoryContext(ctx: PracticeContext): string {
+  const blocks: string[] = [];
+
+  if (ctx.previousQuestions && ctx.previousQuestions.length > 0) {
+    const list = ctx.previousQuestions
+      .slice(-8) // 최근 8개만
+      .map((q, i) => `  ${i + 1}. ${truncate(q, 150)}`)
+      .join("\n");
+    blocks.push(`■ 이번 면접에서 이미 나온 질문 (반드시 다른 질문을 만들 것):\n${list}`);
+  }
+
+  if (ctx.weaknessAnswerQuote) {
+    blocks.push(
+      `■ 약점이 드러난 지원자 답변 (이 약점을 자극하는 새 시나리오 필요):\n  "${truncate(ctx.weaknessAnswerQuote, 350)}"`,
+    );
+  }
+
+  if (ctx.weaknessVerdict) {
+    blocks.push(`■ 평가 핵심 피드백:\n  "${truncate(ctx.weaknessVerdict, 200)}"`);
+  }
+
+  return blocks.length > 0 ? blocks.join("\n\n") : "";
+}
+
+// ── 프롬프트 ───────────────────────────────────────────────────
+
+function buildSystemPrompt(): string {
+  return `당신은 면접 코치입니다. 지원자의 특정 약점 차원을 정확히 타겟하는 단일 면접 연습 질문을 만듭니다.
+
+원칙:
+1. 질문은 1~3문장. 짧고 명확하게.
+2. 약점 차원만 자극할 것. 다른 차원은 답변자가 우회할 수 있게 설계.
+3. 이번 면접에서 이미 나온 질문과 중복 금지. 다른 시나리오·다른 각도로 변형.
+4. 약점이 드러났던 지원자의 실제 답변 패턴을 참고해, 같은 약점이 또 드러날 수 있는 상황을 새로 설계.
+5. 반드시 JSON만 응답. 다른 텍스트 금지.
+
+⚠️ 환각 절대 금지 — 다음을 반드시 지킬 것:
+- 채용공고에 명시되지 않은 기술/도구/방법론을 가정하지 말 것
+  (예: 채용공고에 Kafka, Spark, Airflow 등이 없으면 그런 기술 경험 질문 절대 금지)
+- 지원자 이력에 없는 경력/프로젝트/역할을 가정하지 말 것
+- 채용공고나 지원자 이력에 등장하는 어구만 사용해 질문 구성
+- 의심스러우면 일반적 표현("관련 데이터 도구", "데이터 분석 프로젝트")으로 후퇴
+- 채용공고가 마케팅·기획 직무인데 백엔드 인프라(Kafka, K8s 등)를 묻는 식의 직무 미스매치 금지
+
+응답 JSON 스키마:
+{
+  "question": "<면접 질문 1~3문장>",
+  "hint": "<답변 시 유의사항 1문장 — 무엇을 보여줘야 하는지>"
+}`;
+}
+
+function buildUserPrompt(ctx: PracticeContext): string {
+  const dim = getDimension(ctx.dimensionId);
+  if (!dim) throw new Error(`Unknown dimension: ${ctx.dimensionId}`);
+
+  const style = QUESTION_STYLE[ctx.dimensionId];
+  const styleGuide =
+    style === "situational"
+      ? "이 회사·이 직무 맥락의 가상 상황 또는 동기를 묻는 형식이 적합합니다 ('만약 ~한 상황이라면', '왜 ~를 선택했나요')."
+      : style === "past_behavior"
+      ? "지원자의 과거 실제 경험을 회상하게 하는 형식이 적합합니다 ('~했던 경험을 말씀해주세요')."
+      : "지원자의 과거 기술 사용 경험을 묻는 형식이 적합합니다 ('어떤 도구를 어떻게 사용했는지', '왜 그 기술을 선택했는지').";
+
+  const historyBlock = buildHistoryContext(ctx);
+  const profileBlock = ctx.userProfileSummary
+    ? `[지원자 실제 이력 — 이 범위 내에서만 질문]\n${truncate(ctx.userProfileSummary, 800)}\n`
+    : "";
+
+  return `[약점 차원]
+${dim.label} — ${dim.criterion}
+
+[목표 (Feed Up)]
+${dim.feedUp}
+
+[목표 수준의 답변 묘사]
+${dim.anchors.high.description}
+
+[질문 유형 가이드]
+${styleGuide}
+
+[채용공고 컨텍스트 — 이 범위 내에서만 기술/도구/사업 인용]
+${buildJobContext(ctx)}
+
+${profileBlock}
+${historyBlock ? `[이번 면접 이력 — 반드시 반영]\n${historyBlock}\n` : ""}
+위 약점 차원을 정확히 자극하는 면접 질문 1개를 만들어주세요.
+
+핵심 요구사항:
+- 다른 차원(주도성/구체성 등)은 답변자가 우회 가능하게 설계
+- ${dim.label}만큼은 반드시 드러나야만 답할 수 있는 질문
+- 이번 면접에서 이미 나온 질문과 중복되지 않게 다른 시나리오로
+- 채용공고에 등장하는 기술/도구/사업/자격요건만 사용 (없는 기술 절대 가정 금지)
+- 지원자 이력 범위 안에서 답변 가능한 질문 (이력에 없는 경험을 강요하지 말 것)
+${ctx.weaknessAnswerQuote ? "- 지원자가 약점을 보였던 답변 패턴이 또 드러날 수 있는 상황 설계" : ""}
+
+JSON만 응답:`;
+}
+
+function extractJSON(raw: string): { question?: string; hint?: string } {
+  const match = raw.match(/\{[\s\S]*\}/);
+  if (!match) return {};
+  try {
+    return JSON.parse(match[0]);
+  } catch {
+    return {};
+  }
+}
+
+export async function generatePracticeQuestion(
+  ctx: PracticeContext,
+): Promise<PracticeQuestion> {
+  const dim = getDimension(ctx.dimensionId);
+  if (!dim) throw new Error(`Unknown dimension: ${ctx.dimensionId}`);
+
+  const raw = await callLLM({
+    messages: [
+      { role: "system", content: buildSystemPrompt() },
+      { role: "user", content: buildUserPrompt(ctx) },
+    ],
+    max_tokens: 500,
+    temperature: 0.5, // 환각 방지를 위해 보수적으로
+  });
+
+  const parsed = extractJSON(raw);
+  const question = (parsed.question ?? "").trim();
+  const hint = (parsed.hint ?? "").trim();
+
+  if (!question) {
+    throw new Error(`LLM did not return a valid question: ${raw.slice(0, 200)}`);
+  }
+
+  return {
+    dimensionId: dim.id,
+    dimensionLabel: dim.label,
+    question,
+    hint: hint || dim.processGuide.split(/[.→]/)[0].trim(),
+  };
+}

--- a/lib/practice-scorer.ts
+++ b/lib/practice-scorer.ts
@@ -1,0 +1,135 @@
+/**
+ * 연습 답변 채점기
+ *
+ * 1개 차원만 채점 (연습이 약점 차원 1개만 타겟하므로).
+ *
+ * 근거: Hattie & Timperley (2007). The power of feedback.
+ *       Review of Educational Research, 77(1), 81–112, p. 96.
+ *   - Self-level 피드백("잘했어요!") 배제 — 시스템 프롬프트에 명시
+ */
+
+import { callLLM } from "@/lib/runpod-client";
+import { getDimension, type DimensionId } from "@/lib/rubric";
+
+export interface ScoreResult {
+  dimensionId: DimensionId;
+  dimensionLabel: string;
+  /** 0 ~ maxScore */
+  score: number;
+  maxScore: number;
+  /** 100점 환산 */
+  scorePercent: number;
+  /** low/mid/high 중 어느 앵커에 해당하는가 */
+  anchorLevel: "low" | "mid" | "high";
+  /** Process-level 피드백 1~2문장 */
+  feedback: string;
+  /** 어떤 부분이 좋았는지 (있다면) — Process 수준만, Self level("잘했어요!") 금지 */
+  strength?: string;
+  /** 다음 시도에서 무엇을 더할지 (Feed Forward) */
+  nextStep?: string;
+}
+
+function buildSystemPrompt(): string {
+  return `당신은 면접 평가 전문가입니다. 지원자의 단일 답변을, 명시된 1개 차원에 한정해 행동 앵커 기반으로 채점합니다.
+
+원칙:
+1. 주어진 anchor(low/mid/high) 묘사를 그대로 기준으로 사용. 임의 기준 추가 금지.
+2. 점수는 0~maxScore 정수.
+3. 피드백은 Process 수준(어떻게 개선할지)만 작성. "잘했어요"·"훌륭합니다" 같은 자기참조형(Self level) 금지.
+4. 짧고 구체적으로. 모호한 칭찬·격려 금지.
+5. 반드시 JSON만 응답.
+
+응답 JSON 스키마:
+{
+  "score": <0 ~ maxScore 정수>,
+  "anchorLevel": "<low | mid | high>",
+  "feedback": "<왜 그 점수인지 1~2문장. 답변의 구체적 표현 직접 인용>",
+  "strength": "<답변에서 잘 드러난 행동 1문장. 없으면 빈 문자열>",
+  "nextStep": "<다음 답변에서 추가할 구체적 행동 1문장>"
+}`;
+}
+
+function buildUserPrompt(
+  dimensionId: DimensionId,
+  question: string,
+  answer: string,
+): string {
+  const dim = getDimension(dimensionId);
+  if (!dim) throw new Error(`Unknown dimension: ${dimensionId}`);
+
+  return `[채점 차원]
+${dim.label} (최대 ${dim.maxScore}점)
+${dim.criterion}
+
+[행동 앵커]
+low (${dim.anchors.low.range}): ${dim.anchors.low.description}
+mid (${dim.anchors.mid.range}): ${dim.anchors.mid.description}
+high (${dim.anchors.high.range}): ${dim.anchors.high.description}
+
+[질문]
+${question}
+
+[지원자 답변]
+${answer}
+
+위 답변을 ${dim.label} 차원 1개에 한정해 채점하세요. 다른 차원(예: 발음·문법·동기 등)은 고려하지 마세요.
+
+maxScore는 ${dim.maxScore}입니다. 점수는 0~${dim.maxScore} 정수로 출력하세요.
+
+JSON만 응답:`;
+}
+
+function extractJSON(raw: string): Partial<ScoreResult> & {
+  anchorLevel?: string;
+  score?: number;
+} {
+  const match = raw.match(/\{[\s\S]*\}/);
+  if (!match) return {};
+  try {
+    return JSON.parse(match[0]);
+  } catch {
+    return {};
+  }
+}
+
+function clampAnchor(value: string | undefined): "low" | "mid" | "high" {
+  if (value === "high") return "high";
+  if (value === "mid") return "mid";
+  return "low";
+}
+
+export async function scorePracticeAnswer(
+  dimensionId: DimensionId,
+  question: string,
+  answer: string,
+): Promise<ScoreResult> {
+  const dim = getDimension(dimensionId);
+  if (!dim) throw new Error(`Unknown dimension: ${dimensionId}`);
+
+  const raw = await callLLM({
+    messages: [
+      { role: "system", content: buildSystemPrompt() },
+      { role: "user", content: buildUserPrompt(dimensionId, question, answer) },
+    ],
+    max_tokens: 500,
+    temperature: 0.3, // 채점은 일관성 우선
+  });
+
+  const parsed = extractJSON(raw);
+
+  const rawScore = typeof parsed.score === "number" ? parsed.score : 0;
+  const score = Math.max(0, Math.min(dim.maxScore, Math.round(rawScore)));
+  const anchorLevel = clampAnchor(parsed.anchorLevel);
+
+  return {
+    dimensionId: dim.id,
+    dimensionLabel: dim.label,
+    score,
+    maxScore: dim.maxScore,
+    scorePercent: Math.round((score / dim.maxScore) * 100),
+    anchorLevel,
+    feedback: (parsed.feedback ?? "").toString().trim() || "채점 결과를 받지 못했습니다.",
+    strength: (parsed.strength ?? "").toString().trim() || undefined,
+    nextStep: (parsed.nextStep ?? "").toString().trim() || undefined,
+  };
+}

--- a/lib/rubric.ts
+++ b/lib/rubric.ts
@@ -1,0 +1,416 @@
+/**
+ * 면접 평가 루브릭 — 단일 진실 원천 (Single Source of Truth)
+ *
+ * 평가·약점 진단·연습 채점이 모두 동일한 기준을 공유하도록 함.
+ *
+ * 근거: Hattie & Timperley (2007). The power of feedback.
+ *       Review of Educational Research, 77(1), 81–112.
+ *   - 3 질문 모델 → p. 86
+ *   - 4 수준 정의 (FT/FP/FR/FS) → p. 90
+ *   - Self level(FS) 배제 → p. 96
+ */
+
+import type { AgentId } from "@/lib/interview";
+
+export type DimensionId =
+  // Organization (HR 담당자)
+  | "motivation_specificity"
+  | "company_understanding"
+  | "org_fit"
+  // Logic (실무 팀장)
+  | "ownership"
+  | "action_concreteness"
+  | "result_reproducibility"
+  // Technical (현업 선임)
+  | "tech_actual_use"
+  | "tech_reasoning"
+  | "tech_ownership";
+
+export interface Anchor {
+  /** 점수대 (예: "0-10", "11-25", "26-40") */
+  range: string;
+  /** 이 수준에 해당하는 행동 묘사 */
+  description: string;
+}
+
+export interface RubricDimension {
+  id: DimensionId;
+  agentId: AgentId;
+  label: string;
+  /** 이 차원의 최대 배점 (예: 40, 30, 20) */
+  maxScore: number;
+  /** 차원 설명 — 평가자가 무엇을 보는가 */
+  criterion: string;
+  /** 행동 앵커 (low/mid/high) — BARS */
+  anchors: {
+    low: Anchor;
+    mid: Anchor;
+    high: Anchor;
+  };
+  /** Feed Up: "어디로 가야 하는가?" — 목표 진술 (Hattie 2007, p.86) */
+  feedUp: string;
+  /** Process-level Feed Forward: 어떻게 개선할 것인가 (가장 효과적) */
+  processGuide: string;
+  /** Self-regulation-level Feed Forward: 스스로 점검할 체크리스트 */
+  selfRegChecklist: string[];
+}
+
+// ────────────────────────────────────────────────────────────────────────────
+// Organization (HR 담당자) — "왜 하필 우리 회사인가?"
+// ────────────────────────────────────────────────────────────────────────────
+
+const ORGANIZATION_DIMENSIONS: RubricDimension[] = [
+  {
+    id: "motivation_specificity",
+    agentId: "organization",
+    label: "지원동기 구체성",
+    maxScore: 40,
+    criterion: "이 회사·이 직무여야 하는 구체적 이유가 있는가",
+    anchors: {
+      low: {
+        range: "0-15",
+        description:
+          "'성장 가능성', '비전에 공감' 같은 보편적 표현. 다른 회사로 바꿔도 그대로 통하는 답변.",
+      },
+      mid: {
+        range: "16-28",
+        description:
+          "회사명·서비스를 언급하나 본인의 경험·관심사와의 연결이 약하거나 표면적.",
+      },
+      high: {
+        range: "29-40",
+        description:
+          "이 회사·직무여야 하는 구체적 사건/근거 + 본인 경험과 명확히 연결. 다른 회사로 옮기면 성립 불가한 수준.",
+      },
+    },
+    feedUp:
+      "지원동기는 이 회사·직무여야만 하는 구체적 근거(특정 서비스·사업 방향·문화)와 본인의 경험·가치관이 연결되어야 한다.",
+    processGuide:
+      "1) 회사의 특정 서비스·사업 결정·문화 중 1가지를 명시 → 2) 본인의 어떤 경험·관심이 그것과 연결되는지 인과적으로 설명 → 3) 다른 회사가 아닌 '이' 회사여야 하는 이유로 마무리.",
+    selfRegChecklist: [
+      "이 답변을 다른 회사 이름으로 바꿔도 그대로 통하지 않는가?",
+      "회사의 구체적 사업/서비스를 1가지 이상 언급했는가?",
+      "본인 경험과의 연결고리가 명시적으로 드러나는가?",
+    ],
+  },
+  {
+    id: "company_understanding",
+    agentId: "organization",
+    label: "직무·회사 이해도",
+    maxScore: 30,
+    criterion: "채용공고·회사를 실제로 조사했다는 근거가 있는가",
+    anchors: {
+      low: {
+        range: "0-10",
+        description:
+          "회사·직무에 대한 사실관계가 모호하거나 틀림. 준비 없이 온 흔적이 명확.",
+      },
+      mid: {
+        range: "11-21",
+        description:
+          "기본 정보(주요 사업, 직무 책임)는 알지만 구체적 맥락(최근 동향, 사업부 차이)은 모름.",
+      },
+      high: {
+        range: "22-30",
+        description:
+          "회사의 최근 동향·사업 맥락·직무의 구체적 요구를 답변에 자연스럽게 녹임. 채용공고를 정독한 흔적이 분명.",
+      },
+    },
+    feedUp:
+      "회사의 최근 동향(공시·뉴스·서비스 출시)과 직무의 구체적 책임을 답변 곳곳에 자연스럽게 녹여야 한다.",
+    processGuide:
+      "1) 회사 홈페이지·공시·최근 뉴스에서 사실 3개 이상 메모 → 2) 채용공고의 '담당업무'를 본인 언어로 재진술 가능한 수준까지 학습 → 3) 답변 도중 적절한 위치에 1~2개를 자연스럽게 인용.",
+    selfRegChecklist: [
+      "회사의 최근 사업 동향을 1가지 이상 언급할 수 있는가?",
+      "채용공고의 '담당업무'를 보지 않고도 핵심 3가지를 말할 수 있는가?",
+      "내가 지원한 사업부와 다른 사업부의 차이를 설명할 수 있는가?",
+    ],
+  },
+  {
+    id: "org_fit",
+    agentId: "organization",
+    label: "조직 적합성",
+    maxScore: 30,
+    criterion: "커리어 방향이 직무와 일치하며, 기여 지향인가",
+    anchors: {
+      low: {
+        range: "0-10",
+        description:
+          "'배우고 싶다'는 수혜 지향 표현 중심. 커리어와의 일관성 부족. 이직자라면 이전 회사에 대한 부정적 톤.",
+      },
+      mid: {
+        range: "11-21",
+        description:
+          "커리어 방향은 일관되나 '내가 무엇을 기여할지'에 대한 구체성이 약함.",
+      },
+      high: {
+        range: "22-30",
+        description:
+          "커리어 흐름이 직무와 명확히 일치 + '내가 가진 X로 회사의 Y에 기여하겠다'는 기여 지향. 이직 사유도 긍정적·발전적.",
+      },
+    },
+    feedUp:
+      "지금까지 커리어가 이 직무로 자연스럽게 이어지며, 본인이 가진 강점으로 회사에 무엇을 기여할지가 명확해야 한다.",
+    processGuide:
+      "1) 본인 커리어를 1줄 narrative로 정리 → 2) 그 흐름이 이 직무와 어떻게 연결되는지 명시 → 3) '배우고 싶다' 대신 '~을 가지고 ~에 기여하겠다'로 표현 전환.",
+    selfRegChecklist: [
+      "답변에 '배우고 싶다'보다 '기여하겠다'가 더 많이 나오는가?",
+      "내 커리어 흐름이 이 직무로 이어지는 이유를 1문장으로 말할 수 있는가?",
+      "이직자라면, 이전 회사에 대한 부정적 표현 없이 이직 사유를 설명했는가?",
+    ],
+  },
+];
+
+// ────────────────────────────────────────────────────────────────────────────
+// Logic (실무 팀장) — "내 팀에서 실제로 어떻게 일할 사람인가?"
+// ────────────────────────────────────────────────────────────────────────────
+
+const LOGIC_DIMENSIONS: RubricDimension[] = [
+  {
+    id: "ownership",
+    agentId: "logic",
+    label: "경험 주도성",
+    maxScore: 40,
+    criterion: "'우리 팀이 했다'와 '내가 했다'를 구분할 수 있는가",
+    anchors: {
+      low: {
+        range: "0-15",
+        description:
+          "주어가 '우리 팀'·'프로젝트'로 모호. 본인의 직접 행동이 무엇이었는지 분리되지 않음.",
+      },
+      mid: {
+        range: "16-28",
+        description:
+          "본인 행동이 일부 드러나나, 팀 결정·동료 역할과 본인 역할의 경계가 흐림.",
+      },
+      high: {
+        range: "29-40",
+        description:
+          "'내가 결정한 것'·'내가 실행한 것'이 명확히 분리됨. 팀의 일과 본인의 일이 구분되어 진술됨.",
+      },
+    },
+    feedUp:
+      "경험을 말할 때 '내가 직접 결정하고 실행한 행동'이 '팀이 한 일'과 명확히 분리되어야 한다.",
+    processGuide:
+      "1) 경험을 말하기 전 '이 부분에서 내가 직접 한 것'을 미리 분리 → 2) 답변 시 주어를 '나는'으로 명시 → 3) 팀의 일을 언급할 땐 '팀이 결정한 X 안에서 나는 Y를 맡았다'로 분리 진술.",
+    selfRegChecklist: [
+      "방금 답변에서 주어가 '나'인 문장이 몇 개인지 셀 수 있는가?",
+      "'우리 팀이'와 '내가'를 의식적으로 구분해 말했는가?",
+      "팀 성과를 본인 성과처럼 부풀려 말하지 않았는가?",
+    ],
+  },
+  {
+    id: "action_concreteness",
+    agentId: "logic",
+    label: "행동 구체성",
+    maxScore: 30,
+    criterion: "어떻게 판단·행동했는지 과정이 있는가",
+    anchors: {
+      low: {
+        range: "0-10",
+        description:
+          "'열심히 했다', '잘 해결했다'처럼 결과만 선언. 과정·방법론·판단 근거 부재.",
+      },
+      mid: {
+        range: "11-21",
+        description:
+          "행동을 일부 묘사하나 '왜 그렇게 판단했는지'의 사유 과정이 빠짐.",
+      },
+      high: {
+        range: "22-30",
+        description:
+          "상황 분석 → 옵션 비교 → 의사결정 근거 → 실행이 순서대로 드러남. 다른 선택지를 검토한 흔적까지 보임.",
+      },
+    },
+    feedUp:
+      "행동은 '무엇을 했다'가 아니라 '어떤 상황에서, 어떤 옵션 중, 왜 그것을 선택했는가'까지 보여야 한다.",
+    processGuide:
+      "1) 상황 1문장 → 2) 고려했던 선택지 2개 이상 명시 → 3) 그중 선택한 이유 → 4) 실행 방법 → 5) 결과 순서로 구조화.",
+    selfRegChecklist: [
+      "내 답변에 '왜 그렇게 했는지'의 근거가 들어있는가?",
+      "고려했지만 선택하지 않은 다른 옵션을 1개 이상 언급했는가?",
+      "'열심히', '잘'처럼 측정 불가한 부사로 끝나지 않았는가?",
+    ],
+  },
+  {
+    id: "result_reproducibility",
+    agentId: "logic",
+    label: "성과 재현 가능성",
+    maxScore: 30,
+    criterion: "성과가 본인 역량 덕인지, 운·환경 덕인지 구분 가능한가",
+    anchors: {
+      low: {
+        range: "0-10",
+        description:
+          "성과 수치 없음, 혹은 수치가 있어도 기간·기준·모집단이 빠져 검증 불가.",
+      },
+      mid: {
+        range: "11-21",
+        description:
+          "수치는 있으나 baseline(이전 대비), 기간, 측정 모집단 중 일부가 누락.",
+      },
+      high: {
+        range: "22-30",
+        description:
+          "baseline → 개입 → 결과 + 기간·모집단·측정 방법까지 명시. 동일 상황에서 재현 가능한 수준의 진술.",
+      },
+    },
+    feedUp:
+      "성과 진술은 baseline(이전 상태) → 본인의 개입 → 결과 수치 + 기간·모집단·측정 방법까지 포함되어, 다른 사람도 동일하게 재현 가능한 형태여야 한다.",
+    processGuide:
+      "1) 결과 수치 앞에 baseline(이전 값) 추가 → 2) 측정 기간 명시 (예: '3개월간') → 3) 모집단 크기 명시 (예: '300명 대상') → 4) 측정 방법 명시 (예: 'A/B 테스트로').",
+    selfRegChecklist: [
+      "내 답변에 수치가 있는가? (예: 12%, 300명, 3개월)",
+      "수치 앞에 baseline(이전 값)이 명시되어 있는가?",
+      "측정 기간과 모집단 크기를 언급했는가?",
+    ],
+  },
+];
+
+// ────────────────────────────────────────────────────────────────────────────
+// Technical (현업 선임) — "이력서에 써놓은 것들, 실제로 아는 건가?"
+// ────────────────────────────────────────────────────────────────────────────
+
+const TECHNICAL_DIMENSIONS: RubricDimension[] = [
+  {
+    id: "tech_actual_use",
+    agentId: "technical",
+    label: "기술 실사용 여부",
+    maxScore: 40,
+    criterion: "툴·방법론을 실제로 사용했는가",
+    anchors: {
+      low: {
+        range: "0-15",
+        description:
+          "개념·분야만 언급하고 구체적 툴/라이브러리/방법론 이름이 없음. ('데이터 분석을 했다'만 있고 어떤 도구인지 불명)",
+      },
+      mid: {
+        range: "16-28",
+        description:
+          "툴 이름은 나오나 본인이 직접 다룬 수준인지, 어떤 기능을 어떻게 썼는지 모호.",
+      },
+      high: {
+        range: "29-40",
+        description:
+          "구체적 툴/라이브러리/버전 + 어떤 기능을 어떤 상황에서 사용했는지 묘사. 사용 깊이가 드러남.",
+      },
+    },
+    feedUp:
+      "기술 경험은 구체적 툴·라이브러리·방법론 이름 + 어떤 기능을 어떤 상황에서 어떻게 썼는지가 드러나야 한다.",
+    processGuide:
+      "1) '데이터 분석' 같은 개념어 대신 'pandas로', 'BigQuery로' 같은 구체적 도구명 사용 → 2) 도구의 어떤 기능을 썼는지 1가지 이상 명시 → 3) 그 도구를 쓴 상황 맥락 1문장 추가.",
+    selfRegChecklist: [
+      "답변에 구체적 툴/라이브러리 이름이 1개 이상 있는가?",
+      "그 툴의 어떤 기능을 썼는지 말할 수 있는가?",
+      "직무 요건의 기술스택과 내 답변의 도구가 매칭되는가?",
+    ],
+  },
+  {
+    id: "tech_reasoning",
+    agentId: "technical",
+    label: "기술적 선택 근거",
+    maxScore: 40,
+    criterion: "왜 그 기술·방법을 선택했는지 설명할 수 있는가",
+    anchors: {
+      low: {
+        range: "0-15",
+        description:
+          "툴 이름만 나열. 왜 그것을 선택했는지 근거 부재.",
+      },
+      mid: {
+        range: "16-28",
+        description:
+          "선택 이유를 말하나 '쉬워서', '많이 써서' 수준. 다른 옵션과의 비교 없음.",
+      },
+      high: {
+        range: "29-40",
+        description:
+          "후보 기술 2개 이상 비교 → 프로젝트 제약(데이터 규모/실시간성/팀 역량 등) 기준으로 선택. 트레이드오프 인지.",
+      },
+    },
+    feedUp:
+      "기술 선택은 후보 2개 이상을 비교하고, 프로젝트 제약(규모/속도/팀 역량 등) 기준으로 선택한 근거가 보여야 한다.",
+    processGuide:
+      "1) 사용한 기술의 후보 대안 1~2개 떠올리기 → 2) 프로젝트의 핵심 제약(데이터 규모, 실시간성, 비용, 팀 역량) 식별 → 3) '제약 X 때문에 대안 Y가 아닌 Z를 선택했다'로 진술.",
+    selfRegChecklist: [
+      "선택한 기술의 대안을 1개 이상 언급했는가?",
+      "선택 이유가 '익숙해서'·'좋아서' 외에 프로젝트 제약과 연결되었는가?",
+      "트레이드오프(이 기술의 단점)도 인지하고 있는가?",
+    ],
+  },
+  {
+    id: "tech_ownership",
+    agentId: "technical",
+    label: "경험 주도성",
+    maxScore: 20,
+    criterion: "기술 구현을 본인이 주도했는가, 팀 결정을 따랐는가",
+    anchors: {
+      low: {
+        range: "0-7",
+        description:
+          "'팀이 그렇게 정해서'·'사수가 시켜서' 같은 수동적 표현 중심.",
+      },
+      mid: {
+        range: "8-14",
+        description:
+          "본인 구현 부분과 팀 결정의 경계가 모호.",
+      },
+      high: {
+        range: "15-20",
+        description:
+          "본인이 직접 설계·구현한 부분이 명확히 구분됨. 팀 결정 안에서도 본인의 선택·기여가 분명.",
+      },
+    },
+    feedUp:
+      "기술 경험에서 본인이 직접 설계·구현한 부분이 팀 결정과 명확히 구분되어 드러나야 한다.",
+    processGuide:
+      "1) 프로젝트의 어느 부분을 본인이 직접 코딩/설계했는지 미리 분리 → 2) '팀이 X를 결정했고, 그 안에서 나는 Y를 설계·구현했다'로 진술 → 3) 본인 코드의 핵심 의사결정 1가지 강조.",
+    selfRegChecklist: [
+      "내가 직접 짠 코드/설계한 부분을 구체적으로 말할 수 있는가?",
+      "팀의 결정과 내 결정을 구분해 진술했는가?",
+      "단순히 '구현했다' 외에 '왜 그렇게 구현했는지' 의사결정이 들어갔는가?",
+    ],
+  },
+];
+
+// ────────────────────────────────────────────────────────────────────────────
+// 통합 루브릭
+// ────────────────────────────────────────────────────────────────────────────
+
+export const RUBRIC_DIMENSIONS: RubricDimension[] = [
+  ...ORGANIZATION_DIMENSIONS,
+  ...LOGIC_DIMENSIONS,
+  ...TECHNICAL_DIMENSIONS,
+];
+
+/** 에이전트별 차원 묶음 */
+export const RUBRIC_BY_AGENT: Record<AgentId, RubricDimension[]> = {
+  organization: ORGANIZATION_DIMENSIONS,
+  logic: LOGIC_DIMENSIONS,
+  technical: TECHNICAL_DIMENSIONS,
+};
+
+/** ID로 차원 조회 */
+export function getDimension(id: DimensionId): RubricDimension | undefined {
+  return RUBRIC_DIMENSIONS.find((d) => d.id === id);
+}
+
+/** 에이전트의 총점 (정합성 검증용 — 항상 100이어야 함) */
+export function getAgentMaxScore(agentId: AgentId): number {
+  return RUBRIC_BY_AGENT[agentId].reduce((sum, d) => sum + d.maxScore, 0);
+}
+
+/**
+ * 점수 → 앵커 매핑 (low/mid/high 중 어느 수준인가)
+ */
+export function scoreToAnchorLevel(
+  dimensionId: DimensionId,
+  score: number,
+): "low" | "mid" | "high" | null {
+  const dim = getDimension(dimensionId);
+  if (!dim) return null;
+  const ratio = score / dim.maxScore;
+  if (ratio < 0.4) return "low";
+  if (ratio < 0.7) return "mid";
+  return "high";
+}

--- a/lib/weakness-diagnoser.ts
+++ b/lib/weakness-diagnoser.ts
@@ -1,0 +1,220 @@
+/**
+ * 약점 진단기 (Weakness Diagnoser)
+ *
+ * 면접 종료 후 저장된 agentEvaluations / agentFinalOpinions 데이터에서
+ * 9차원 중 약점 차원을 식별합니다. LLM 호출 없이 순수 함수.
+ *
+ * 학술 기반:
+ *   - Cognitive Diagnosis (ConceptKT): 개념(차원) 단위 결함 진단
+ *   - Hattie & Timperley (2007): Feed Back 단계 = 현재 약점 식별
+ *
+ * 현재 줌인터뷰의 한계:
+ *   AgentEvaluation은 에이전트 단위 통합 score(0-100)만 저장하고
+ *   차원별 점수를 직접 저장하지 않음. 따라서 휴리스틱으로 약점 차원을
+ *   추정합니다.
+ *
+ *   ① 에이전트 통합 점수가 낮은 에이전트 → 그 에이전트의 차원이 약점 후보
+ *   ② opinion/verdict/highlights 텍스트에서 차원별 키워드 매칭으로 가중치
+ *   ③ 가장 가중치 높은 1~2개 차원 반환
+ */
+
+import type { AgentEvaluation, AgentFinalOpinion } from "@/lib/agents";
+import {
+  RUBRIC_BY_AGENT,
+  type DimensionId,
+  type RubricDimension,
+} from "@/lib/rubric";
+
+export type WeaknessSeverity = "critical" | "moderate" | "minor";
+
+export interface WeaknessDimension {
+  dimensionId: DimensionId;
+  label: string;
+  agentId: RubricDimension["agentId"];
+  agentLabel: string;
+  /** 에이전트 통합 점수 (이 차원이 속한 에이전트의 score) */
+  agentScore: number;
+  /** 에이전트 점수 기반 추정 비율 (0~1). 낮을수록 약점. */
+  agentScoreRatio: number;
+  severity: WeaknessSeverity;
+  /** 평가 텍스트에서 추출한 약점 근거 (직접 인용) */
+  evidence: string[];
+  /** 평가에서 추출한 핵심 피드백 1문장 */
+  verdict: string;
+}
+
+// ────────────────────────────────────────────────────────────────────────────
+// 차원별 키워드 매칭 사전
+// — opinion/verdict/highlights 텍스트에서 어느 차원이 약점인지 추정
+// ────────────────────────────────────────────────────────────────────────────
+
+const DIMENSION_KEYWORDS: Record<DimensionId, string[]> = {
+  motivation_specificity: [
+    "지원동기", "동기", "왜 이 회사", "성장 가능성", "비전", "보편적",
+    "관심", "지원 이유", "선택한 이유",
+  ],
+  company_understanding: [
+    "회사 이해", "직무 이해", "채용공고", "준비", "조사", "정보",
+    "사업 이해", "회사에 대한",
+  ],
+  org_fit: [
+    "조직 적합", "커리어", "이직", "배우고 싶", "기여", "수혜",
+    "방향", "적합성", "맞지 않",
+  ],
+  ownership: [
+    "주도성", "주도", "내가", "우리 팀이", "팀이 했", "본인 역할",
+    "주어", "직접", "맡았", "수동",
+  ],
+  action_concreteness: [
+    "구체성", "구체적", "과정", "어떻게", "판단", "근거",
+    "열심히", "잘 해결", "결과 선언", "방법론",
+  ],
+  result_reproducibility: [
+    "성과", "수치", "기간", "기준", "모집단", "재현", "검증 불가",
+    "baseline", "측정", "성공적이었",
+  ],
+  tech_actual_use: [
+    "기술 실사용", "툴", "라이브러리", "실사용", "사용 경험",
+    "기술 사용", "도구",
+  ],
+  tech_reasoning: [
+    "선택 근거", "왜 그 기술", "대안", "트레이드오프", "비교",
+    "선택 이유", "기술적 선택",
+  ],
+  tech_ownership: [
+    "주도", "직접 구현", "팀 결정", "사수", "시켜서",
+    "설계", "구현 주도",
+  ],
+};
+
+// ────────────────────────────────────────────────────────────────────────────
+// 진단 로직
+// ────────────────────────────────────────────────────────────────────────────
+
+const AGENT_WEAKNESS_THRESHOLD = 70; // 에이전트 점수 70 미만이면 약점 에이전트
+const CRITICAL_RATIO = 0.5;
+const MODERATE_RATIO = 0.7;
+
+interface DiagnosisInput {
+  agentEvaluations: AgentEvaluation[];
+  agentFinalOpinions?: AgentFinalOpinion[];
+}
+
+/**
+ * 면접 결과에서 약점 차원 Top-N 추출.
+ * agentFinalOpinions(Round 3)가 있으면 우선 사용, 없으면 agentEvaluations(Round 0) 사용.
+ */
+export function diagnoseWeaknesses(
+  input: DiagnosisInput,
+  options: { limit?: number } = {},
+): WeaknessDimension[] {
+  const limit = options.limit ?? 2;
+
+  const source =
+    input.agentFinalOpinions && input.agentFinalOpinions.length > 0
+      ? input.agentFinalOpinions
+      : input.agentEvaluations;
+
+  if (!source || source.length === 0) return [];
+
+  const candidates: Array<WeaknessDimension & { keywordHits: number }> = [];
+
+  for (const evaluation of source) {
+    const agentScore = evaluation.score ?? 50;
+    const agentScoreRatio = agentScore / 100;
+
+    // 에이전트 점수가 임계값 이상이면 그 에이전트는 약점 없음으로 간주
+    if (agentScore >= AGENT_WEAKNESS_THRESHOLD) continue;
+
+    // 평가 텍스트 통합 (소문자화는 한글에 무의미하므로 그대로)
+    const evalText = [
+      evaluation.opinion ?? "",
+      evaluation.verdict ?? "",
+      ...(evaluation.highlights ?? []),
+    ].join("\n");
+
+    // 이 에이전트가 담당하는 차원들에 대해 키워드 매칭
+    const dims = RUBRIC_BY_AGENT[evaluation.agentId] ?? [];
+    for (const dim of dims) {
+      const keywords = DIMENSION_KEYWORDS[dim.id] ?? [];
+      let hits = 0;
+      for (const kw of keywords) {
+        if (evalText.includes(kw)) hits++;
+      }
+
+      candidates.push({
+        dimensionId: dim.id,
+        label: dim.label,
+        agentId: dim.agentId,
+        agentLabel: evaluation.agentLabel,
+        agentScore,
+        agentScoreRatio,
+        severity:
+          agentScoreRatio < CRITICAL_RATIO
+            ? "critical"
+            : agentScoreRatio < MODERATE_RATIO
+            ? "moderate"
+            : "minor",
+        evidence: extractEvidence(evalText, keywords),
+        verdict: evaluation.verdict ?? "",
+        keywordHits: hits,
+      });
+    }
+  }
+
+  // 정렬: ① 키워드 매칭 많은 순 ② 에이전트 점수 낮은 순
+  candidates.sort((a, b) => {
+    if (b.keywordHits !== a.keywordHits) return b.keywordHits - a.keywordHits;
+    return a.agentScore - b.agentScore;
+  });
+
+  // 키워드 매칭이 0인 차원만 있으면 — 에이전트 점수 낮은 순으로라도 반환
+  const filtered = candidates.filter((c) => c.keywordHits > 0);
+  const finalList = filtered.length > 0 ? filtered : candidates;
+
+  // 같은 에이전트 차원이 limit개 다 차지하지 않도록 다양성 보장 (선택)
+  const result: WeaknessDimension[] = [];
+  const seenAgents = new Set<string>();
+  for (const c of finalList) {
+    if (result.length >= limit) break;
+    // 다른 에이전트 우선, 단 후보가 부족하면 같은 에이전트도 허용
+    if (seenAgents.has(c.agentId) && result.length < limit - 1) continue;
+    const { keywordHits: _hits, ...weakness } = c;
+    void _hits;
+    result.push(weakness);
+    seenAgents.add(c.agentId);
+  }
+
+  // 다양성 필터로 부족해진 경우 채우기
+  if (result.length < limit) {
+    for (const c of finalList) {
+      if (result.length >= limit) break;
+      if (result.find((r) => r.dimensionId === c.dimensionId)) continue;
+      const { keywordHits: _hits, ...weakness } = c;
+      void _hits;
+      result.push(weakness);
+    }
+  }
+
+  return result;
+}
+
+/**
+ * 평가 텍스트에서 키워드가 등장하는 문장(또는 짧은 인용)을 추출.
+ * 사용자에게 "왜 약점인지"의 근거로 보여줄 직접 인용용.
+ */
+function extractEvidence(text: string, keywords: string[]): string[] {
+  if (!text) return [];
+  // 문장 단위 분리 (마침표·물음표·느낌표·줄바꿈)
+  const sentences = text
+    .split(/[.!?。\n]+/)
+    .map((s) => s.trim())
+    .filter((s) => s.length > 5 && s.length < 200);
+
+  const matched = sentences.filter((s) =>
+    keywords.some((kw) => s.includes(kw)),
+  );
+
+  // 중복 제거 + 최대 2개
+  return Array.from(new Set(matched)).slice(0, 2);
+}


### PR DESCRIPTION
## 요약

면접 결과 페이지에 **약점 진단 카드**와 **인라인 연습 문제 풀기·채점 UI**를 추가합니다. 평가가 끝난 뒤 사용자가 "그래서 무엇을 어떻게 개선해야 하는가"를 구체적으로 알 수 있도록 하는 것이 목적입니다.

설계는 교육학 피드백 분야의 정설인 **Hattie & Timperley (2007) 〈The Power of Feedback〉**을 직접 인용해 진행했습니다.

---

## 학술적 근거 (직접 적용)

| 적용 위치 | 출처 |
|---|---|
| 약점 카드의 3 섹션 (🎯 Where am I going? / 🔍 How am I going? / 🚀 Where to next?) | Hattie & Timperley (2007), **p. 86** |
| 채점 LLM 프롬프트의 \"Self level 피드백 금지\" 명령 | Hattie & Timperley (2007), **p. 96** |

> ⚠️ 그 외 BARS·Constructive Alignment·Deliberate Practice 등은 사후 정합성 검토 차원에서만 코드 주석에 표기. 직접 인용 구현은 위 2가지에 한정됩니다.

---

## 무엇이 들어왔나

### 신규 라이브러리 (5개)

| 파일 | 역할 |
|---|---|
| \`lib/rubric.ts\` | 9차원 단일 진실 원천 (Organization 3 + Logic 3 + Technical 3). 각 차원에 low/mid/high anchor + Feed Up 목표 + Process 가이드 + Self-regulation 체크리스트 정의 |
| \`lib/weakness-diagnoser.ts\` | \`agentEvaluations\` JSON에서 약점 차원 Top-2 추출 (휴리스틱 + 키워드 매칭, LLM 호출 없음) |
| \`lib/hattie-feedback.ts\` | 약점 차원을 Hattie 3질문 패키지로 변환 (LLM 호출 없음) |
| \`lib/practice-generator.ts\` | 약점 차원에 맞춰 LLM이 연습 면접 질문 1개 생성. **채용공고·지원자 프로필·이전 면접 질문·약점 답변 직접 인용** 모두 프롬프트에 반영 |
| \`lib/practice-scorer.ts\` | BARS anchor를 LLM 프롬프트에 직접 인용해 답변 1개 차원만 채점. Self-level 피드백 명시적 금지 |

### 신규 컴포넌트 / API (3개)

| 파일 | 역할 |
|---|---|
| \`components/WeaknessFeedbackCard.tsx\` | 약점 카드 1개 = Hattie 3섹션 + 연습 인라인 UI. 🎤 **음성 입력 지원** (기존 \`useSpeechRecognition\` 훅 재사용, Web Speech API ko-KR) |
| \`app/api/practice/generate/route.ts\` | 인증 + 세션·메시지·평가·프로필·채용공고 전체 필드 로드 후 생성기 호출 |
| \`app/api/practice/score/route.ts\` | 인증 + 채점기 호출 |

### 수정 (3개, 모두 props 연결)

- \`app/sessions/[id]/page.tsx\` — \`sessionId={session.id}\` 전달
- \`components/SessionDetailResult.tsx\` — sessionId props 추가
- \`components/DebateResult.tsx\` — \`diagnoseWeaknesses\` + \`buildHattieFeedbackList\` 호출 + 약점 카드 섹션 렌더링 (개선 포인트 다음 위치)

---

## 사용자 흐름

```
면접 종료 → 결과 페이지 (/sessions/[id])
              │
              ▼
   기존 영역 (점수·평가·토론·개선 포인트)
              │
              ▼
   🎯 약점 기반 맞춤 피드백  ← 신규
   ┌─────────────────────────────────────┐
   │ HR 담당자 · 조직 적합성 · 보완 권장  │
   │ 🎯 Where am I going? (목표 + 행동)  │
   │ 🔍 How am I going? (현재 수준 + 인용)│
   │ 🚀 Where to next?  (Process + 체크) │
   │ 📝 연습 문제 풀어보기                │
   │   ├─ 질문 생성 → textarea + 🎤      │
   │   └─ 채점받기 → 점수 + 피드백        │
   └─────────────────────────────────────┘
```

---

## 환각 방지 장치

초기 구현에서 LLM이 채용공고에 없는 기술(예: Kafka)을 가정해 묻는 환각이 발생했습니다. 다음 3가지로 대응:

1. **지원자 프로필 LLM 전달** — \`loadProfileContext\`로 학력·경력·자격증·활동을 프롬프트에 주입
2. **프롬프트 강화** — \"채용공고에 명시되지 않은 기술/도구 가정 금지\", \"지원자 이력 범위 내에서만 질문\", \"마케팅·기획 직무에 백엔드 인프라 미스매치 금지\" 명시
3. **temperature 0.85 → 0.5** — 다양성보다 정확성 우선

---

## 테스트 방법

- [ ] 로그인 → 완료된 면접 1건 필요 (\`/history\` 또는 결과 화면 진입)
- [ ] \`/sessions/[id]\` 결과 페이지 진입
- [ ] \"개선 포인트\" 아래에 \"🎯 약점 기반 맞춤 피드백\" 섹션이 보이는지 확인
- [ ] 각 약점 카드의 3 섹션 (Where am I going? / How am I going? / Where to next?) 표시 확인
- [ ] [연습 문제 생성하기] 클릭 → 10~30초 후 질문 등장
- [ ] textarea에 답변 작성 → [채점받기] → 점수·anchor·피드백 표시
- [ ] 🎤 마이크 버튼으로 음성 입력 (Chrome/Edge에서)
- [ ] [같은 문제 다시 풀기] / [새 문제 만들기] 동작 확인

---

## 알려진 한계 (향후 작업 후보)

- \`rubric.ts\`가 \`lib/agents.ts\` 평가 기준의 복제본 상태. 평가 기준 변경 시 두 곳 동기화 필요 → 향후 통합 권장
- 연습 기록 DB 저장 없음 (페이지 새로고침 시 사라짐). 향후 \`practice_sessions\` 테이블 추가하면 pre/post 향상도 추적 가능
- 면접 직후 결과 화면(\`InterviewSession.tsx\`)에는 sessionId 미전달 → 컨텍스트 없는 일반 문제로 생성. \`/sessions/[id]\` 경로에서는 풍부한 컨텍스트 동작
- 차원별 점수가 아직 통합 점수 기반 추정. 향후 \`agents.ts\` 평가 프롬프트가 차원별 score를 직접 저장하면 더 정확

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)