### PR TITLE
fix: 면접 에이전트 외부 데이터 주입 정리 (뉴스 조건부화·재무 추상화·공시 제거)

### DIFF
--- a/lib/agents.ts
+++ b/lib/agents.ts
@@ -190,8 +190,7 @@ function buildContextBlock(profile: ProfileContext, jobPosting: JobPostingContex
       jobPosting.foundedYear ? `설립: ${jobPosting.foundedYear}` : "",
       jobPosting.listingStatus ? `상장 현황: ${jobPosting.listingStatus}` : "",
       jobPosting.employeeSummary ? `직원 현황: ${jobPosting.employeeSummary}` : "",
-      jobPosting.financialSummary ? `재무 현황:\n${jobPosting.financialSummary}` : "",
-      jobPosting.recentDisclosures ? `최근 주요 공시:\n${jobPosting.recentDisclosures}` : "",
+      // 재무 수치·공시는 BARS 채점 기준이 참조하지 않으므로 평가 컨텍스트에서 제외 (답변 기반 채점 원칙 유지).
       jobPosting.companyDescription ? `회사 소개: ${jobPosting.companyDescription}` : "",
       jobPosting.companyCulture ? `조직 문화: ${jobPosting.companyCulture}` : "",
       jobPosting.businessSummary ? `사업 요약:\n${jobPosting.businessSummary}` : "",

--- a/lib/company-info-collector.ts
+++ b/lib/company-info-collector.ts
@@ -519,15 +519,13 @@ export async function collectCompanyInfo(jobPostingId: string, companyName: stri
       let foundedYear: string | null = null;
       let listingStatus: string | null = null;
       let financialSummary: string | null = null;
-      let recentDisclosures: string | null = null;
       let employeeSummary: string | null = null;
       let businessSummary: string | null = null;
 
       if (corp) {
-        const [detail, financial, disclosures, employees, bizReport] = await Promise.all([
+        const [detail, financial, employees, bizReport] = await Promise.all([
           fetchCompanyDetail(corp.corp_code),
           fetchFinancial3Years(corp.corp_code),
-          fetchRecentDisclosures(corp.corp_code),
           fetchEmployeeSummary(corp.corp_code),
           fetchBusinessReportSections(corp.corp_code),
         ]);
@@ -538,7 +536,6 @@ export async function collectCompanyInfo(jobPostingId: string, companyName: stri
           if (ls) listingStatus = ls;
         }
         if (financial) financialSummary = financial;
-        if (disclosures) recentDisclosures = disclosures;
         if (employees) employeeSummary = employees;
         businessSummary = bizReport;
       }
@@ -551,7 +548,6 @@ export async function collectCompanyInfo(jobPostingId: string, companyName: stri
             foundedYear,
             listingStatus,
             financialSummary,
-            recentDisclosures,
             employeeSummary,
             businessSummary,
             isListed,

--- a/lib/interview-context.ts
+++ b/lib/interview-context.ts
@@ -41,7 +41,6 @@ type CompanyCache = {
   foundedYear: string | null;
   listingStatus: string | null;
   financialSummary: string | null;
-  recentDisclosures: string | null;
   employeeSummary: string | null;
   businessSummary: string | null;
   industrySector: string | null;
@@ -70,7 +69,7 @@ export async function loadJobPostingWithContext(
 
   const { data: companyInfo } = await supabase
     .from("company_info")
-    .select("newsContext, newsCollectedAt, company_cache(foundedYear, listingStatus, financialSummary, recentDisclosures, employeeSummary, businessSummary, industrySector, mainServices, visionMission, coreProduct, targetCustomer, competitivePosition)")
+    .select("newsContext, newsCollectedAt, company_cache(foundedYear, listingStatus, financialSummary, employeeSummary, businessSummary, industrySector, mainServices, visionMission, coreProduct, targetCustomer, competitivePosition)")
     .eq("jobPostingId", jobPosting.id)
     .maybeSingle();
 
@@ -143,7 +142,6 @@ export async function loadJobPostingWithContext(
     foundedYear: cache?.foundedYear ?? undefined,
     listingStatus: cache?.listingStatus ?? undefined,
     financialSummary: cache?.financialSummary ?? undefined,
-    recentDisclosures: cache?.recentDisclosures ?? undefined,
     employeeSummary: cache?.employeeSummary ?? undefined,
     businessSummary: cache?.businessSummary ?? undefined,
     industrySector: cache?.industrySector ?? undefined,

--- a/lib/interview.ts
+++ b/lib/interview.ts
@@ -100,7 +100,6 @@ export interface JobPostingContext {
   foundedYear?: string;
   listingStatus?: string;
   financialSummary?: string;
-  recentDisclosures?: string;
   employeeSummary?: string;
   businessSummary?: string;
   // 홈페이지 수집 데이터
@@ -213,8 +212,8 @@ function classifyFinancialPhase(financialSummary: string | undefined): Financial
 
 const FINANCIAL_PHASE_HINTS: Record<FinancialPhase, string> = {
   확장기: "현재 회사는 매출 성장세(확장기)입니다. 지원자가 변화·확장 환경을 선호하는지, 빠른 성장 속도에 적응할 준비가 됐는지 위주로 파악하세요. 안정 지향 답변이 나오면 직접 인용하며 정합성을 검증하세요.",
-  위기: "현재 회사는 매출 감소세(위기 국면)입니다. 지원자가 회사의 도전 과제를 인지하고 있는지, '왜 이 시점에 이 회사인가'에 대한 답이 명확한지 위주로 파악하세요. 안정성·복지만 기대한 답변이 나오면 파고드세요.",
-  생존모드: "현재 회사는 영업 적자(생존 모드)입니다. 지원자가 회사 상황을 인지하고도 합류하려는 이유가 무엇인지, 단기 성과 압박 환경에 대한 준비가 있는지 위주로 파악하세요.",
+  위기: "현재 회사는 매출 감소세(위기 국면)입니다. 지원자가 회사의 도전 과제를 인지하고 있는지, '왜 이 시점에 이 회사인가'에 대한 답이 명확한지 위주로 파악하세요. 안정성·복지만 기대한 답변이 나오면 파고드세요. 단, 회사의 재무 상태를 직접 언급하거나 부정적으로 단정하지 말 것. 지원동기의 진정성·각오를 우회적으로 확인하세요.",
+  생존모드: "현재 회사는 영업 적자(생존 모드)입니다. 지원자가 회사 상황을 인지하고도 합류하려는 이유가 무엇인지, 단기 성과 압박 환경에 대한 준비가 있는지 위주로 파악하세요. 단, 회사의 재무 상태를 직접 언급하거나 부정적으로 단정하지 말 것. 지원동기의 진정성·각오를 우회적으로 확인하세요.",
 };
 
 type CompanyMaturity = "초기" | "성숙기";
@@ -245,18 +244,6 @@ const COMPANY_MATURITY_HINTS: Record<CompanyMaturity, string> = {
   성숙기: "현재 회사는 성숙 단계 대기업입니다. 지원자가 대규모 조직 내 협업 구조에서 일한 경험, 절차·문서 기반 실행 역량, 전문성의 깊이를 갖췄는지 위주로 파악하세요.",
 };
 
-function detectDisclosureSignal(disclosures: string | undefined): string | null {
-  if (!disclosures) return null;
-  const hasMA = /인수|합병/.test(disclosures);
-  const hasNew = /신사업|투자/.test(disclosures);
-  if (!hasMA && !hasNew) return null;
-
-  const parts: string[] = [];
-  if (hasMA) parts.push("최근 인수·합병이 진행된 회사입니다. 지원자가 조직 변화·통합 과정에서 실행력을 유지한 경험, 불확실한 상황에서 우선순위를 판단한 경험을 갖췄는지 파악하세요.");
-  if (hasNew) parts.push("최근 신사업·신규 투자가 활발한 회사입니다. 지원자가 검증되지 않은 영역에서 빠르게 학습·실행한 경험, 명확한 정답이 없는 문제를 다룬 경험을 갖췄는지 파악하세요.");
-  return parts.join("\n");
-}
-
 const BUSINESS_SUMMARY_HINT = `사업 요약이 컨텍스트에 포함된 경우, 지원자가 "왜 이 회사인가"를 답할 때 사업 방향·고객군·서비스를 실제로 참조하는지 검증하세요. "성장 가능성이 좋아서", "비전에 공감해서" 같은 보편 답변만 하고 사업 특성을 한 번도 언급하지 않으면, 사업 요약의 특정 문구를 인용하며 "이 부분에 대해 어떻게 생각하시는지" 파고드세요.`;
 
 // organization 페르소나 전용: 다트 데이터 기반 4종 힌트를 묶어서 반환.
@@ -267,12 +254,9 @@ function buildOrganizationDartHints(jobPosting: JobPostingContext): string {
     jobPosting.listingStatus,
     jobPosting.employeeSummary,
   );
-  const disclosureSignal = detectDisclosureSignal(jobPosting.recentDisclosures);
-
   const sections: string[] = [];
   if (financialPhase) sections.push(`[재무 국면 — 질문 방향 참고]\n${FINANCIAL_PHASE_HINTS[financialPhase]}`);
   if (maturity) sections.push(`[기업 성숙도 — 질문 방향 참고]\n${COMPANY_MATURITY_HINTS[maturity]}`);
-  if (disclosureSignal) sections.push(`[최근 공시 시그널 — 질문 방향 참고]\n${disclosureSignal}`);
   if (jobPosting.businessSummary) sections.push(`[사업 요약 활용 지침]\n${BUSINESS_SUMMARY_HINT}`);
 
   return sections.length > 0 ? `\n\n${sections.join("\n\n")}` : "";
@@ -533,8 +517,7 @@ function buildAgentSystemPrompt(
       jobPosting.listingStatus ? `상장 현황: ${jobPosting.listingStatus}` : "",
       jobPosting.employeeSummary ? `직원 현황: ${jobPosting.employeeSummary}` : "",
       jobPosting.industrySector ? `업종: ${jobPosting.industrySector}` : "",
-      jobPosting.financialSummary ? `재무 현황:\n${jobPosting.financialSummary}` : "",
-      jobPosting.recentDisclosures ? `최근 주요 공시:\n${jobPosting.recentDisclosures}` : "",
+      // 재무 수치는 국면 힌트(buildOrganizationDartHints)로만 추상화 전달, 공시는 미사용 — 원시 데이터 직접 노출 방지.
       jobPosting.visionMission ? `비전/미션: ${jobPosting.visionMission}` : "",
       jobPosting.targetCustomer ? `타겟 고객: ${jobPosting.targetCustomer}` : "",
       jobPosting.competitivePosition ? `경쟁 포지셔닝: ${jobPosting.competitivePosition}` : "",
@@ -570,15 +553,15 @@ ${DIFFICULTY_QUESTION_HINT[difficulty]}
 [채용공고]
 ${agentJobBlock[agentId]}
 
-${jobPosting.newsContext ? `[최근 업계 뉴스 및 동향 — 면접 질문 생성에 적극 활용할 것]
+${jobPosting.newsContext ? `[최근 업계 뉴스 및 동향 — 관련 있을 때 참고]
 ${jobPosting.newsContext}
 
-[뉴스 활용 필수 지침]
-- 위 "주요 이슈"와 "최근 뉴스"는 회사의 실시간 컨텍스트입니다. 면접 질문 1개 이상에 반드시 자연스럽게 녹여내세요.
+[뉴스 활용 지침]
+- 위 "주요 이슈"와 "최근 뉴스"는 회사의 실시간 컨텍스트입니다. 직무·역할과 직접 관련된 이슈일 때만 자연스럽게 활용하세요. 관련성이 약하면 사용하지 마세요.
 - 뉴스 내용을 그대로 읊지 말 것. 대신 지원자의 입장·판단·경험과 연결해 질문하세요.
   좋은 예: "최근 회사에서 [이슈]를 두고 [상황]에 직면해 있다고 들었습니다. 만약 ${jobPosting.divisionName || "해당 부서"}에서 이런 문제를 만난다면 어떤 관점으로 접근하시겠어요?"
   나쁜 예: "최근 뉴스에서 [이슈]가 있던데 알고 계신가요?" (단순 지식 확인은 금지)
-- 단, 뉴스가 직무·역할과 무관하다면 억지로 끼워넣지 말 것. 자연스러움이 우선.
+- 직무·역할과 무관하다면 억지로 끼워넣지 말 것. 자연스러움이 우선.
 - 첫 질문(자기소개·지원동기)이 아닌 두 번째 이후 질문에서 활용하는 것을 권장합니다.
 ${jobPosting.jobClassification && getNewsQuestionGuide(jobPosting.jobClassification) ? `
 [${jobPosting.jobClassification} 직무 — 뉴스 주제별 질문 가이드]
@@ -651,9 +634,9 @@ export async function generateAgentBaseQuestion(
   const newsHint = jobPosting.newsContext
     ? `
 
-[뉴스 활용 우선 옵션]
+[뉴스 활용 옵션]
 시스템 프롬프트에 [최근 업계 뉴스 및 동향]이 주입돼 있습니다. 뉴스의 "주요 이슈"가 이 직무와 연관성이 있다면,
-지금까지 다루지 않은 경우 이번 질문에서 우선적으로 활용하세요. 단, 뉴스 내용을 그대로 읊지 말고 지원자의
+지금까지 다루지 않은 경우 이번 질문에서 활용을 고려하세요. 단, 뉴스 내용을 그대로 읊지 말고 지원자의
 입장·판단·경험과 연결한 형태로 질문하세요.`
     : "";
 
@@ -845,8 +828,7 @@ async function generateSingleAgentThought(
       jobPosting.listingStatus ? `상장 현황: ${jobPosting.listingStatus}` : "",
       jobPosting.employeeSummary ? `직원 현황: ${jobPosting.employeeSummary}` : "",
       jobPosting.industrySector ? `업종: ${jobPosting.industrySector}` : "",
-      jobPosting.financialSummary ? `재무 현황:\n${jobPosting.financialSummary}` : "",
-      jobPosting.recentDisclosures ? `최근 주요 공시:\n${jobPosting.recentDisclosures}` : "",
+      // 재무 수치는 국면 힌트(buildOrganizationDartHints)로만 추상화 전달, 공시는 미사용 — 원시 데이터 직접 노출 방지.
       jobPosting.visionMission ? `비전/미션: ${jobPosting.visionMission}` : "",
       jobPosting.targetCustomer ? `타겟 고객: ${jobPosting.targetCustomer}` : "",
       jobPosting.competitivePosition ? `경쟁 포지셔닝: ${jobPosting.competitivePosition}` : "",
@@ -887,15 +869,15 @@ async function generateSingleAgentThought(
 [채용공고]
 ${thoughtAgentJobBlock[agentId]}
 
-${jobPosting.newsContext ? `[최근 업계 뉴스 및 동향 — 면접 질문 생성에 적극 활용할 것]
+${jobPosting.newsContext ? `[최근 업계 뉴스 및 동향 — 관련 있을 때 참고]
 ${jobPosting.newsContext}
 
-[뉴스 활용 필수 지침]
-- 위 "주요 이슈"와 "최근 뉴스"는 회사의 실시간 컨텍스트입니다. 면접 질문 1개 이상에 반드시 자연스럽게 녹여내세요.
+[뉴스 활용 지침]
+- 위 "주요 이슈"와 "최근 뉴스"는 회사의 실시간 컨텍스트입니다. 직무·역할과 직접 관련된 이슈일 때만 자연스럽게 활용하세요. 관련성이 약하면 사용하지 마세요.
 - 뉴스 내용을 그대로 읊지 말 것. 대신 지원자의 입장·판단·경험과 연결해 질문하세요.
   좋은 예: "최근 회사에서 [이슈]를 두고 [상황]에 직면해 있다고 들었습니다. 만약 ${jobPosting.divisionName || "해당 부서"}에서 이런 문제를 만난다면 어떤 관점으로 접근하시겠어요?"
   나쁜 예: "최근 뉴스에서 [이슈]가 있던데 알고 계신가요?" (단순 지식 확인은 금지)
-- 단, 뉴스가 직무·역할과 무관하다면 억지로 끼워넣지 말 것. 자연스러움이 우선.
+- 직무·역할과 무관하다면 억지로 끼워넣지 말 것. 자연스러움이 우선.
 - 첫 질문(자기소개·지원동기)이 아닌 두 번째 이후 질문에서 활용하는 것을 권장합니다.
 ${jobPosting.jobClassification && getNewsQuestionGuide(jobPosting.jobClassification) ? `
 [${jobPosting.jobClassification} 직무 — 뉴스 주제별 질문 가이드]


### PR DESCRIPTION
## 배경

면접 단계에서 에이전트에게 주입되는 외부 데이터(뉴스·DART 재무·공시)가 비현실적이거나 강제적으로 들어가던 부분을 정리했습니다. 실제 면접관처럼 자연스럽게 동작하도록 톤다운하고, 평가 단계와도 일관성을 맞췄습니다.

## 변경 내용

### 1. 뉴스 — 강제 주입 → 조건부
- 기존: "면접 질문 1개 이상에 **반드시** 녹여내세요" + "억지로 끼워넣지 말 것" → 프롬프트 내부 모순
- 변경: 직무·역할과 **직접 관련된 이슈일 때만** 활용. 질문·속마음 프롬프트 양쪽 + `newsHint` 톤다운

### 2. 재무 — distress 노출 차단 + 원시 수치 제거
- 위기/생존 국면 힌트에 "재무 상태 직접 언급·부정 단정 금지, 지원동기 우회 확인" 가드 추가
- 원시 재무 수치 verbatim 주입 제거 → `재무 국면` 힌트로만 추상화 전달 (모델이 구체 수치를 캐물 여지 제거)

### 3. 공시 — 제품 경로 전면 제거
- 질문 신호(`detectDisclosureSignal`), 평가 주입, DART 수집, DB 로드, 타입에서 모두 제거
- 근거: M&A/투자만 잡는 좁은 신호 + 뉴스와 중복 + 느슨한 추론
- **테스트 엔드포인트(`/api/test-dart`)와 DB 컬럼은 보존** (디버그 가시성 / 휴면 컬럼)

### 4. 평가 디베이트 — 재무·공시 제외
- BARS 채점 루브릭이 재무 수치·공시를 참조하지 않음 + "답변에 드러난 내용만 평가" 원칙과 충돌 → 평가 컨텍스트에서 제외
- 회사 이해도 판단에 필요한 사업/서비스/소개/문화 컨텍스트는 유지

## 검증
- `tsc --noEmit` 통과
- 잔여 `recentDisclosures` 참조는 테스트 경로에만 한정 확인

## 후속(미처리)
- `recentDisclosures` DB 컬럼 드롭은 마이그레이션 필요 → 별도 작업
- 키워드 휴리스틱(B2B/B2C·비전 fluff) 취약성, 크롤러 포맷 결합, 데이터 출처 검증 부재

🤖 Generated with [Claude Code](https://claude.com/claude-code)