### PR TITLE
fix: 홈페이지 크롤러 URL 필터링 및 coreProduct 컨텍스트 반영

### DIFF
--- a/lib/homepage-collector.ts
+++ b/lib/homepage-collector.ts
@@ -11,6 +11,12 @@ const EXCLUDED_DOMAINS = [
   "google.com", "daum.net", "namu.wiki", "wikipedia",
 ];
 
+// 검색 결과에서 기사/게시물 URL 제외 패턴
+const NEWS_URL_PATTERNS = [
+  "articleView", "/article/", "/articles/", "/news/", "/board/",
+  "idxno=", "idx=", "/post/", "/bbs/", "/notice/",
+];
+
 async function getHomepageUrl(companyName: string): Promise<string | null> {
   const result = await getHomepageUrlWithSource(companyName);
   return result?.url ?? null;
@@ -48,7 +54,11 @@ async function getHomepageUrlWithSource(companyName: string): Promise<{ url: str
         const data = await res.json() as { items?: { link: string }[] };
         for (const item of data.items ?? []) {
           const u = item.link;
-          if (u?.startsWith("http") && !EXCLUDED_DOMAINS.some(d => u.includes(d))) {
+          if (
+            u?.startsWith("http") &&
+            !EXCLUDED_DOMAINS.some(d => u.includes(d)) &&
+            !NEWS_URL_PATTERNS.some(p => u.includes(p))
+          ) {
             return { url: u, source: "검색" };
           }
         }
@@ -199,7 +209,12 @@ async function fetchPage(url: string): Promise<string | null> {
 }
 
 function buildCandidateUrls(homepage: string): string[] {
-  const base = homepage.replace(/\/$/, "");
+  let base: string;
+  try {
+    base = new URL(homepage).origin;
+  } catch {
+    base = homepage.replace(/\/$/, "");
+  }
   return [
     `${base}/`,
     // 회사 소개
@@ -436,7 +451,6 @@ export async function collectHomepageInfo(jobPostingId: string, companyName: str
     const extracted = await extractInfo(companyName, combinedText);
 
     // extractInfo가 반환하는 businessArea → DB 컬럼명 industrySector 로 매핑.
-    // coreProduct는 현재 DB 스키마에 없으므로 제외한다.
     const { data: upserted } = await supabase
       .from("company_cache")
       .upsert(
@@ -446,6 +460,7 @@ export async function collectHomepageInfo(jobPostingId: string, companyName: str
           industrySector: extracted.businessArea,
           mainServices: extracted.mainServices,
           visionMission: extracted.visionMission,
+          coreProduct: extracted.coreProduct,
           targetCustomer: extracted.targetCustomer,
           competitivePosition: extracted.competitivePosition,
           homepageCollectedAt: new Date().toISOString(),

--- a/lib/interview-context.ts
+++ b/lib/interview-context.ts
@@ -47,6 +47,7 @@ type CompanyCache = {
   industrySector: string | null;
   mainServices: string | null;
   visionMission: string | null;
+  coreProduct: string | null;
   targetCustomer: string | null;
   competitivePosition: string | null;
 } | null;
@@ -69,7 +70,7 @@ export async function loadJobPostingWithContext(
 
   const { data: companyInfo } = await supabase
     .from("company_info")
-    .select("newsContext, newsCollectedAt, company_cache(foundedYear, listingStatus, financialSummary, recentDisclosures, employeeSummary, businessSummary, industrySector, mainServices, visionMission, targetCustomer, competitivePosition)")
+    .select("newsContext, newsCollectedAt, company_cache(foundedYear, listingStatus, financialSummary, recentDisclosures, employeeSummary, businessSummary, industrySector, mainServices, visionMission, coreProduct, targetCustomer, competitivePosition)")
     .eq("jobPostingId", jobPosting.id)
     .maybeSingle();
 
@@ -148,6 +149,7 @@ export async function loadJobPostingWithContext(
     industrySector: cache?.industrySector ?? undefined,
     mainServices: cache?.mainServices ?? undefined,
     visionMission: cache?.visionMission ?? undefined,
+    coreProduct: cache?.coreProduct ?? undefined,
     targetCustomer: cache?.targetCustomer ?? undefined,
     competitivePosition: cache?.competitivePosition ?? undefined,
   };

--- a/lib/interview.ts
+++ b/lib/interview.ts
@@ -107,6 +107,7 @@ export interface JobPostingContext {
   industrySector?: string;
   mainServices?: string;
   visionMission?: string;
+  coreProduct?: string;
   targetCustomer?: string;
   competitivePosition?: string;
 }
@@ -360,11 +361,16 @@ function buildOrganizationHomepageHints(jobPosting: JobPostingContext): string {
   }
 
   // 힌트 2: 서비스 이해 검증
-  if (parsedServices) {
+  if (parsedServices || jobPosting.coreProduct) {
+    const serviceDetail = [
+      parsedServices ? `주요 서비스: ${parsedServices}` : "",
+      jobPosting.coreProduct ? `핵심 제품: ${jobPosting.coreProduct}` : "",
+    ].filter(Boolean).join("\n");
+
     if (customerType === "B2C") {
       sections.push(
         `[서비스 이해 검증 — 질문 방향 참고]\n` +
-        `주요 서비스: ${parsedServices}\n` +
+        `${serviceDetail}\n` +
         `개인이 직접 사용할 수 있는 서비스입니다. 실제 사용 경험이 있는지, 어떤 기능을 살펴봤는지, ` +
         `사용자 관점의 장단점을 말할 수 있는지 확인하세요. ` +
         `단순 "써봤다"에서 끝내지 말고 구체적인 관찰과 본인 직무 연결까지 끌어내세요.\n` +
@@ -373,7 +379,7 @@ function buildOrganizationHomepageHints(jobPosting: JobPostingContext): string {
     } else if (customerType === "B2B") {
       sections.push(
         `[서비스 이해 검증 — 질문 방향 참고]\n` +
-        `주요 서비스: ${parsedServices}\n` +
+        `${serviceDetail}\n` +
         `기업 고객 대상 서비스로 개인이 직접 사용하기 어렵습니다. ` +
         `"써보셨나요?"를 묻지 말고, 고객사가 왜 이 서비스를 필요로 하는지, ` +
         `어떤 문제를 해결하는지 이해하고 있는지 확인하세요.\n` +
@@ -551,6 +557,7 @@ function buildAgentSystemPrompt(
       jobPosting.techStack ? `기술스택: ${jobPosting.techStack}` : "",
       jobPosting.industrySector ? `업종: ${jobPosting.industrySector}` : "",
       jobPosting.mainServices ? `주요 서비스: ${parseMainServices(jobPosting.mainServices)}` : "",
+      jobPosting.coreProduct ? `핵심 제품: ${jobPosting.coreProduct}` : "",
       commonJobBlock,
     ].filter(Boolean).join("\n"),
   };
@@ -862,6 +869,7 @@ async function generateSingleAgentThought(
       jobPosting.techStack ? `기술스택: ${jobPosting.techStack}` : "",
       jobPosting.industrySector ? `업종: ${jobPosting.industrySector}` : "",
       jobPosting.mainServices ? `주요 서비스: ${parseMainServices(jobPosting.mainServices)}` : "",
+      jobPosting.coreProduct ? `핵심 제품: ${jobPosting.coreProduct}` : "",
       thoughtCommonJobBlock,
     ].filter(Boolean).join("\n"),
   };


### PR DESCRIPTION
## Summary

- 네이버 검색 결과에서 뉴스·게시글 URL 제외 (`articleView`, `/news/`, `idxno=` 등 패턴 필터)
- `buildCandidateUrls`가 URL 전체 경로 대신 `origin`만 사용하도록 수정 → 기사 URL이 base로 쓰여 후보 URL이 오염되던 버그 수정
- `company_cache.coreProduct`를 면접 에이전트 컨텍스트에 반영 (`interview-context.ts`, `interview.ts`)

## Test plan

- [ ] "OVLR" 등 소규모 회사명으로 홈페이지 크롤링 테스트 → 뉴스 기사 URL이 반환되지 않는지 확인
- [ ] 정상 회사명으로 크롤링 시 `pagesCollected > 0` 및 `businessArea` 등 필드 채워지는지 확인
- [ ] 면접 세션에서 `coreProduct` 정보가 에이전트 힌트에 포함되는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)