### PR TITLE
feat: 모바일 하단 탭 바 추가

### DIFF
--- a/components/Sidebar.tsx
+++ b/components/Sidebar.tsx
@@ -138,10 +138,24 @@ export default function Sidebar({ children }: { children: ReactNode }) {
     return pathname === href || pathname.startsWith(href + "/");
   }
 
+  const BOTTOM_TABS = [
+    {
+      href: "/",
+      label: "홈",
+      icon: (
+        <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+          <path d="M3 9.5L12 3l9 6.5V20a1 1 0 0 1-1 1H4a1 1 0 0 1-1-1V9.5z" />
+          <path d="M9 21V12h6v9" />
+        </svg>
+      ),
+    },
+    ...NAV_ITEMS,
+  ];
+
   return (
     <div className="flex min-h-screen">
       <aside
-        className={`${collapsed ? "w-16" : "w-60"} shrink-0 sticky top-0 h-screen flex flex-col bg-white border-r border-gray-100 dark:bg-slate-900 dark:border-slate-800 transition-all duration-200 z-10`}
+        className={`${collapsed ? "w-16" : "w-60"} shrink-0 sticky top-0 h-screen hidden md:flex flex-col bg-white border-r border-gray-100 dark:bg-slate-900 dark:border-slate-800 transition-all duration-200 z-10`}
       >
         {/* 로고 + 토글 */}
         <div className="flex items-center h-14 border-b border-gray-100 dark:border-slate-800 px-3 gap-1">
@@ -378,7 +392,101 @@ export default function Sidebar({ children }: { children: ReactNode }) {
       </aside>
 
       {/* 본문 */}
-      <div className="flex-1 min-w-0">{children}</div>
+      <div className="flex-1 min-w-0 flex flex-col">
+        {/* 모바일 프로필 헤더 */}
+        {pathname.startsWith("/profile") && (
+          <div className="md:hidden flex items-center justify-between px-4 h-14 border-b border-gray-100 dark:border-slate-800 bg-white dark:bg-slate-900">
+            <span className="text-sm font-semibold text-gray-800 dark:text-slate-100">
+              {userName || "…"}
+            </span>
+            <div className="relative" ref={settingsRef}>
+              <button
+                onClick={() => setSettingsOpen((o) => !o)}
+                className={`p-2 rounded-md transition-colors ${
+                  settingsOpen
+                    ? "bg-gray-100 text-gray-700 dark:bg-slate-800 dark:text-slate-200"
+                    : "text-gray-400 hover:text-gray-700 hover:bg-gray-100 dark:text-slate-500 dark:hover:text-slate-200 dark:hover:bg-slate-800"
+                }`}
+              >
+                <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                  <circle cx="12" cy="12" r="3" />
+                  <path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 0 1-2.83 2.83l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-4 0v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 0 1-2.83-2.83l.06-.06A1.65 1.65 0 0 0 4.68 15a1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1 0-4h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 0 1 2.83-2.83l.06.06A1.65 1.65 0 0 0 9 4.68a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 4 0v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 0 1 2.83 2.83l-.06.06A1.65 1.65 0 0 0 19.4 9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 0 4h-.09a1.65 1.65 0 0 0-1.51 1z" />
+                </svg>
+              </button>
+              {settingsOpen && (
+                <div className="absolute top-full right-0 mt-1 w-44 bg-white dark:bg-slate-800 border border-gray-200 dark:border-slate-700 rounded-lg shadow-lg py-1 z-50">
+                  <button
+                    onClick={toggleTheme}
+                    className="w-full flex items-center gap-3 px-3 py-2 text-sm text-gray-700 hover:bg-gray-100 dark:text-slate-300 dark:hover:bg-slate-700 transition-colors"
+                  >
+                    <span className="text-gray-400 dark:text-slate-500">
+                      {isDark ? (
+                        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                          <circle cx="12" cy="12" r="4" />
+                          <path d="M12 2v2M12 20v2M4.93 4.93l1.41 1.41M17.66 17.66l1.41 1.41M2 12h2M20 12h2M4.93 19.07l1.41-1.41M17.66 6.34l1.41-1.41" />
+                        </svg>
+                      ) : (
+                        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                          <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z" />
+                        </svg>
+                      )}
+                    </span>
+                    {isDark ? "라이트 모드" : "다크 모드"}
+                  </button>
+                  <button
+                    onClick={handleLogout}
+                    className="w-full flex items-center gap-3 px-3 py-2 text-sm text-gray-700 hover:bg-gray-100 dark:text-slate-300 dark:hover:bg-slate-700 transition-colors"
+                  >
+                    <span className="text-gray-400 dark:text-slate-500">
+                      <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                        <path d="M9 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h4M16 17l5-5-5-5M21 12H9" />
+                      </svg>
+                    </span>
+                    로그아웃
+                  </button>
+                  <div className="my-1 border-t border-gray-100 dark:border-slate-700" />
+                  <Link
+                    href="/account"
+                    onClick={() => setSettingsOpen(false)}
+                    className="w-full flex items-center gap-3 px-3 py-2 text-sm text-gray-700 hover:bg-gray-100 dark:text-slate-300 dark:hover:bg-slate-700 transition-colors"
+                  >
+                    <span className="text-gray-400 dark:text-slate-500">
+                      <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                        <path d="M20 21v-2a4 4 0 0 0-4-4H8a4 4 0 0 0-4 4v2" />
+                        <circle cx="12" cy="7" r="4" />
+                      </svg>
+                    </span>
+                    계정 설정
+                  </Link>
+                </div>
+              )}
+            </div>
+          </div>
+        )}
+
+        <div className="flex-1 pb-16 md:pb-0">{children}</div>
+      </div>
+
+      {/* 모바일 하단 탭 바 */}
+      <nav className="md:hidden fixed bottom-0 left-0 right-0 z-50 bg-white dark:bg-slate-900 border-t border-gray-100 dark:border-slate-800 flex items-stretch" style={{ paddingBottom: "env(safe-area-inset-bottom)" }}>
+        {BOTTOM_TABS.map((tab) => {
+          const active = tab.href === "/" ? pathname === "/" : isActive(tab.href);
+          return (
+            <Link
+              key={tab.href}
+              href={tab.href}
+              className={`flex-1 flex flex-col items-center justify-center gap-1 py-2 text-xs font-medium transition-colors ${
+                active
+                  ? "text-blue-600 dark:text-blue-400"
+                  : "text-gray-400 dark:text-slate-500"
+              }`}
+            >
+              {tab.icon}
+              <span>{tab.label}</span>
+            </Link>
+          );
+        })}
+      </nav>
     </div>
   );
 }


### PR DESCRIPTION
## Summary

- 모바일(< md)에서 사이드바를 숨기고 하단 탭 바(홈 / 면접 / 프로필)로 교체
- `/profile` 계열 페이지에서만 모바일 상단 헤더에 유저 이름 + 설정 버튼 표시 (테마 전환, 로그아웃, 계정 설정)
- iPhone safe-area-inset-bottom 처리로 홈 인디케이터 영역 침범 방지
- 데스크탑은 기존 사이드바 동작 그대로 유지

## Test plan

- [ ] 모바일 뷰(390px)에서 하단 탭 바 3개(홈/면접/프로필) 표시 확인
- [ ] 각 탭 active 상태(파란색) 정상 동작 확인
- [ ] `/profile` 페이지에서 상단 설정 버튼 → 팝업 메뉴(테마/로그아웃/계정) 확인
- [ ] 콘텐츠가 탭 바에 가려지지 않는지 확인
- [ ] 데스크탑에서 사이드바 기존 동작 유지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)