### PR TITLE
feat: 홈페이지 시네마틱 인트로 애니메이션 추가

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -59,3 +59,241 @@
       transition-all duration-150;
   }
 }
+
+/* === ZoomInterview cinematic hero === */
+
+/* 0. opening camera flash */
+@keyframes zi-flash {
+  0%   { opacity: 0; }
+  4%   { opacity: 0.45; }
+  18%  { opacity: 0; }
+  100% { opacity: 0; }
+}
+
+/* 1. cinema letterbox bars */
+@keyframes zi-letterbox-top {
+  0%   { transform: translateY(-100%); }
+  35%  { transform: translateY(0); }
+  100% { transform: translateY(0); }
+}
+@keyframes zi-letterbox-bot {
+  0%   { transform: translateY(100%); }
+  35%  { transform: translateY(0); }
+  100% { transform: translateY(0); }
+}
+
+/* 2. viewfinder corner brackets shoot inward */
+@keyframes zi-bracket-tl {
+  0%   { opacity: 0; transform: translate(-40px, -40px); }
+  100% { opacity: 1; transform: translate(0, 0); }
+}
+@keyframes zi-bracket-tr {
+  0%   { opacity: 0; transform: translate(40px, -40px); }
+  100% { opacity: 1; transform: translate(0, 0); }
+}
+@keyframes zi-bracket-bl {
+  0%   { opacity: 0; transform: translate(-40px, 40px); }
+  100% { opacity: 1; transform: translate(0, 0); }
+}
+@keyframes zi-bracket-br {
+  0%   { opacity: 0; transform: translate(40px, 40px); }
+  100% { opacity: 1; transform: translate(0, 0); }
+}
+
+/* 3. title dolly zoom — huge & blurred → locked focus */
+@keyframes zi-dolly {
+  0% {
+    opacity: 0;
+    transform: scale(3);
+    filter: blur(40px);
+    letter-spacing: 0.3em;
+  }
+  55% {
+    opacity: 1;
+    filter: blur(6px);
+    letter-spacing: 0.05em;
+  }
+  100% {
+    opacity: 1;
+    transform: scale(1);
+    filter: blur(0);
+    letter-spacing: -0.025em;
+  }
+}
+
+/* 4. focus rings COLLAPSE inward, converging onto title */
+@keyframes zi-ring-collapse {
+  0% {
+    opacity: 0;
+    transform: translate(-50%, -50%) scale(2.4);
+    border-width: 1px;
+  }
+  20% { opacity: 0.7; }
+  100% {
+    opacity: 0;
+    transform: translate(-50%, -50%) scale(0.3);
+    border-width: 4px;
+  }
+}
+
+/* 5. focus lock burst */
+@keyframes zi-lock-burst {
+  0%   { opacity: 0; transform: translate(-50%, -50%) scale(0.4); }
+  30%  { opacity: 0.85; }
+  100% { opacity: 0; transform: translate(-50%, -50%) scale(2.5); }
+}
+
+/* 6. snappy spring entrance (badge / subtitle) */
+@keyframes zi-snap-in {
+  0%   { opacity: 0; transform: translateY(14px) scale(0.94); }
+  55%  { opacity: 1; transform: translateY(-3px) scale(1.02); }
+  100% { opacity: 1; transform: translateY(0) scale(1); }
+}
+
+/* 7. title continuous breathing after lock */
+@keyframes zi-breath {
+  0%, 100% { transform: scale(1); }
+  50%      { transform: scale(1.018); }
+}
+
+/* 8. CTA pop with bounce */
+@keyframes zi-cta-pop {
+  0%   { opacity: 0; transform: translateY(40px) scale(0.85); }
+  60%  { opacity: 1; transform: translateY(-6px) scale(1.03); }
+  100% { opacity: 1; transform: translateY(0) scale(1); }
+}
+
+/* 9. step cards 3D flip-in */
+@keyframes zi-card-flip {
+  0%   { opacity: 0; transform: perspective(800px) rotateX(-55deg) translateY(40px); }
+  100% { opacity: 1; transform: perspective(800px) rotateX(0) translateY(0); }
+}
+
+/* 10. floating Q&A bubbles drift upward */
+@keyframes zi-bubble-rise {
+  0%   { opacity: 0; transform: translateY(40px) scale(0.9); }
+  10%  { opacity: 0.55; }
+  85%  { opacity: 0.55; }
+  100% { opacity: 0; transform: translateY(-180px) scale(1); }
+}
+
+/* 11. REC dot pulse */
+@keyframes zi-rec-pulse {
+  0%, 100% { opacity: 1; box-shadow: 0 0 0 0 rgba(239, 68, 68, 0.75); }
+  50%      { opacity: 0.55; box-shadow: 0 0 0 8px rgba(239, 68, 68, 0); }
+}
+
+/* 12. HUD slide in */
+@keyframes zi-hud-in {
+  0%   { opacity: 0; transform: translateY(-12px); }
+  100% { opacity: 1; transform: translateY(0); }
+}
+
+/* 14. background orb drift */
+@keyframes zi-orb-drift {
+  0%, 100% { transform: translate(0, 0) scale(1); }
+  33% { transform: translate(50px, -34px) scale(1.18); }
+  66% { transform: translate(-34px, 26px) scale(0.92); }
+}
+
+/* 16. continuous title shimmer (gradient sweep) */
+@keyframes zi-shimmer {
+  0%   { background-position: -150% 0; }
+  100% { background-position: 250% 0; }
+}
+
+/* 17. periodic title re-pulse (commercial-style logo reveal loop) */
+@keyframes zi-title-pulse {
+  0%, 88%, 100% { transform: scale(1); filter: blur(0); }
+  93% { transform: scale(1.07); filter: blur(1.5px); }
+}
+
+/* 18. periodic camera flash (rhythmic ad beat) */
+@keyframes zi-flash-loop {
+  0%, 97%, 100% { opacity: 0; }
+  98.5% { opacity: 0.15; }
+}
+
+/* 19. gentle continuous bracket pulse */
+@keyframes zi-bracket-breathe {
+  0%, 100% { opacity: 0.6; transform: scale(1); }
+  50%      { opacity: 1;   transform: scale(1.08); }
+}
+
+/* Apply timing — opening compressed to ~1.6s */
+.zi-flash          { opacity: 0; animation: zi-flash 1.2s ease-out 0s both; }
+.zi-flash-loop     { opacity: 0; animation: zi-flash-loop 10s ease-in-out 3s infinite; }
+.zi-letter-top     { animation: zi-letterbox-top 0.55s cubic-bezier(0.6, 0, 0.2, 1) 0s both; }
+.zi-letter-bot     { animation: zi-letterbox-bot 0.55s cubic-bezier(0.6, 0, 0.2, 1) 0s both; }
+
+.zi-hud            { animation: zi-hud-in 0.5s ease-out 0.2s both; }
+
+.zi-bracket-tl     { animation: zi-bracket-tl 0.5s cubic-bezier(0.2, 0.9, 0.3, 1) 0.15s both, zi-bracket-breathe 4s ease-in-out 2s infinite; }
+.zi-bracket-tr     { animation: zi-bracket-tr 0.5s cubic-bezier(0.2, 0.9, 0.3, 1) 0.15s both, zi-bracket-breathe 4s ease-in-out 2.2s infinite; }
+.zi-bracket-bl     { animation: zi-bracket-bl 0.5s cubic-bezier(0.2, 0.9, 0.3, 1) 0.15s both, zi-bracket-breathe 4s ease-in-out 2.4s infinite; }
+.zi-bracket-br     { animation: zi-bracket-br 0.5s cubic-bezier(0.2, 0.9, 0.3, 1) 0.15s both, zi-bracket-breathe 4s ease-in-out 2.6s infinite; }
+
+.zi-anim-title     {
+  /* Light mode — deep saturated palette so it pops against pale blue bg */
+  background-image: linear-gradient(110deg, #0c1e3e 0%, #1e3a8a 25%, #4338ca 50%, #1e3a8a 75%, #0c1e3e 100%);
+  background-size: 200% 100%;
+  -webkit-background-clip: text;
+  background-clip: text;
+  -webkit-text-fill-color: transparent;
+  color: transparent;
+  animation:
+    zi-dolly 0.7s cubic-bezier(0.2, 0.8, 0.2, 1) 0.1s both,
+    zi-shimmer 3s linear 1.8s infinite,
+    zi-title-pulse 6s ease-in-out 2.4s infinite;
+}
+
+/* Dark mode (Tailwind class strategy) — bright cyan/white peak against dark navy bg */
+.dark .zi-anim-title {
+  background-image: linear-gradient(110deg, #60a5fa 0%, #bfdbfe 30%, #ffffff 50%, #bfdbfe 70%, #60a5fa 100%);
+}
+
+/* Title glow wrapper — filter applied outside the animated h1 so dolly's filter doesn't override */
+.zi-title-glow {
+  display: inline-block;
+  /* Light mode — subtle dark shadow, no blue haze that would blend with the bg */
+  filter:
+    drop-shadow(0 2px 4px rgba(15, 23, 42, 0.25))
+    drop-shadow(0 8px 24px rgba(30, 58, 138, 0.18));
+}
+
+.dark .zi-title-glow {
+  filter:
+    drop-shadow(0 0 28px rgba(147, 197, 253, 0.55))
+    drop-shadow(0 0 70px rgba(59, 130, 246, 0.35));
+}
+
+/* --- WAVE 1 (t=0.1s): 배지 + 타이틀 --- */
+.zi-anim-badge     { animation: zi-snap-in 0.5s cubic-bezier(0.34, 1.4, 0.64, 1) 0.1s both; }
+
+.zi-ring-c         { opacity: 0; animation: zi-ring-collapse 0.55s cubic-bezier(0.4, 0, 0.2, 1) 0.1s both; }
+.zi-ring-c2        { opacity: 0; animation: zi-ring-collapse 0.55s cubic-bezier(0.4, 0, 0.2, 1) 0.2s both; }
+.zi-ring-c3        { opacity: 0; animation: zi-ring-collapse 0.55s cubic-bezier(0.4, 0, 0.2, 1) 0.3s both; }
+.zi-lock-burst     { opacity: 0; animation: zi-lock-burst 0.45s ease-out 0.5s both; }
+
+/* --- WAVE 2 (t=0.95s): 서브타이틀 + CTA --- */
+.zi-anim-sub       { display: inline-block; animation: zi-snap-in 0.5s cubic-bezier(0.34, 1.4, 0.64, 1) 0.95s both; }
+.zi-anim-cta-1     { animation: zi-cta-pop 0.5s cubic-bezier(0.34, 1.56, 0.64, 1) 0.95s both; }
+.zi-anim-cta-2     { animation: zi-cta-pop 0.5s cubic-bezier(0.34, 1.56, 0.64, 1) 1.05s both; }
+
+/* --- WAVE 3 (t=1.6s~): 스텝 카드 (개별 delay는 page.tsx inline 스타일로) --- */
+.zi-anim-card      { animation: zi-card-flip 0.55s cubic-bezier(0.2, 0.8, 0.2, 1) both; transform-origin: center top; }
+
+.zi-rec-dot        { animation: zi-rec-pulse 1.4s ease-in-out infinite; }
+.zi-orb            { animation: zi-orb-drift 14s ease-in-out infinite; }
+.zi-orb-r          { animation: zi-orb-drift 17s ease-in-out infinite reverse; }
+.zi-bubble         { opacity: 0; animation: zi-bubble-rise 6s ease-in-out infinite; }
+
+@media (prefers-reduced-motion: reduce) {
+  .zi-flash, .zi-flash-loop, .zi-letter-top, .zi-letter-bot, .zi-hud,
+  .zi-bracket-tl, .zi-bracket-tr, .zi-bracket-bl, .zi-bracket-br,
+  .zi-anim-title, .zi-anim-badge, .zi-ring-c, .zi-ring-c2, .zi-ring-c3, .zi-lock-burst,
+  .zi-anim-sub, .zi-anim-cta-1, .zi-anim-cta-2, .zi-anim-card,
+  .zi-rec-dot, .zi-orb, .zi-orb-r, .zi-bubble {
+    animation: none !important;
+  }
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,23 +1,124 @@
 import Link from "next/link";
 import { getAuthUser } from "@/lib/auth";
+import { RecTimecode } from "@/components/RecTimecode";
+
+const FLOATING_QA = [
+  { text: "Q. 자기소개 부탁드립니다", side: "left", top: "62%", delay: "0s" },
+  { text: "A. 안녕하세요, 5년차…", side: "right", top: "70%", delay: "1s" },
+  { text: "Q. 지원 동기는?", side: "left", top: "78%", delay: "2s" },
+  { text: "A. 귀사의 기술 비전이…", side: "right", top: "55%", delay: "3s" },
+  { text: "Q. 강점이 무엇인가요?", side: "left", top: "48%", delay: "4s" },
+  { text: "A. 문제 해결 능력입니다", side: "right", top: "85%", delay: "5s" },
+  { text: "Q. 마지막으로 하실 말씀?", side: "left", top: "92%", delay: "5.5s" },
+];
 
 export default async function HomePage() {
   const userId = await getAuthUser();
 
   return (
-    <main className="min-h-screen flex flex-col items-center justify-center px-4 py-16 bg-gradient-to-b from-blue-50 via-white to-white dark:from-slate-900 dark:via-slate-900 dark:to-slate-900">
-      <div className="max-w-2xl w-full text-center space-y-10">
+    <main className="relative min-h-screen flex flex-col items-center justify-center px-4 py-16 overflow-hidden bg-gradient-to-b from-blue-50 via-white to-white dark:from-slate-900 dark:via-slate-900 dark:to-slate-900">
+
+      {/* Opening camera flash */}
+      <div aria-hidden className="zi-flash pointer-events-none absolute inset-0 bg-white dark:bg-white/40 z-50" />
+
+      {/* Recurring camera flash (every 10s) */}
+      <div aria-hidden className="zi-flash-loop pointer-events-none absolute inset-0 bg-white dark:bg-white/25 z-50" />
+
+      {/* Cinema letterbox bars */}
+      <div aria-hidden className="zi-letter-top pointer-events-none absolute top-0 left-0 right-0 h-10 bg-gradient-to-b from-black/85 to-black/0 z-40" />
+      <div aria-hidden className="zi-letter-bot pointer-events-none absolute bottom-0 left-0 right-0 h-10 bg-gradient-to-t from-black/85 to-black/0 z-40" />
+
+      {/* Top HUD: REC + LIVE + timecode */}
+      <div aria-hidden className="zi-hud pointer-events-none absolute top-3 left-0 right-0 z-40 flex items-center justify-between px-5 sm:px-8 font-mono text-[10px] sm:text-xs tracking-widest text-white/85">
+        <div className="flex items-center gap-2">
+          <span className="zi-rec-dot inline-block w-2 h-2 rounded-full bg-red-500" />
+          <span>REC</span>
+          <span className="opacity-60">●</span>
+          <RecTimecode />
+        </div>
+        <div className="flex items-center gap-3 opacity-80">
+          <span>ZOOM 2.4×</span>
+          <span>F 1.8</span>
+          <span className="hidden sm:inline">ISO 400</span>
+        </div>
+      </div>
+
+      {/* Viewfinder corner brackets */}
+      <svg aria-hidden viewBox="0 0 24 24" className="zi-bracket-tl pointer-events-none absolute top-12 left-4 sm:top-14 sm:left-8 w-7 h-7 sm:w-9 sm:h-9 text-blue-500/80 z-30">
+        <path d="M2 8 V2 H8" fill="none" stroke="currentColor" strokeWidth="2.2" strokeLinecap="round" />
+      </svg>
+      <svg aria-hidden viewBox="0 0 24 24" className="zi-bracket-tr pointer-events-none absolute top-12 right-4 sm:top-14 sm:right-8 w-7 h-7 sm:w-9 sm:h-9 text-blue-500/80 z-30">
+        <path d="M16 2 H22 V8" fill="none" stroke="currentColor" strokeWidth="2.2" strokeLinecap="round" />
+      </svg>
+      <svg aria-hidden viewBox="0 0 24 24" className="zi-bracket-bl pointer-events-none absolute bottom-12 left-4 sm:bottom-14 sm:left-8 w-7 h-7 sm:w-9 sm:h-9 text-blue-500/80 z-30">
+        <path d="M2 16 V22 H8" fill="none" stroke="currentColor" strokeWidth="2.2" strokeLinecap="round" />
+      </svg>
+      <svg aria-hidden viewBox="0 0 24 24" className="zi-bracket-br pointer-events-none absolute bottom-12 right-4 sm:bottom-14 sm:right-8 w-7 h-7 sm:w-9 sm:h-9 text-blue-500/80 z-30">
+        <path d="M16 22 H22 V16" fill="none" stroke="currentColor" strokeWidth="2.2" strokeLinecap="round" />
+      </svg>
+
+      {/* Animated background orbs */}
+      <div aria-hidden className="pointer-events-none absolute inset-0 overflow-hidden">
+        <div className="zi-orb absolute -top-32 -left-24 w-[460px] h-[460px] rounded-full bg-blue-300/35 blur-3xl dark:bg-blue-500/25" />
+        <div className="zi-orb-r absolute -bottom-40 -right-20 w-[520px] h-[520px] rounded-full bg-indigo-300/30 blur-3xl dark:bg-indigo-500/25" />
+        <div className="zi-orb absolute top-1/3 left-1/2 w-[320px] h-[320px] rounded-full bg-sky-200/25 blur-3xl dark:bg-sky-400/15" style={{ animationDelay: "-7s" }} />
+      </div>
+
+      {/* Floating Q&A bubbles drifting upward */}
+      <div aria-hidden className="pointer-events-none absolute inset-0 overflow-hidden">
+        {FLOATING_QA.map((b, i) => {
+          const isQ = b.text.startsWith("Q");
+          return (
+            <div
+              key={i}
+              className="zi-bubble absolute text-[11px] sm:text-xs font-medium px-3 py-1.5 rounded-full backdrop-blur-sm border whitespace-nowrap shadow-sm"
+              style={{
+                top: b.top,
+                left: b.side === "left" ? "5%" : undefined,
+                right: b.side === "right" ? "5%" : undefined,
+                animationDelay: b.delay,
+                background: isQ ? "rgba(59,130,246,0.15)" : "rgba(16,185,129,0.15)",
+                borderColor: isQ ? "rgba(59,130,246,0.45)" : "rgba(16,185,129,0.45)",
+                color: isQ ? "rgb(29 78 216)" : "rgb(4 120 87)",
+              }}
+            >
+              {b.text}
+            </div>
+          );
+        })}
+      </div>
+
+      <div className="relative z-10 max-w-2xl w-full text-center space-y-10">
 
         {/* Hero */}
-        <div className="space-y-5">
-          <div className="inline-flex items-center gap-2 bg-blue-100 text-blue-700 text-xs font-semibold px-3 py-1.5 rounded-full dark:bg-blue-900/40 dark:text-blue-300">
+        <div className="relative space-y-5">
+          {/* Focus rings COLLAPSING into title */}
+          <div aria-hidden className="pointer-events-none absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 w-[360px] h-[360px] sm:w-[480px] sm:h-[480px]">
+            <span className="zi-ring-c absolute left-1/2 top-1/2 w-full h-full rounded-full border-blue-400/70 dark:border-blue-400/60" />
+            <span className="zi-ring-c2 absolute left-1/2 top-1/2 w-full h-full rounded-full border-blue-400/55 dark:border-blue-400/45" />
+            <span className="zi-ring-c3 absolute left-1/2 top-1/2 w-full h-full rounded-full border-blue-400/40 dark:border-blue-400/30" />
+          </div>
+
+          {/* Focus lock burst (subtle, doesn't cover CTA) */}
+          <div
+            aria-hidden
+            className="zi-lock-burst pointer-events-none absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 w-[240px] h-[240px] sm:w-[340px] sm:h-[340px] rounded-full blur-2xl"
+            style={{ background: "radial-gradient(circle, rgba(147,197,253,0.55) 0%, rgba(255,255,255,0.25) 35%, transparent 70%)" }}
+          />
+
+          <div className="zi-anim-badge relative inline-flex items-center gap-2 bg-blue-100 text-blue-700 text-xs font-semibold px-3 py-1.5 rounded-full dark:bg-blue-900/40 dark:text-blue-300">
+            <span className="zi-rec-dot inline-block w-1.5 h-1.5 rounded-full bg-red-500" />
             AI 기반 면접 연습
           </div>
-          <h1 className="text-4xl sm:text-5xl font-extrabold text-gray-900 leading-tight tracking-tight dark:text-slate-50">
-            줌인터뷰
-          </h1>
-          <p className="text-lg text-gray-500 dark:text-slate-400 max-w-md mx-auto leading-relaxed">
-            면접관을 보다 가까이서 바라보다
+
+          <div className="zi-title-glow relative">
+            <h1 className="zi-anim-title text-4xl sm:text-6xl font-extrabold leading-tight tracking-tight inline-block">
+              줌인터뷰
+            </h1>
+          </div>
+
+          <p className="relative text-lg text-gray-600 dark:text-slate-300 max-w-md mx-auto leading-relaxed font-medium">
+            <span className="zi-anim-sub">면접관을 보다 가까이서 바라보다</span>
           </p>
         </div>
 
@@ -26,7 +127,7 @@ export default async function HomePage() {
           {userId ? (
             <Link
               href="/job-posting"
-              className="w-full sm:w-auto inline-flex items-center justify-center gap-2 bg-blue-600 text-white font-semibold text-base px-8 py-3.5 rounded-xl hover:bg-blue-700 active:scale-95 transition-all shadow-lg shadow-blue-200 dark:shadow-blue-900/40"
+              className="zi-anim-cta-1 w-full sm:w-auto inline-flex items-center justify-center gap-2 bg-blue-600 text-white font-semibold text-base px-8 py-3.5 rounded-xl hover:bg-blue-700 hover:-translate-y-0.5 active:scale-95 transition-all shadow-lg shadow-blue-200 hover:shadow-xl hover:shadow-blue-300/60 dark:shadow-blue-900/40 dark:hover:shadow-blue-800/60"
             >
               면접 시작하기 →
             </Link>
@@ -34,13 +135,13 @@ export default async function HomePage() {
             <>
               <Link
                 href="/login"
-                className="w-full sm:w-auto inline-flex items-center justify-center gap-2 bg-blue-600 text-white font-semibold text-base px-8 py-3.5 rounded-xl hover:bg-blue-700 active:scale-95 transition-all shadow-lg shadow-blue-200 dark:shadow-blue-900/40"
+                className="zi-anim-cta-1 w-full sm:w-auto inline-flex items-center justify-center gap-2 bg-blue-600 text-white font-semibold text-base px-8 py-3.5 rounded-xl hover:bg-blue-700 hover:-translate-y-0.5 active:scale-95 transition-all shadow-lg shadow-blue-200 hover:shadow-xl hover:shadow-blue-300/60 dark:shadow-blue-900/40 dark:hover:shadow-blue-800/60"
               >
                 시작하기
               </Link>
               <Link
                 href="/signup"
-                className="w-full sm:w-auto inline-flex items-center justify-center gap-2 bg-white text-gray-700 font-semibold text-base px-8 py-3.5 rounded-xl border border-gray-200 hover:bg-gray-50 active:scale-95 transition-all dark:bg-slate-800 dark:text-slate-200 dark:border-slate-700 dark:hover:bg-slate-700"
+                className="zi-anim-cta-2 w-full sm:w-auto inline-flex items-center justify-center gap-2 bg-white text-gray-700 font-semibold text-base px-8 py-3.5 rounded-xl border border-gray-200 hover:bg-gray-50 hover:-translate-y-0.5 active:scale-95 transition-all dark:bg-slate-800 dark:text-slate-200 dark:border-slate-700 dark:hover:bg-slate-700"
               >
                 회원가입
               </Link>
@@ -51,13 +152,14 @@ export default async function HomePage() {
         {/* Steps */}
         <div className="grid grid-cols-1 sm:grid-cols-3 gap-3 mt-4">
           {[
-            { step: "1", title: "프로필 입력", desc: "학력·경력·자격증 입력" },
-            { step: "2", title: "채용공고 등록", desc: "지원할 공고 링크 붙여넣기" },
-            { step: "3", title: "AI 면접 연습", desc: "맞춤 질문으로 실전 연습" },
+            { step: "1", title: "프로필 입력", desc: "학력·경력·자격증 입력", delay: "1.6s" },
+            { step: "2", title: "채용공고 등록", desc: "지원할 공고 링크 붙여넣기", delay: "1.68s" },
+            { step: "3", title: "AI 면접 연습", desc: "맞춤 질문으로 실전 연습", delay: "1.76s" },
           ].map((item) => (
             <div
               key={item.step}
-              className="bg-white/80 backdrop-blur-sm rounded-2xl p-5 border border-gray-100 shadow-card text-left hover:shadow-card-md transition-shadow dark:bg-slate-800/80 dark:border-slate-700"
+              style={{ animationDelay: item.delay }}
+              className="zi-anim-card bg-white/85 backdrop-blur-sm rounded-2xl p-5 border border-gray-100 shadow-card text-left hover:shadow-card-md hover:-translate-y-1 transition-all duration-300 dark:bg-slate-800/85 dark:border-slate-700"
             >
               <div className="w-8 h-8 bg-blue-600 text-white font-bold rounded-lg flex items-center justify-center text-sm mb-3">
                 {item.step}

--- a/components/RecTimecode.tsx
+++ b/components/RecTimecode.tsx
@@ -1,0 +1,22 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+export function RecTimecode() {
+  const [seconds, setSeconds] = useState(0);
+
+  useEffect(() => {
+    const id = setInterval(() => setSeconds((v) => v + 1), 1000);
+    return () => clearInterval(id);
+  }, []);
+
+  const hh = String(Math.floor(seconds / 3600)).padStart(2, "0");
+  const mm = String(Math.floor((seconds % 3600) / 60)).padStart(2, "0");
+  const ss = String(seconds % 60).padStart(2, "0");
+
+  return (
+    <span suppressHydrationWarning>
+      {hh}:{mm}:{ss}
+    </span>
+  );
+}


### PR DESCRIPTION
## Summary
- 홈페이지(`/`)에 카메라 dolly-zoom 컨셉의 시네마틱 인트로 시퀀스를 추가
- 광고/CM 느낌의 3박자 스태카토 진입 — **배지+타이틀 → 서브타이틀+CTA → 스텝 카드** 순으로 끊어서 등장
- 실시간 타임코드 카운터를 위한 작은 클라이언트 컴포넌트 분리

## 변경 내역

### 비주얼/모션
- **카메라 dolly-zoom 타이틀** — scale 3x + blur 40px → 1x로 압축되며 포커스 락
- **타이틀 그라데이션 시머** + 6초마다 줌-펄스 (라이트/다크 모드 색상 분리)
  - 라이트: 딥네이비~인디고
  - 다크: 라이트블루~화이트 + 블루 네온 글로우
- **카메라 HUD**: `● REC` 인디케이터, `ZOOM 2.4× / F1.8 / ISO 400`, 실시간 타임코드(HH:MM:SS)
- **시네마 레터박스** + **4모서리 뷰파인더 브래킷** + **포커스 링 수렴**
- 배경에 면접 Q&A 말풍선 7개가 떠다니는 라이브 면접 연출
- 부드러운 그라디언트 오브 3개 드리프트

### 접근성
- `prefers-reduced-motion: reduce` 사용자에게는 모든 진입/루프 애니메이션 비활성화
- 오버레이 요소들(`zi-flash`, `zi-lock-burst`, `zi-ring-c*`, `zi-bubble`)에 baseline `opacity: 0` 명시 → reduced-motion일 때도 잔여 노출 없음

### 추가 파일
- `components/RecTimecode.tsx` — `setInterval`로 매초 카운트업하는 라이브 타임코드

## Test plan
- [ ] `/` 진입 시 약 2초 안에 3박자로 끊어서 등장하는지
- [ ] 타이틀이 라이트/다크 모드 모두에서 배경과 충분히 대비되는지
- [ ] REC 옆 타임코드가 매초 +1초씩 증가하는지
- [ ] 시스템 "애니메이션 줄이기" ON 상태에서도 최종 화면이 깨지지 않는지
- [ ] 페이지 이탈 후 재진입 시 타이머/interval이 누수 없이 정리되는지

🤖 Generated with [Claude Code](https://claude.com/claude-code)